### PR TITLE
Visual Studio 2012 Debugger Visualizers

### DIFF
--- a/util/glm.natvis
+++ b/util/glm.natvis
@@ -1,0 +1,29 @@
+<!-- GLM visualizers for Visual Studio 2012 -->
+<!-- Put them into My Documents/Visual Studio 2012/Visualizers/ -->
+<?xml version="1.0" encoding="utf-8"?>
+<AutoVisualizer xmlns="http://schemas.microsoft.com/vstudio/debugger/natvis/2010">
+    <Type Name="glm::detail::tvec2&lt;*&gt;">
+        <DisplayString>({x}, {y})</DisplayString>
+		<Expand>
+			<Item Name="x">x</Item>
+			<Item Name="y">y</Item>
+		</Expand>
+    </Type>
+    <Type Name="glm::detail::tvec3&lt;*&gt;">
+        <DisplayString>({x}, {y}, {z})</DisplayString>
+		<Expand>
+			<Item Name="x">x</Item>
+			<Item Name="y">y</Item>
+			<Item Name="z">z</Item>
+		</Expand>
+    </Type>
+    <Type Name="glm::detail::tvec4&lt;*&gt;">
+        <DisplayString>({x}, {y}, {z}, {w})</DisplayString>
+		<Expand>
+			<Item Name="x">x</Item>
+			<Item Name="y">y</Item>
+			<Item Name="z">z</Item>
+			<Item Name="w">w</Item>
+		</Expand>
+    </Type>
+</AutoVisualizer>


### PR DESCRIPTION
Added new debbugger visualizers for vs2012 as it doesn't use autoexp.dat anymore.
Signed-off-by: Jonathan Lima greenboxal@gmail.com
