### PR TITLE
Fixed component swapping in tmat2x2::_inverse()

### DIFF
--- a/glm/core/type_mat2x2.inl
+++ b/glm/core/type_mat2x2.inl
@@ -271,8 +271,8 @@ namespace detail
 
         tmat2x2<T> Inverse(
             + this->value[1][1] / Determinant,
+            - this->value[0][1] / Determinant,
             - this->value[1][0] / Determinant,
-            - this->value[0][1] / Determinant, 
             + this->value[0][0] / Determinant);
         return Inverse;
     }


### PR DESCRIPTION
`glm::detail::tmat2x2::_inverse()` incorrectly swaps both diagonals instead of only main diagonals:

```
A = ⌈a  b⌉
    ⌊c  d⌋
```

(using standard representation). `_inverse()` on `A` incorrectly gives the order

```
⌈ d  -c⌉
⌊-b   a⌋
```

(swaps both diagonals) where it should be

```
⌈ d  -b⌉
⌊-c   a⌋
```

(I am leaving out division by the determinate for clarity).

Also, `glm::inverse()` in `glm/core/func_matrix.inl` is **correct** for 2x2 matrices and shows the mistake of `_inverse()`.
The unit tests do not appear to test division of a `mat2` by a `mat2` (where this could arise).
