### PR TITLE
Fix a -Wswitch-default warning in GCC.

### DIFF
--- a/glm/gtc/quaternion.inl
+++ b/glm/gtc/quaternion.inl
@@ -707,6 +707,10 @@ namespace detail
 			Result.y = (m[1][2] + m[2][1]) * mult;
 			Result.z = biggestVal;
 			break;
+			
+        default:                // Silence a -Wswitch-default warning in GCC. Should never actually get here. Assert is just for sanity.
+            assert(false);
+            break;
 		}
 		return Result;
 	}


### PR DESCRIPTION
The default case should never actually be met. I've added an assert(false) statement here for sanity.
