### PR TITLE
tvec2, tvec3 and tvec4 static constants.

### DIFF
--- a/glm/core/type_vec2.hpp
+++ b/glm/core/type_vec2.hpp
@@ -224,6 +224,9 @@ namespace detail
         //////////////////////////////////////
 		// Static constants
 
+        static const tvec2<T> zero;
+        static const tvec2<T> one;
+
         static const tvec2<T> xpos;
         static const tvec2<T> xneg;
         static const tvec2<T> ypos;

--- a/glm/core/type_vec2.inl
+++ b/glm/core/type_vec2.inl
@@ -1029,6 +1029,9 @@ namespace detail
     //////////////////////////////////////
 	// Static constants
 
+    template <typename T> const tvec2<T> tvec2<T>::zero  = tvec2<T>(T( 0), T( 0));
+    template <typename T> const tvec2<T> tvec2<T>::one   = tvec2<T>(T( 1), T( 1));
+
     template <typename T> const tvec2<T> tvec2<T>::xpos  = tvec2<T>(T( 1), T( 0));
     template <typename T> const tvec2<T> tvec2<T>::xneg  = tvec2<T>(T(-1), T( 0));
     template <typename T> const tvec2<T> tvec2<T>::ypos  = tvec2<T>(T( 0), T( 1));

--- a/glm/core/type_vec3.hpp
+++ b/glm/core/type_vec3.hpp
@@ -249,6 +249,9 @@ namespace detail
         //////////////////////////////////////
 		// Static constants
 
+        static const tvec3<T> zero;
+        static const tvec3<T> one;
+
         static const tvec3<T> xpos;
         static const tvec3<T> xneg;
         static const tvec3<T> ypos;

--- a/glm/core/type_vec3.inl
+++ b/glm/core/type_vec3.inl
@@ -1153,6 +1153,9 @@ namespace detail
     //////////////////////////////////////
 	// Static constants
 
+    template <typename T> const tvec3<T> tvec3<T>::zero     = tvec3<T>(T( 0), T( 0), T( 0));
+    template <typename T> const tvec3<T> tvec3<T>::one      = tvec3<T>(T( 1), T( 1), T( 1));
+
     template <typename T> const tvec3<T> tvec3<T>::xpos     = tvec3<T>(T( 1), T( 0), T( 0));
     template <typename T> const tvec3<T> tvec3<T>::xneg     = tvec3<T>(T(-1), T( 0), T( 0));
     template <typename T> const tvec3<T> tvec3<T>::ypos     = tvec3<T>(T( 0), T( 1), T( 0));

--- a/glm/core/type_vec4.hpp
+++ b/glm/core/type_vec4.hpp
@@ -305,6 +305,9 @@ namespace detail
         //////////////////////////////////////
 		// Static constants
 
+        static const tvec4<T> zero;
+        static const tvec4<T> one;
+
         static const tvec4<T> xpos;
         static const tvec4<T> xneg;
         static const tvec4<T> ypos;

--- a/glm/core/type_vec4.inl
+++ b/glm/core/type_vec4.inl
@@ -1379,6 +1379,9 @@ namespace detail
     //////////////////////////////////////
 	// Static constants
 
+    template <typename T> const tvec4<T> tvec4<T>::zero     = tvec4<T>(T( 0), T( 0), T( 0), T( 0));
+    template <typename T> const tvec4<T> tvec4<T>::one      = tvec4<T>(T( 1), T( 1), T( 1), T( 1));
+
     template <typename T> const tvec4<T> tvec4<T>::xpos     = tvec4<T>(T( 1), T( 0), T( 0), T( 0));
     template <typename T> const tvec4<T> tvec4<T>::xneg     = tvec4<T>(T(-1), T( 0), T( 0), T( 0));
     template <typename T> const tvec4<T> tvec4<T>::ypos     = tvec4<T>(T( 0), T( 1), T( 0), T( 0));


### PR DESCRIPTION
This pull request is a proposed implementation to https://github.com/g-truc/glm/issues/21. I had actually also looked for something like this in the past so I figured it might be worthwhile to implement it.

The way I've done it is the most intuitive way for me, but I'm not sure if that's necessarily the best way to do it in the context of GLM. The way I've done it is pretty much the same as they do it in Ogre and Unity.
