### PR TITLE
Fix a warning in func_integer.inl

### DIFF
--- a/glm/core/func_integer.inl
+++ b/glm/core/func_integer.inl
@@ -103,7 +103,7 @@ namespace glm
 		if(x > y)
 			return genUType(detail::highp_int_t(x) - detail::highp_int_t(y));
 		else
-			return genUType(detail::highp_int_t(1) << detail::highp_int_t(32) + detail::highp_int_t(x) - detail::highp_int_t(y));
+			return genUType((detail::highp_int_t(1) << detail::highp_int_t(32)) + detail::highp_int_t(x) - detail::highp_int_t(y));
 	}
 
 	template <typename T>


### PR DESCRIPTION
The lack of parenthesis triggered -Wshift-op-parentheses in Clang 3.2
