### PR TITLE
Fix a bug in glm::perspective().

### DIFF
--- a/glm/gtc/matrix_transform.inl
+++ b/glm/gtc/matrix_transform.inl
@@ -242,7 +242,7 @@ namespace glm
 		valType const rad = glm::radians(fovy);
 #endif
         
-		valType range = tan(radians(rad / valType(2))) * zNear;	
+		valType range = tan(rad / valType(2)) * zNear;	
 		valType left = -range * aspect;
 		valType right = range * aspect;
 		valType bottom = -range;


### PR DESCRIPTION
The fix for https://github.com/g-truc/glm/issues/34 introduces another bug where the degrees-to-radians conversion is performed twice when GLM_FORCE_RADIANS is undefined.
