### PR TITLE
Clang compilation error.

### DIFF
--- a/glm/core/_detail.hpp
+++ b/glm/core/_detail.hpp
@@ -452,7 +452,7 @@ namespace detail
 #   define GLM_RESTRICT
 #   define GLM_RESTRICT_VAR __restrict
 #   define GLM_CONSTEXPR
-#elif((GLM_COMPILER & (GLM_COMPILER_GCC | GLM_COMPILER_LLVM_GCC)) && (GLM_COMPILER >= GLM_COMPILER_GCC31))
+#elif(((GLM_COMPILER & (GLM_COMPILER_GCC | GLM_COMPILER_LLVM_GCC)) && (GLM_COMPILER >= GLM_COMPILER_GCC31)) || (GLM_COMPILER & GLM_COMPILER_CLANG))
 #	define GLM_DEPRECATED __attribute__((__deprecated__))
 #	define GLM_ALIGN(x) __attribute__((aligned(x)))
 #	define GLM_ALIGNED_STRUCT(x) struct __attribute__((aligned(x)))


### PR DESCRIPTION
The issue here is that GLM_DEPRECATED, GLM_ALIGN, etc is being left undefined with the Clang build.

This doesn't do any versioning checks with Clang because I wasn't sure which versions would be applicable, so you might want to double check.
