### PR TITLE
Fixed mat2x4 value-type constructor

### DIFF
--- a/glm/core/type_mat2x4.inl
+++ b/glm/core/type_mat2x4.inl
@@ -109,7 +109,7 @@ namespace detail
 	{
 		value_type const Zero(0);
 		this->value[0] = col_type(s, Zero, Zero, Zero);
-		this->value[1] = col_type(Zero, Zero, Zero, Zero);
+		this->value[1] = col_type(Zero, s, Zero, Zero);
 	}
 
 	template <typename T> 


### PR DESCRIPTION
Hi,

I'm new to GLM and liking it a lot. I'm writing bindings to Chicken Scheme (call-cc.org) and I came across what I think might be a bug. That is, if I have understood the column-major/internal data-structure correctly.

The problem I came across was that the mat2x4(float) constructor does not work properly, and have attempted to fix it with the attached patch.

I was unsure of which branch might be suitable, so I gave 0.9.4 a shot.

Thanks for a brilliant mathlib!
