### PR TITLE
Minor fix

### DIFF
--- a/glm/core/type_vec4.hpp
+++ b/glm/core/type_vec4.hpp
@@ -37,7 +37,7 @@ namespace glm{
 namespace detail
 {
 	template <typename T, precision P>
-	struct __declspec(align(16)) tvec4
+	struct tvec4
 	{
 		enum ctor{_null};
 

--- a/test/gtx/gtx_bit.cpp
+++ b/test/gtx/gtx_bit.cpp
@@ -361,8 +361,8 @@ namespace bitfieldInterleave
 
 	int test()
 	{
-		glm::uint32 x_max = 1 << 13;
-		glm::uint32 y_max = 1 << 12;
+		glm::uint32 x_max = 1 << 11;
+		glm::uint32 y_max = 1 << 10;
 
 		// ALU
 		std::vector<glm::uint64> Data(x_max * y_max);
@@ -493,17 +493,14 @@ namespace bitfieldInterleave
 #		if(GLM_ARCH != GLM_ARCH_PURE)
 		{
 			// SIMD
-			glm::int32 simd_x_max = 1 << 13;
-			glm::int32 simd_y_max = 1 << 12;
-
 			std::vector<__m128i> SimdData(x_max * y_max);
 			std::vector<__m128i> SimdParam(x_max * y_max);
 			for(int i = 0; i < SimdParam.size(); ++i)
-				SimdParam[i] = _mm_set_epi32(i % simd_x_max, 0, i / simd_y_max, 0);
+				SimdParam[i] = _mm_set_epi32(i % x_max, 0, i / y_max, 0);
 
 			std::clock_t LastTime = std::clock();
 
-			for(std::size_t i = 0; i < Data.size(); ++i)
+			for(std::size_t i = 0; i < SimdData.size(); ++i)
 				SimdData[i] = glm::detail::_mm_bit_interleave_si128(SimdParam[i]);
 
 			std::clock_t Time = std::clock() - LastTime;


### PR DESCRIPTION
1. type_vec4.hpp
   __declspec(align(16)) produces a compiler error on VS2012:
   func_common.inl(634): error C2719: 'a': formal parameter with
   __declspec(align('16')) won't be aligned
   core_func_common.cpp(310) : see reference to function template
   instantiation 'glm::detail::tvec4<T,P> glm::mix<float,highp>(const
   glm::detail::tvec4<T,P> &,const glm::detail::tvec4<T,P>
   &,glm::detail::tvec4<bool,highp>)' being compiled
   with
   [
   T=float,
   P=highp
   ]
   and a warning on CygWin using gcc 4.7.2:
   type_vec4.hpp:40:31: warning: 'align' attribute directive ignored
   [-Wattributes]
2. gtx_bit.cpp
   glm::uint32 x_max = 1 << 13;
   glm::uint32 y_max = 1 << 12;
   result out of memory on my machine.
