### PR TITLE
remove register specifier, deprecated in C++11

### DIFF
--- a/glm/core/type_half.inl
+++ b/glm/core/type_half.inl
@@ -133,9 +133,9 @@ namespace detail
 		// of float and half (127 versus 15).
 		//
 
-		register int s =  (i >> 16) & 0x00008000;
-		register int e = ((i >> 23) & 0x000000ff) - (127 - 15);
-		register int m =   i        & 0x007fffff;
+		int s =  (i >> 16) & 0x00008000;
+		int e = ((i >> 23) & 0x000000ff) - (127 - 15);
+		int m =   i        & 0x007fffff;
 
 		//
 		// Now reassemble s, e and m into a half:


### PR DESCRIPTION
The register storage class specifier was deprecated in C++11. Clang now warns about this.
More info: http://en.cppreference.com/w/cpp/language/storage_duration
