### PR TITLE
Refactored glm/gtc/quaternion mat3_cast

### DIFF
--- a/glm/gtc/quaternion.inl
+++ b/glm/gtc/quaternion.inl
@@ -92,7 +92,7 @@ namespace detail
 		z(static_cast<T>(l.begin()[2])),
 		w(static_cast<T>(l.begin()[3]))
 	{
-		assert(v.size() >= this->length());
+		assert(l.size() >= this->length());
 	}
 #endif//GLM_HAS_INITIALIZER_LISTS
 


### PR DESCRIPTION
- Factored out minus signs.  Previous commit was incorrect.
