### PR TITLE
Remove #include of missing file.

### DIFF
--- a/glm/gtx/fast_exponential.hpp
+++ b/glm/gtx/fast_exponential.hpp
@@ -41,7 +41,6 @@
 
 // Dependency:
 #include "../glm.hpp"
-#include "../gtc/half_float.hpp"
 
 #if(defined(GLM_MESSAGES) && !defined(glm_ext))
 #	pragma message("GLM: GLM_GTX_fast_exponential extension included")


### PR DESCRIPTION
It appears half_float.hpp has been removed. There is a lingering #include in fast_exponential.hpp.
