### PR TITLE
Remove includes of deleted half_float.hpp

### DIFF
--- a/glm/ext.hpp
+++ b/glm/ext.hpp
@@ -65,7 +65,6 @@
 
 #include "./gtc/constants.hpp"
 #include "./gtc/epsilon.hpp"
-#include "./gtc/half_float.hpp"
 #include "./gtc/matrix_access.hpp"
 #include "./gtc/matrix_integer.hpp"
 #include "./gtc/matrix_inverse.hpp"

--- a/glm/gtx/extented_min_max.hpp
+++ b/glm/gtx/extented_min_max.hpp
@@ -41,7 +41,6 @@
 
 // Dependency:
 #include "../glm.hpp"
-#include "../gtc/half_float.hpp"
 
 #if(defined(GLM_MESSAGES) && !defined(glm_ext))
 #	pragma message("GLM: GLM_GTX_extented_min_max extension included")


### PR DESCRIPTION
The header half_float.hpp has been removed in 25a5c21a24196d23fb84c823f19f257f1117f0b1  .
