### PR TITLE
Is there an @endcond missing?

### DIFF
--- a/glm/detail/type_mat4x4.hpp
+++ b/glm/detail/type_mat4x4.hpp
@@ -59,6 +59,7 @@ namespace detail
 	private:
 		/// @cond DETAIL
 		col_type value[4];
+		/// @endcond
 
 	public:
 		// Constructors


### PR DESCRIPTION
I don't know if what I did there makes any sense. I just compared type_mat4x4 to type_mat3x3 and type_mat2x2 files. In all the other files there is an @encond at that place, while mat4x4 misses one.
Is that intentional or could it be that it was accidentally removed in aa26672da1c6272ba71ff6e9b90434113a1edbb1?

Without the @endcond, this screws up my my doxygen configuration for a program that includes glm.
