### PR TITLE
fixed bug in quaternion slerp

### DIFF
--- a/glm/gtc/quaternion.inl
+++ b/glm/gtc/quaternion.inl
@@ -582,10 +582,10 @@ namespace detail
 		{
 			// Linear interpolation
 			return detail::tquat<T, P>(
-				mix(x.w, y.w, a),
-				mix(x.x, y.x, a),
-				mix(x.y, y.y, a),
-				mix(x.z, y.z, a));
+				mix(x.w, z.w, a),
+				mix(x.x, z.x, a),
+				mix(x.y, z.y, a),
+				mix(x.z, z.z, a));
 		}
 		else
 		{

--- a/test/gtc/gtc_quaternion.cpp
+++ b/test/gtc/gtc_quaternion.cpp
@@ -196,6 +196,15 @@ int test_quat_slerp()
 	// Must be 0 0.00X 0 0.99999
 	glm::quat almostid = glm::slerp(id, glm::angleAxis(0.1f, glm::vec3(0.0f, 1.0f, 0.0f)), 0.5f);
 
+	// Testing quaternions with opposite sign
+	{
+		glm::quat a(-1, 0, 0, 0);
+
+		glm::quat result = glm::slerp(a, id, 0.5f);
+
+		Error += glm::epsilonEqual(glm::pow(glm::dot(id, result), 2.f), 1.f, 0.01f) ? 0 : 1;
+	}
+
 	return Error;
 }
 


### PR DESCRIPTION
Slerp doesn't interpolate correctly when both quaternions are equal but with different sign.
