### PR TITLE
Fixed missing "#include <utility>" for std::move.

### DIFF
--- a/glm/detail/type_mat2x2.hpp
+++ b/glm/detail/type_mat2x2.hpp
@@ -41,6 +41,7 @@
 #endif
 #include <limits>
 #include <cstddef>
+#include <utility>
 
 namespace glm{
 namespace detail

--- a/glm/detail/type_mat2x3.hpp
+++ b/glm/detail/type_mat2x3.hpp
@@ -41,6 +41,7 @@
 #endif
 #include <limits>
 #include <cstddef>
+#include <utility>
 
 namespace glm{
 namespace detail

--- a/glm/detail/type_mat2x4.hpp
+++ b/glm/detail/type_mat2x4.hpp
@@ -41,6 +41,7 @@
 #endif
 #include <limits>
 #include <cstddef>
+#include <utility>
 
 namespace glm{
 namespace detail

--- a/glm/detail/type_mat3x2.hpp
+++ b/glm/detail/type_mat3x2.hpp
@@ -41,6 +41,7 @@
 #endif
 #include <limits>
 #include <cstddef>
+#include <utility>
 
 namespace glm{
 namespace detail

--- a/glm/detail/type_mat3x3.hpp
+++ b/glm/detail/type_mat3x3.hpp
@@ -40,6 +40,7 @@
 #endif
 #include <limits>
 #include <cstddef>
+#include <utility>
 
 namespace glm{
 namespace detail

--- a/glm/detail/type_mat3x4.hpp
+++ b/glm/detail/type_mat3x4.hpp
@@ -41,6 +41,7 @@
 #endif
 #include <limits>
 #include <cstddef>
+#include <utility>
 
 namespace glm{
 namespace detail

--- a/glm/detail/type_mat4x2.hpp
+++ b/glm/detail/type_mat4x2.hpp
@@ -41,6 +41,7 @@
 #endif
 #include <limits>
 #include <cstddef>
+#include <utility>
 
 namespace glm{
 namespace detail

--- a/glm/detail/type_mat4x3.hpp
+++ b/glm/detail/type_mat4x3.hpp
@@ -41,6 +41,7 @@
 #endif
 #include <limits>
 #include <cstddef>
+#include <utility>
 
 namespace glm{
 namespace detail

--- a/glm/detail/type_mat4x4.hpp
+++ b/glm/detail/type_mat4x4.hpp
@@ -34,6 +34,7 @@
 #include "type_mat.hpp"
 #include <limits>
 #include <cstddef>
+#include <utility>
 
 namespace glm{
 namespace detail


### PR DESCRIPTION
Building projects using glm with gcc 4.8.2 resulted in errors like as the following:

/usr/local/include/glm/detail/type_mat4x4.hpp:128:22: error: ‘move’ is not a member of ‘std’
     this->value[0] = std::move(m.value[0]);

The matrix headers appeared to be missing the inclusion of the utility header.
