### PR TITLE
Fixed build error due missing includes related to enum 'uninitialized'

### DIFF
--- a/glm/detail/func_vector_relational.hpp
+++ b/glm/detail/func_vector_relational.hpp
@@ -43,6 +43,9 @@
 #include "precision.hpp"
 #include "setup.hpp"
 
+// Dependency for 'uninitialized' enum
+#include "type_vec.hpp"
+
 #if !((GLM_COMPILER & GLM_COMPILER_VC) && (GLM_COMPILER <= GLM_COMPILER_VC10)) // Workaround a Visual C++ bug
 
 namespace glm

--- a/glm/gtc/ulp.hpp
+++ b/glm/gtc/ulp.hpp
@@ -42,6 +42,7 @@
 #include "../detail/setup.hpp"
 #include "../detail/precision.hpp"
 #include "../detail/type_int.hpp"
+#include "../detail/type_vec.hpp"
 
 #if(defined(GLM_MESSAGES) && !defined(GLM_EXT_INCLUDED))
 #	pragma message("GLM: GLM_GTC_ulp extension included")


### PR DESCRIPTION
`uninitialized` enum was referenced in 'ulp.inl' and 'func_vector_relational.inl' but the header where it is declared, 'type_vec.hpp' was not included in either.
Solution: include 'type_vec.hpp' in 'ulp.hpp' and 'func_vector_relational.hpp'
