### PR TITLE
optimized cot function implementation

### DIFF
--- a/glm/gtc/reciprocal.inl
+++ b/glm/gtc/reciprocal.inl
@@ -66,8 +66,8 @@ namespace glm
 	GLM_FUNC_QUALIFIER genType cot(genType angle)
 	{
 		GLM_STATIC_ASSERT(std::numeric_limits<genType>::is_iec559, "'cot' only accept floating-point values");
+	
 		genType const pi_over_2 = genType(3.1415926535897932384626433832795 / 2.0);
-		
 		return glm::tan(pi_over_2 - angle);
 	}
 


### PR DESCRIPTION
faster, divisionless implementation of the cot function
based on the fact that "cot = tan(PI/2 - angle)"
