### PR TITLE
Fix MSVC intrinsics detection

### DIFF
--- a/glm/detail/func_integer.inl
+++ b/glm/detail/func_integer.inl
@@ -104,7 +104,7 @@ namespace detail
 		}
 	};
 
-#	if(GLM_ARCH != GLM_ARCH_PURE) && (GLM_COMPILER & (GLM_COMPILER_VC | GLM_COMPILER_APPLE_CLANG | GLM_COMPILER_LLVM))
+#	if(GLM_ARCH != GLM_ARCH_PURE) && ((GLM_COMPILER & GLM_COMPILER_VC) || ((GLM_COMPILER & GLM_COMPILER_LLVM) && (GLM_PLATFORM & GLM_PLATFORM_WINDOWS)))
 		template <typename genIUType>
 		struct compute_findLSB<genIUType, 32>
 		{
@@ -162,7 +162,7 @@ namespace detail
 		}
 	};
 
-#	if(GLM_ARCH != GLM_ARCH_PURE) && (GLM_COMPILER & (GLM_COMPILER_VC | GLM_COMPILER_APPLE_CLANG | GLM_COMPILER_LLVM))
+#	if(GLM_ARCH != GLM_ARCH_PURE) && ((GLM_COMPILER & GLM_COMPILER_VC) || ((GLM_COMPILER & GLM_COMPILER_LLVM) && (GLM_PLATFORM & GLM_PLATFORM_WINDOWS)))
 		template <typename genIUType>
 		GLM_FUNC_QUALIFIER int compute_findMSB_32(genIUType Value)
 		{


### PR DESCRIPTION
MSVC and Clang support BitScanFoward and BitScanReverse only on Windows.
This should also fix issue #278.
