### PR TITLE
Decompose Function VS2010 Templating Issues

### DIFF
--- a/glm/gtx/matrix_decompose.inl
+++ b/glm/gtx/matrix_decompose.inl
@@ -125,31 +125,32 @@ namespace glm
 
 		// Now get scale and shear.
 		for(length_t i = 0; i < 3; ++i)
-			Row[i] = LocalMatrix[i];
+			for(int j = 0; j < 3; ++j)
+				Row[i][j] = LocalMatrix[i][j];
 
 		// Compute X scale factor and normalize first row.
 		Scale.x = length(Row[0]);// v3Length(Row[0]);
 
-		v3Scale(Row[0], 1.0);
+		v3Scale(Row[0], static_cast<T>(1));
 
 		// Compute XY shear factor and make 2nd row orthogonal to 1st.
 		Skew.z = dot(Row[0], Row[1]);
-		Row[1] = combine(Row[1], Row[0], 1.0, -Skew.z);
+		Row[1] = combine(Row[1], Row[0], static_cast<T>(1.0), -Skew.z);
 
 		// Now, compute Y scale and normalize 2nd row.
 		Scale.y = length(Row[1]);
-		v3Scale(Row[1], 1.0);
+		v3Scale(Row[1], static_cast<T>(1));
 		Skew.z /= Scale.y;
 
 		// Compute XZ and YZ shears, orthogonalize 3rd row.
 		Skew.y = glm::dot(Row[0], Row[2]);
-		Row[2] = combine(Row[2], Row[0], 1.0, -Skew.y);
+		Row[2] = combine(Row[2], Row[0], static_cast<T>(1), -Skew.y);
 		Skew.x = glm::dot(Row[1], Row[2]);
-		Row[2] = combine(Row[2], Row[1], 1.0, -Skew.x);
+		Row[2] = combine(Row[2], Row[1], static_cast<T>(1), -Skew.x);
 
 		// Next, get Z scale and normalize 3rd row.
 		Scale.z = length(Row[2]);
-		v3Scale(Row[2], 1.0);
+		v3Scale(Row[2], static_cast<T>(1));
 		Skew.y /= Scale.z;
 		Skew.x /= Scale.z;
 

--- a/glm/gtx/matrix_decompose.inl
+++ b/glm/gtx/matrix_decompose.inl
@@ -135,7 +135,7 @@ namespace glm
 
 		// Compute XY shear factor and make 2nd row orthogonal to 1st.
 		Skew.z = dot(Row[0], Row[1]);
-		Row[1] = combine(Row[1], Row[0], static_cast<T>(1.0), -Skew.z);
+		Row[1] = combine(Row[1], Row[0], static_cast<T>(1), -Skew.z);
 
 		// Now, compute Y scale and normalize 2nd row.
 		Scale.y = length(Row[1]);


### PR DESCRIPTION
VS2010 seems to get confused when compiling matrix_decompose.inl because all the calls to v3Scale have an argument of 1.0, which is of ambiguous type. I replaced it with a static_cast<T>(1) as that is what's used further on in the code and it now compiles. Additionally, the conversion from vec4 to vec3 (for getting the scale and shear) doesn't seem to play nicely either, copying the first three values of the vector manually via a for loop seems to fix it.