### PR TITLE
Fixed (u)int64 MSB/LSB handling on BE archs

### DIFF
--- a/glm/detail/func_integer.inl
+++ b/glm/detail/func_integer.inl
@@ -248,10 +248,8 @@ namespace detail
 		GLM_STATIC_ASSERT(sizeof(uint) == sizeof(uint32), "uint and uint32 size mismatch");
 
 		uint64 Value64 = static_cast<uint64>(x) * static_cast<uint64>(y);
-		uint32* PointerMSB = (reinterpret_cast<uint32*>(&Value64) + 1);
-		msb = *PointerMSB;
-		uint32* PointerLSB = (reinterpret_cast<uint32*>(&Value64) + 0);
-		lsb = *PointerLSB;
+		msb = Value64 >> 32;
+		lsb = Value64;
 	}
 
 	template <precision P, template <typename, precision> class vecType>
@@ -270,10 +268,8 @@ namespace detail
 		GLM_STATIC_ASSERT(sizeof(int) == sizeof(int32), "int and int32 size mismatch");
 
 		int64 Value64 = static_cast<int64>(x) * static_cast<int64>(y);
-		int32* PointerMSB = (reinterpret_cast<int32*>(&Value64) + 1);
-		msb = *PointerMSB;
-		int32* PointerLSB = (reinterpret_cast<int32*>(&Value64));
-		lsb = *PointerLSB;
+		msb = Value64 >> 32;
+		lsb = Value64;
 	}
 
 	template <precision P, template <typename, precision> class vecType>


### PR DESCRIPTION
Hello,
test-core_func_integer fails on BE machines(ppc, s390,...). Specifically imul/umul (u)int tests. This is caused by incorrect handling of MSB/LSB parts of (u)int64 value in corresponding functions. This pull request fixes this issue. I have tested it in Fedora 21/rawhide on ppc64, s390(x), x86(_64), arm7 and aarch64.

Fedora bug: https://bugzilla.redhat.com/show_bug.cgi?id=1185298

