### PR TITLE
Changed usage of __has_include to support Intel compiler.

### DIFF
--- a/glm/detail/setup.hpp
+++ b/glm/detail/setup.hpp
@@ -514,7 +514,7 @@
 #define GLM_HAS_CXX11_STL !defined(GLM_FORCE_CXX98) && !defined(GLM_FORCE_CXX03) && ((GLM_PLATFORM != GLM_PLATFORM_ANDROID) && (\
 	((GLM_LANG & GLM_LANG_CXX0X_FLAG) && (GLM_COMPILER & GLM_COMPILER_GCC) && (GLM_COMPILER >= GLM_COMPILER_GCC48)) || \
 	((GLM_LANG & GLM_LANG_CXX0X_FLAG) && (GLM_COMPILER & GLM_COMPILER_VC) && (GLM_COMPILER >= GLM_COMPILER_VC2013)) || \
-	__has_include(<__config>)))
+	__has_include("__config")))
 
 // N1720
 #define GLM_HAS_STATIC_ASSERT !defined(GLM_FORCE_CXX98) && !defined(GLM_FORCE_CXX03) && ( \


### PR DESCRIPTION
Intel compiler supports __has_include, but does not support angle brackets in the argument. Clang and Intel both accept quotes with seemingly identical semantics to one another, and to angle brackets. Only difference appears to be that `icpc` no longer crashes trying to compile code using glm.