### PR TITLE
Specialize integer implementation of YCoCg-R to use bitshifts

### DIFF
--- a/glm/gtx/color_space_YCoCg.inl
+++ b/glm/gtx/color_space_YCoCg.inl
@@ -86,7 +86,7 @@ namespace glm
 			return result;
 		}
 	};
-#if 0
+
 	template <typename T, precision P>
 	class compute_YCoCgR<T, P, true> {
 	public:
@@ -116,7 +116,7 @@ namespace glm
 			return result;
 		}
 	};
-#endif  
+
 	template <typename T, precision P>
 	GLM_FUNC_QUALIFIER tvec3<T, P> rgb2YCoCgR
 	(

--- a/glm/gtx/color_space_YCoCg.inl
+++ b/glm/gtx/color_space_YCoCg.inl
@@ -46,19 +46,6 @@ namespace glm
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tvec3<T, P> rgb2YCoCgR
-	(
-		tvec3<T, P> const & rgbColor
-	)
-	{
-		tvec3<T, P> result;
-		result.x/*Y */ = rgbColor.g / T(2) + (rgbColor.r + rgbColor.b) / T(4);
-		result.y/*Co*/ = rgbColor.r - rgbColor.b;
-		result.z/*Cg*/ = rgbColor.g - (rgbColor.r + rgbColor.b) / T(2);
-		return result;
-	}
-
-	template <typename T, precision P>
 	GLM_FUNC_QUALIFIER tvec3<T, P> YCoCg2rgb
 	(
 		tvec3<T, P> const & YCoCgColor
@@ -66,9 +53,77 @@ namespace glm
 	{
 		tvec3<T, P> result;
 		result.r = YCoCgColor.x + YCoCgColor.y - YCoCgColor.z;
-		result.g = YCoCgColor.x                + YCoCgColor.z;
+		result.g = YCoCgColor.x				   + YCoCgColor.z;
 		result.b = YCoCgColor.x - YCoCgColor.y - YCoCgColor.z;
 		return result;
+	}
+
+	template <typename T, precision P, bool isInteger>
+	class compute_YCoCgR {
+	public:
+		static GLM_FUNC_QUALIFIER tvec3<T, P> rgb2YCoCgR
+		(
+			tvec3<T, P> const & rgbColor
+		)
+		{
+			tvec3<T, P> result;
+			result.x/*Y */ = rgbColor.g / T(2) + (rgbColor.r + rgbColor.b) / T(4);
+			result.y/*Co*/ = rgbColor.r - rgbColor.b;
+			result.z/*Cg*/ = rgbColor.g - (rgbColor.r + rgbColor.b) / T(2);
+			return result;
+		}
+
+		static GLM_FUNC_QUALIFIER tvec3<T, P> YCoCgR2rgb
+		(
+			tvec3<T, P> const & YCoCgRColor
+		)
+		{
+			tvec3<T, P> result;
+			T tmp = YCoCgRColor.x - (YCoCgRColor.z / T(2));
+			result.g = YCoCgRColor.z + tmp;
+			result.b = tmp - (YCoCgRColor.y / T(2));
+			result.r = result.b + YCoCgRColor.y;
+			return result;
+		}
+	};
+#if 0
+	template <typename T, precision P>
+	class compute_YCoCgR<T, P, true> {
+	public:
+		static GLM_FUNC_QUALIFIER tvec3<T, P> rgb2YCoCgR
+		(
+			tvec3<T, P> const & rgbColor
+		)
+		{
+			tvec3<T, P> result;
+			result.y/*Co*/ = rgbColor.r - rgbColor.b;
+			T tmp = rgbColor.b + (result.y >> 1);
+			result.z/*Cg*/ = rgbColor.g - tmp;
+			result.x/*Y */ = tmp + (result.z >> 1);
+			return result;
+		}
+
+		static GLM_FUNC_QUALIFIER tvec3<T, P> YCoCgR2rgb
+		(
+			tvec3<T, P> const & YCoCgRColor
+		)
+		{
+			tvec3<T, P> result;
+			T tmp = YCoCgRColor.x - (YCoCgRColor.z >> 1);
+			result.g = YCoCgRColor.z + tmp;
+			result.b = tmp - (YCoCgRColor.y >> 1);
+			result.r = result.b + YCoCgRColor.y;
+			return result;
+		}
+	};
+#endif  
+	template <typename T, precision P>
+	GLM_FUNC_QUALIFIER tvec3<T, P> rgb2YCoCgR
+	(
+		tvec3<T, P> const & rgbColor
+	)
+	{
+		return compute_YCoCgR<T, P, std::numeric_limits<T>::is_integer>::rgb2YCoCgR(rgbColor);
 	}
 
 	template <typename T, precision P>
@@ -77,11 +132,6 @@ namespace glm
 		tvec3<T, P> const & YCoCgRColor
 	)
 	{
-		tvec3<T, P> result;
-		T tmp = YCoCgRColor.x - (YCoCgRColor.z / T(2));
-		result.g = YCoCgRColor.z + tmp;
-		result.b = tmp - (YCoCgRColor.y / T(2));
-		result.r = result.b + YCoCgRColor.y;
-		return result;
+		return compute_YCoCgR<T, P, std::numeric_limits<T>::is_integer>::YCoCgR2rgb(YCoCgRColor);
 	}
 }//namespace glm


### PR DESCRIPTION
It turns out that the current implementation of YCoCgR conversion is not reversible (f(g(x)) != x) for certain combinations of pixels, for example:

    glm::ivec3 v(226, 124, 192);
    // This fires, when it shouldn't if the implementations are reversible.
    assert (v == YCoCgR2rgb(rgb2YCoCgR(v)));

I've added a patch that specializes the template instantiation for integer types to use bit shifts as outlined in Eqn (8) of [this paper](http://research.microsoft.com/pubs/102040/2008_ColorTransforms_MalvarSullivanSrinivasan.PDF). This fixes the situation in the assert, yet leaves floating point implementations to work as they used to.