### PR TITLE
added: 'operator<<(std::pair<tmat4x4<T,P>, tmat4x4<T,P>>)' routed to 'op...

### DIFF
--- a/glm/gtx/io.hpp
+++ b/glm/gtx/io.hpp
@@ -214,12 +214,18 @@ namespace glm
 	template <typename CTy, typename CTr, typename T, precision P>
 	GLM_FUNC_DECL std::basic_ostream<CTy,CTr>& operator<<(std::basic_ostream<CTy,CTr>&, tmat4x4<T,P> const&);
 
-	template <typename CTy, typename CTr, typename T, precision P>
+  template <typename CTy, typename CTr, typename T, precision P>
 	GLM_FUNC_DECL std::basic_ostream<CTy,CTr> & operator<<(
 		std::basic_ostream<CTy,CTr> &,
 		std::pair<tmat4x4<T,P> const,
 		tmat4x4<T,P> const> const &);
 
+  template <typename CTy, typename CTr, typename T, precision P>
+	GLM_FUNC_DECL std::basic_ostream<CTy,CTr> & operator<<(
+		std::basic_ostream<CTy,CTr> &,
+		std::pair<tmat4x4<T,P>,
+		tmat4x4<T,P>> const &);
+  
 	/// @}
 }//namespace glm
 

--- a/glm/gtx/io.inl
+++ b/glm/gtx/io.inl
@@ -605,7 +605,7 @@ namespace io
 
 		return os;
 	}
-
+  
 	template <typename CTy, typename CTr, typename T, precision P>
 	GLM_FUNC_QUALIFIER std::basic_ostream<CTy,CTr>& operator<<(
 		std::basic_ostream<CTy,CTr> & os,
@@ -645,4 +645,13 @@ namespace io
 
 		return os;
 	}
+
+  template <typename CTy, typename CTr, typename T, precision P>
+	GLM_FUNC_QUALIFIER std::basic_ostream<CTy,CTr>& operator<<(
+		std::basic_ostream<CTy,CTr> & os,
+		std::pair<tmat4x4<T,P>, tmat4x4<T,P>> const& a)
+	{
+    return operator<<(os, static_cast<std::pair<tmat4x4<T,P> const, tmat4x4<T,P> const> const&>(a));
+  }
+  
 }//namespace glm


### PR DESCRIPTION
...erator<<(std::pair<tmat4x4<T,P> const, tmat4x4<T,P> const>)' to avoid specifier removal by 'std::make_pair<>' and follow-up type-deduction problems; see [http://stackoverflow.com/questions/29985791/]