### PR TITLE
Add static components and prec members to all vector and quat types

### DIFF
--- a/glm/detail/type_mat2x2.hpp
+++ b/glm/detail/type_mat2x2.hpp
@@ -8,14 +8,14 @@
 /// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 /// copies of the Software, and to permit persons to whom the Software is
 /// furnished to do so, subject to the following conditions:
-/// 
+///
 /// The above copyright notice and this permission notice shall be included in
 /// all copies or substantial portions of the Software.
-/// 
+///
 /// Restrictions:
 ///		By making use of the Software for military purposes, you choose to make
 ///		a Bunny unhappy.
-/// 
+///
 /// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 /// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 /// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -54,11 +54,23 @@ namespace glm
 		template <typename U, precision Q>
 		friend tvec2<U, Q> operator/(tvec2<U, Q> const & v, tmat2x2<U, Q> const & m);
 
+#		if GLM_HAS_CONSTEXPR
+		static GLM_CONSTEXPR length_t components = 2;
+		static GLM_CONSTEXPR length_t cols = 2;
+		static GLM_CONSTEXPR length_t rows = 2;
+		static GLM_CONSTEXPR precision prec = P;
+#		else
+		static const length_t components = 2;
+		static const length_t cols = 2;
+		static const length_t rows = 2;
+		static const precision prec = P;
+#		endif
+
 	private:
 		/// @cond DETAIL
 		col_type value[2];
 		/// @endcond
-		
+
 	public:
 		//////////////////////////////////////
 		// Constructors
@@ -130,23 +142,23 @@ namespace glm
 
 		GLM_FUNC_DECL tmat2x2<T, P> & operator=(tmat2x2<T, P> const & v);
 
-		template <typename U> 
+		template <typename U>
 		GLM_FUNC_DECL tmat2x2<T, P> & operator=(tmat2x2<U, P> const & m);
-		template <typename U> 
+		template <typename U>
 		GLM_FUNC_DECL tmat2x2<T, P> & operator+=(U s);
-		template <typename U> 
+		template <typename U>
 		GLM_FUNC_DECL tmat2x2<T, P> & operator+=(tmat2x2<U, P> const & m);
-		template <typename U> 
+		template <typename U>
 		GLM_FUNC_DECL tmat2x2<T, P> & operator-=(U s);
-		template <typename U> 
+		template <typename U>
 		GLM_FUNC_DECL tmat2x2<T, P> & operator-=(tmat2x2<U, P> const & m);
-		template <typename U> 
+		template <typename U>
 		GLM_FUNC_DECL tmat2x2<T, P> & operator*=(U s);
-		template <typename U> 
+		template <typename U>
 		GLM_FUNC_DECL tmat2x2<T, P> & operator*=(tmat2x2<U, P> const & m);
-		template <typename U> 
+		template <typename U>
 		GLM_FUNC_DECL tmat2x2<T, P> & operator/=(U s);
-		template <typename U> 
+		template <typename U>
 		GLM_FUNC_DECL tmat2x2<T, P> & operator/=(tmat2x2<U, P> const & m);
 
 		//////////////////////////////////////
@@ -191,10 +203,10 @@ namespace glm
 
 	template <typename T, precision P>
 	GLM_FUNC_DECL tmat2x2<T, P> operator*(tmat2x2<T, P> const & m1,	tmat2x2<T, P> const & m2);
-		
+
 	template <typename T, precision P>
 	GLM_FUNC_DECL tmat3x2<T, P> operator*(tmat2x2<T, P> const & m1, tmat3x2<T, P> const & m2);
-		
+
 	template <typename T, precision P>
 	GLM_FUNC_DECL tmat4x2<T, P> operator*(tmat2x2<T, P> const & m1, tmat4x2<T, P> const & m2);
 
@@ -214,7 +226,7 @@ namespace glm
 	GLM_FUNC_DECL tmat2x2<T, P> operator/(tmat2x2<T, P> const & m1, tmat2x2<T, P> const & m2);
 
 	// Unary constant operators
-	template <typename T, precision P> 
+	template <typename T, precision P>
 	GLM_FUNC_DECL tmat2x2<T, P> const operator-(tmat2x2<T, P> const & m);
 } //namespace glm
 

--- a/glm/detail/type_mat2x3.hpp
+++ b/glm/detail/type_mat2x3.hpp
@@ -8,14 +8,14 @@
 /// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 /// copies of the Software, and to permit persons to whom the Software is
 /// furnished to do so, subject to the following conditions:
-/// 
+///
 /// The above copyright notice and this permission notice shall be included in
 /// all copies or substantial portions of the Software.
-/// 
+///
 /// Restrictions:
 ///		By making use of the Software for military purposes, you choose to make
 ///		a Bunny unhappy.
-/// 
+///
 /// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 /// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 /// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -50,11 +50,23 @@ namespace glm
 		typedef tmat3x2<T, P> transpose_type;
 		typedef T value_type;
 
+#		if GLM_HAS_CONSTEXPR
+		static GLM_CONSTEXPR length_t components = 2;
+		static GLM_CONSTEXPR length_t cols = 3;
+		static GLM_CONSTEXPR length_t rows = 2;
+		static GLM_CONSTEXPR precision prec = P;
+#		else
+		static const length_t components = 2;
+		static const length_t cols = 3;
+		static const length_t rows = 2;
+		static const precision prec = P;
+#		endif
+
 	private:
-		/// @cond DETAIL 
+		/// @cond DETAIL
 		col_type value[2];
 		/// @endcond
-		
+
 	public:
 		// Constructors
 		GLM_FUNC_DECL tmat2x3();
@@ -78,7 +90,7 @@ namespace glm
 		GLM_FUNC_DECL tmat2x3(
 			X1 const & x1, Y1 const & y1, Z1 const & z1,
 			X2 const & x2, Y2 const & y2, Z2 const & z2);
-			
+
 		template <typename U, typename V>
 		GLM_FUNC_DECL tmat2x3(
 			tvec3<U, P> const & v1,
@@ -126,19 +138,19 @@ namespace glm
 
 		GLM_FUNC_DECL tmat2x3<T, P> & operator=(tmat2x3<T, P> const & m);
 
-		template <typename U> 
+		template <typename U>
 		GLM_FUNC_DECL tmat2x3<T, P> & operator=(tmat2x3<U, P> const & m);
-		template <typename U> 
+		template <typename U>
 		GLM_FUNC_DECL tmat2x3<T, P> & operator+=(U s);
-		template <typename U> 
+		template <typename U>
 		GLM_FUNC_DECL tmat2x3<T, P> & operator+=(tmat2x3<U, P> const & m);
-		template <typename U> 
+		template <typename U>
 		GLM_FUNC_DECL tmat2x3<T, P> & operator-=(U s);
-		template <typename U> 
+		template <typename U>
 		GLM_FUNC_DECL tmat2x3<T, P> & operator-=(tmat2x3<U, P> const & m);
-		template <typename U> 
+		template <typename U>
 		GLM_FUNC_DECL tmat2x3<T, P> & operator*=(U s);
-		template <typename U> 
+		template <typename U>
 		GLM_FUNC_DECL tmat2x3<T, P> & operator/=(U s);
 
 		//////////////////////////////////////
@@ -181,7 +193,7 @@ namespace glm
 
 	template <typename T, precision P>
 	GLM_FUNC_DECL tmat3x3<T, P> operator*(tmat2x3<T, P> const & m1, tmat3x2<T, P> const & m2);
-		
+
 	template <typename T, precision P>
 	GLM_FUNC_DECL tmat4x3<T, P> operator*(tmat2x3<T, P> const & m1, tmat4x2<T, P> const & m2);
 

--- a/glm/detail/type_mat2x4.hpp
+++ b/glm/detail/type_mat2x4.hpp
@@ -8,14 +8,14 @@
 /// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 /// copies of the Software, and to permit persons to whom the Software is
 /// furnished to do so, subject to the following conditions:
-/// 
+///
 /// The above copyright notice and this permission notice shall be included in
 /// all copies or substantial portions of the Software.
-/// 
+///
 /// Restrictions:
 ///		By making use of the Software for military purposes, you choose to make
 ///		a Bunny unhappy.
-/// 
+///
 /// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 /// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 /// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -50,11 +50,23 @@ namespace glm
 		typedef tmat4x2<T, P> transpose_type;
 		typedef T value_type;
 
+#		if GLM_HAS_CONSTEXPR
+		static GLM_CONSTEXPR length_t components = 2;
+		static GLM_CONSTEXPR length_t cols = 4;
+		static GLM_CONSTEXPR length_t rows = 2;
+		static GLM_CONSTEXPR precision prec = P;
+#		else
+		static const length_t components = 2;
+		static const length_t cols = 4;
+		static const length_t rows = 2;
+		static const precision prec = P;
+#		endif
+
 	private:
 		/// @cond DETAIL
 		col_type value[2];
 		/// @endcond
-		
+
 	public:
 		// Constructors
 		GLM_FUNC_DECL tmat2x4();
@@ -68,7 +80,7 @@ namespace glm
 			T const & x0, T const & y0, T const & z0, T const & w0,
 			T const & x1, T const & y1, T const & z1, T const & w1);
 		GLM_FUNC_DECL tmat2x4(
-			col_type const & v0, 
+			col_type const & v0,
 			col_type const & v1);
 
 		//////////////////////////////////////
@@ -127,19 +139,19 @@ namespace glm
 
 		GLM_FUNC_DECL tmat2x4<T, P> & operator=(tmat2x4<T, P> const & m);
 
-		template <typename U> 
+		template <typename U>
 		GLM_FUNC_DECL tmat2x4<T, P> & operator=(tmat2x4<U, P> const & m);
-		template <typename U> 
+		template <typename U>
 		GLM_FUNC_DECL tmat2x4<T, P> & operator+=(U s);
-		template <typename U> 
+		template <typename U>
 		GLM_FUNC_DECL tmat2x4<T, P> & operator+=(tmat2x4<U, P> const & m);
-		template <typename U> 
+		template <typename U>
 		GLM_FUNC_DECL tmat2x4<T, P> & operator-=(U s);
-		template <typename U> 
+		template <typename U>
 		GLM_FUNC_DECL tmat2x4<T, P> & operator-=(tmat2x4<U, P> const & m);
-		template <typename U> 
+		template <typename U>
 		GLM_FUNC_DECL tmat2x4<T, P> & operator*=(U s);
-		template <typename U> 
+		template <typename U>
 		GLM_FUNC_DECL tmat2x4<T, P> & operator/=(U s);
 
 		//////////////////////////////////////
@@ -179,7 +191,7 @@ namespace glm
 
 	template <typename T, precision P>
 	GLM_FUNC_DECL tmat4x4<T, P> operator*(tmat2x4<T, P> const & m1, tmat4x2<T, P> const & m2);
-		
+
 	template <typename T, precision P>
 	GLM_FUNC_DECL tmat2x4<T, P> operator*(tmat2x4<T, P> const & m1, tmat2x2<T, P> const & m2);
 
@@ -189,7 +201,7 @@ namespace glm
 	template <typename T, precision P>
 	GLM_FUNC_DECL tmat2x4<T, P> operator/(tmat2x4<T, P> const & m, T s);
 
-	template <typename T, precision P> 
+	template <typename T, precision P>
 	GLM_FUNC_DECL tmat2x4<T, P> operator/(T s, tmat2x4<T, P> const & m);
 
 	// Unary constant operators

--- a/glm/detail/type_mat3x2.hpp
+++ b/glm/detail/type_mat3x2.hpp
@@ -8,14 +8,14 @@
 /// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 /// copies of the Software, and to permit persons to whom the Software is
 /// furnished to do so, subject to the following conditions:
-/// 
+///
 /// The above copyright notice and this permission notice shall be included in
 /// all copies or substantial portions of the Software.
-/// 
+///
 /// Restrictions:
 ///		By making use of the Software for military purposes, you choose to make
 ///		a Bunny unhappy.
-/// 
+///
 /// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 /// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 /// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -50,11 +50,23 @@ namespace glm
 		typedef tmat2x3<T, P> transpose_type;
 		typedef T value_type;
 
+#		if GLM_HAS_CONSTEXPR
+		static GLM_CONSTEXPR length_t components = 3;
+		static GLM_CONSTEXPR length_t cols = 2;
+		static GLM_CONSTEXPR length_t rows = 3;
+		static GLM_CONSTEXPR precision prec = P;
+#		else
+		static const length_t components = 3;
+		static const length_t cols = 2;
+		static const length_t rows = 3;
+		static const precision prec = P;
+#		endif
+
 	private:
 		/// @cond DETAIL
 		col_type value[3];
 		/// @endcond
-		
+
 	public:
 		// Constructors
 		GLM_FUNC_DECL tmat3x2();
@@ -84,7 +96,7 @@ namespace glm
 			X1 const & x1, Y1 const & y1,
 			X2 const & x2, Y2 const & y2,
 			X3 const & x3, Y3 const & y3);
-			
+
 		template <typename V1, typename V2, typename V3>
 		GLM_FUNC_DECL tmat3x2(
 			tvec2<V1, P> const & v1,
@@ -133,19 +145,19 @@ namespace glm
 
 		GLM_FUNC_DECL tmat3x2<T, P> & operator=(tmat3x2<T, P> const & m);
 
-		template <typename U> 
+		template <typename U>
 		GLM_FUNC_DECL tmat3x2<T, P> & operator=(tmat3x2<U, P> const & m);
-		template <typename U> 
+		template <typename U>
 		GLM_FUNC_DECL tmat3x2<T, P> & operator+=(U s);
-		template <typename U> 
+		template <typename U>
 		GLM_FUNC_DECL tmat3x2<T, P> & operator+=(tmat3x2<U, P> const & m);
-		template <typename U> 
+		template <typename U>
 		GLM_FUNC_DECL tmat3x2<T, P> & operator-=(U s);
-		template <typename U> 
+		template <typename U>
 		GLM_FUNC_DECL tmat3x2<T, P> & operator-=(tmat3x2<U, P> const & m);
-		template <typename U> 
+		template <typename U>
 		GLM_FUNC_DECL tmat3x2<T, P> & operator*=(U s);
-		template <typename U> 
+		template <typename U>
 		GLM_FUNC_DECL tmat3x2<T, P> & operator/=(U s);
 
 		//////////////////////////////////////
@@ -184,10 +196,10 @@ namespace glm
 
 	template <typename T, precision P>
 	GLM_FUNC_DECL tmat2x2<T, P> operator*(tmat3x2<T, P> const & m1, tmat2x3<T, P> const & m2);
-		
+
 	template <typename T, precision P>
 	GLM_FUNC_DECL tmat3x2<T, P> operator*(tmat3x2<T, P> const & m1, tmat3x3<T, P> const & m2);
-		
+
 	template <typename T, precision P>
 	GLM_FUNC_DECL tmat4x2<T, P> operator*(tmat3x2<T, P> const & m1, tmat4x3<T, P> const & m2);
 

--- a/glm/detail/type_mat3x3.hpp
+++ b/glm/detail/type_mat3x3.hpp
@@ -8,14 +8,14 @@
 /// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 /// copies of the Software, and to permit persons to whom the Software is
 /// furnished to do so, subject to the following conditions:
-/// 
+///
 /// The above copyright notice and this permission notice shall be included in
 /// all copies or substantial portions of the Software.
-/// 
+///
 /// Restrictions:
 ///		By making use of the Software for military purposes, you choose to make
 ///		a Bunny unhappy.
-/// 
+///
 /// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 /// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 /// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -48,6 +48,18 @@ namespace glm
 		typedef tmat3x3<T, P> type;
 		typedef tmat3x3<T, P> transpose_type;
 		typedef T value_type;
+
+#		if GLM_HAS_CONSTEXPR
+		static GLM_CONSTEXPR length_t components = 3;
+		static GLM_CONSTEXPR length_t cols = 3;
+		static GLM_CONSTEXPR length_t rows = 3;
+		static GLM_CONSTEXPR precision prec = P;
+#		else
+		static const length_t components = 3;
+		static const length_t cols = 3;
+		static const length_t rows = 3;
+		static const precision prec = P;
+#		endif
 
 		template <typename U, precision Q>
 		friend tvec3<U, Q> operator/(tmat3x3<U, Q> const & m, tvec3<U, Q> const & v);
@@ -88,7 +100,7 @@ namespace glm
 			X1 const & x1, Y1 const & y1, Z1 const & z1,
 			X2 const & x2, Y2 const & y2, Z2 const & z2,
 			X3 const & x3, Y3 const & y3, Z3 const & z3);
-			
+
 		template <typename V1, typename V2, typename V3>
 		GLM_FUNC_DECL tmat3x3(
 			tvec3<V1, P> const & v1,
@@ -198,10 +210,10 @@ namespace glm
 
 	template <typename T, precision P>
 	GLM_FUNC_DECL tmat3x3<T, P> operator*(tmat3x3<T, P> const & m1, tmat3x3<T, P> const & m2);
-		
+
 	template <typename T, precision P>
 	GLM_FUNC_DECL tmat2x3<T, P> operator*(tmat3x3<T, P> const & m1, tmat2x3<T, P> const & m2);
-		
+
 	template <typename T, precision P>
 	GLM_FUNC_DECL tmat4x3<T, P> operator*(tmat3x3<T, P> const & m1, tmat4x3<T, P> const & m2);
 

--- a/glm/detail/type_mat3x4.hpp
+++ b/glm/detail/type_mat3x4.hpp
@@ -8,14 +8,14 @@
 /// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 /// copies of the Software, and to permit persons to whom the Software is
 /// furnished to do so, subject to the following conditions:
-/// 
+///
 /// The above copyright notice and this permission notice shall be included in
 /// all copies or substantial portions of the Software.
-/// 
+///
 /// Restrictions:
 ///		By making use of the Software for military purposes, you choose to make
 ///		a Bunny unhappy.
-/// 
+///
 /// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 /// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 /// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -50,6 +50,18 @@ namespace glm
 		typedef tmat4x3<T, P> transpose_type;
 		typedef T value_type;
 
+#		if GLM_HAS_CONSTEXPR
+		static GLM_CONSTEXPR length_t components = 3;
+		static GLM_CONSTEXPR length_t cols = 4;
+		static GLM_CONSTEXPR length_t rows = 3;
+		static GLM_CONSTEXPR precision prec = P;
+#		else
+		static const length_t components = 3;
+		static const length_t cols = 4;
+		static const length_t rows = 3;
+		static const precision prec = P;
+#		endif
+
 	private:
 		/// @cond DETAIL
 		col_type value[3];
@@ -83,7 +95,7 @@ namespace glm
 			X1 const & x1, Y1 const & y1, Z1 const & z1, W1 const & w1,
 			X2 const & x2, Y2 const & y2, Z2 const & z2, W2 const & w2,
 			X3 const & x3, Y3 const & y3, Z3 const & z3, W3 const & w3);
-			
+
 		template <typename V1, typename V2, typename V3>
 		GLM_FUNC_DECL tmat3x4(
 			tvec4<V1, P> const & v1,
@@ -132,19 +144,19 @@ namespace glm
 
 		GLM_FUNC_DECL tmat3x4<T, P> & operator=(tmat3x4<T, P> const & m);
 
-		template <typename U> 
+		template <typename U>
 		GLM_FUNC_DECL tmat3x4<T, P> & operator=(tmat3x4<U, P> const & m);
-		template <typename U> 
+		template <typename U>
 		GLM_FUNC_DECL tmat3x4<T, P> & operator+=(U s);
-		template <typename U> 
+		template <typename U>
 		GLM_FUNC_DECL tmat3x4<T, P> & operator+=(tmat3x4<U, P> const & m);
-		template <typename U> 
+		template <typename U>
 		GLM_FUNC_DECL tmat3x4<T, P> & operator-=(U s);
-		template <typename U> 
+		template <typename U>
 		GLM_FUNC_DECL tmat3x4<T, P> & operator-=(tmat3x4<U, P> const & m);
-		template <typename U> 
+		template <typename U>
 		GLM_FUNC_DECL tmat3x4<T, P> & operator*=(U s);
-		template <typename U> 
+		template <typename U>
 		GLM_FUNC_DECL tmat3x4<T, P> & operator/=(U s);
 
 		//////////////////////////////////////
@@ -178,15 +190,15 @@ namespace glm
 	template <typename T, precision P>
 	GLM_FUNC_DECL typename tmat3x4<T, P>::col_type operator*(tmat3x4<T, P> const & m, typename tmat3x4<T, P>::row_type const & v);
 
-	template <typename T, precision P> 
+	template <typename T, precision P>
 	GLM_FUNC_DECL typename tmat3x4<T, P>::row_type operator*(typename tmat3x4<T, P>::col_type const & v, tmat3x4<T, P> const & m);
 
 	template <typename T, precision P>
 	GLM_FUNC_DECL tmat4x4<T, P> operator*(tmat3x4<T, P> const & m1,	tmat4x3<T, P> const & m2);
-		
+
 	template <typename T, precision P>
 	GLM_FUNC_DECL tmat2x4<T, P> operator*(tmat3x4<T, P> const & m1, tmat2x3<T, P> const & m2);
-		
+
 	template <typename T, precision P>
 	GLM_FUNC_DECL tmat3x4<T, P> operator*(tmat3x4<T, P> const & m1,	tmat3x3<T, P> const & m2);
 

--- a/glm/detail/type_mat4x2.hpp
+++ b/glm/detail/type_mat4x2.hpp
@@ -8,14 +8,14 @@
 /// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 /// copies of the Software, and to permit persons to whom the Software is
 /// furnished to do so, subject to the following conditions:
-/// 
+///
 /// The above copyright notice and this permission notice shall be included in
 /// all copies or substantial portions of the Software.
-/// 
+///
 /// Restrictions:
 ///		By making use of the Software for military purposes, you choose to make
 ///		a Bunny unhappy.
-/// 
+///
 /// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 /// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 /// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -50,6 +50,18 @@ namespace glm
 		typedef tmat2x4<T, P> transpose_type;
 		typedef T value_type;
 
+#		if GLM_HAS_CONSTEXPR
+		static GLM_CONSTEXPR length_t components = 4;
+		static GLM_CONSTEXPR length_t cols = 2;
+		static GLM_CONSTEXPR length_t rows = 4;
+		static GLM_CONSTEXPR precision prec = P;
+#		else
+		static const length_t components = 4;
+		static const length_t cols = 2;
+		static const length_t rows = 4;
+		static const precision prec = P;
+#		endif
+
 	private:
 		/// @cond DETAIL
 		col_type value[4];
@@ -70,7 +82,7 @@ namespace glm
 			T const & x2, T const & y2,
 			T const & x3, T const & y3);
 		GLM_FUNC_DECL tmat4x2(
-			col_type const & v0, 
+			col_type const & v0,
 			col_type const & v1,
 			col_type const & v2,
 			col_type const & v3);
@@ -138,19 +150,19 @@ namespace glm
 
 		GLM_FUNC_DECL tmat4x2<T, P> & operator=(tmat4x2<T, P> const & m);
 
-		template <typename U> 
+		template <typename U>
 		GLM_FUNC_DECL tmat4x2<T, P> & operator=(tmat4x2<U, P> const & m);
-		template <typename U> 
+		template <typename U>
 		GLM_FUNC_DECL tmat4x2<T, P> & operator+=(U s);
-		template <typename U> 
+		template <typename U>
 		GLM_FUNC_DECL tmat4x2<T, P> & operator+=(tmat4x2<U, P> const & m);
-		template <typename U> 
+		template <typename U>
 		GLM_FUNC_DECL tmat4x2<T, P> & operator-=(U s);
-		template <typename U> 
+		template <typename U>
 		GLM_FUNC_DECL tmat4x2<T, P> & operator-=(tmat4x2<U, P> const & m);
-		template <typename U> 
+		template <typename U>
 		GLM_FUNC_DECL tmat4x2<T, P> & operator*=(U s);
-		template <typename U> 
+		template <typename U>
 		GLM_FUNC_DECL tmat4x2<T, P> & operator/=(U s);
 
 		//////////////////////////////////////
@@ -189,10 +201,10 @@ namespace glm
 
 	template <typename T, precision P>
 	GLM_FUNC_DECL tmat3x2<T, P> operator*(tmat4x2<T, P> const & m1, tmat3x4<T, P> const & m2);
-		
+
 	template <typename T, precision P>
 	GLM_FUNC_DECL tmat4x2<T, P> operator*(tmat4x2<T, P> const & m1, tmat4x4<T, P> const & m2);
-		
+
 	template <typename T, precision P>
 	GLM_FUNC_DECL tmat2x3<T, P> operator*(tmat4x3<T, P> const & m1, tmat2x4<T, P> const & m2);
 

--- a/glm/detail/type_mat4x3.hpp
+++ b/glm/detail/type_mat4x3.hpp
@@ -8,14 +8,14 @@
 /// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 /// copies of the Software, and to permit persons to whom the Software is
 /// furnished to do so, subject to the following conditions:
-/// 
+///
 /// The above copyright notice and this permission notice shall be included in
 /// all copies or substantial portions of the Software.
-/// 
+///
 /// Restrictions:
 ///		By making use of the Software for military purposes, you choose to make
 ///		a Bunny unhappy.
-/// 
+///
 /// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 /// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 /// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -50,8 +50,20 @@ namespace glm
 		typedef tmat3x4<T, P> transpose_type;
 		typedef T value_type;
 
+#		if GLM_HAS_CONSTEXPR
+		static GLM_CONSTEXPR length_t components = 4;
+		static GLM_CONSTEXPR length_t cols = 3;
+		static GLM_CONSTEXPR length_t rows = 4;
+		static GLM_CONSTEXPR precision prec = P;
+#		else
+		static const length_t components = 4;
+		static const length_t cols = 3;
+		static const length_t rows = 4;
+		static const precision prec = P;
+#		endif
+
 	private:
-		// Data 
+		// Data
 		col_type value[4];
 
 	public:
@@ -87,7 +99,7 @@ namespace glm
 			X2 const & x2, Y2 const & y2, Z2 const & z2,
 			X3 const & x3, Y3 const & y3, Z3 const & z3,
 			X4 const & x4, Y4 const & y4, Z4 const & z4);
-			
+
 		template <typename V1, typename V2, typename V3, typename V4>
 		GLM_FUNC_DECL tmat4x3(
 			tvec3<V1, P> const & v1,
@@ -191,7 +203,7 @@ namespace glm
 
 	template <typename T, precision P>
 	GLM_FUNC_DECL tmat3x3<T, P> operator*(tmat4x3<T, P> const & m1,	tmat3x4<T, P> const & m2);
-		
+
 	template <typename T, precision P>
 	GLM_FUNC_DECL tmat4x3<T, P> operator*(tmat4x3<T, P> const & m1, tmat4x4<T, P> const & m2);
 

--- a/glm/detail/type_mat4x4.hpp
+++ b/glm/detail/type_mat4x4.hpp
@@ -8,14 +8,14 @@
 /// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 /// copies of the Software, and to permit persons to whom the Software is
 /// furnished to do so, subject to the following conditions:
-/// 
+///
 /// The above copyright notice and this permission notice shall be included in
 /// all copies or substantial portions of the Software.
-/// 
+///
 /// Restrictions:
 ///		By making use of the Software for military purposes, you choose to make
 ///		a Bunny unhappy.
-/// 
+///
 /// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 /// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 /// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -48,6 +48,18 @@ namespace glm
 		typedef tmat4x4<T, P> type;
 		typedef tmat4x4<T, P> transpose_type;
 		typedef T value_type;
+
+#		if GLM_HAS_CONSTEXPR
+		static GLM_CONSTEXPR length_t components = 4;
+		static GLM_CONSTEXPR length_t cols = 4;
+		static GLM_CONSTEXPR length_t rows = 4;
+		static GLM_CONSTEXPR precision prec = P;
+#		else
+		static const length_t components = 4;
+		static const length_t cols = 4;
+		static const length_t rows = 4;
+		static const precision prec = P;
+#		endif
 
 		template <typename U, precision Q>
 		friend tvec4<U, Q> operator/(tmat4x4<U, Q> const & m, tvec4<U, Q> const & v);
@@ -177,13 +189,13 @@ namespace glm
 	template <typename T, precision P>
 	GLM_FUNC_DECL tmat4x4<T, P> operator+(T const & s, tmat4x4<T, P> const & m);
 
-	template <typename T, precision P> 
+	template <typename T, precision P>
 	GLM_FUNC_DECL tmat4x4<T, P> operator+(tmat4x4<T, P> const & m1, tmat4x4<T, P> const & m2);
 
-	template <typename T, precision P> 
+	template <typename T, precision P>
 	GLM_FUNC_DECL tmat4x4<T, P> operator-(tmat4x4<T, P> const & m, T const & s);
 
-	template <typename T, precision P> 
+	template <typename T, precision P>
 	GLM_FUNC_DECL tmat4x4<T, P> operator-(T const & s, tmat4x4<T, P> const & m);
 
 	template <typename T, precision P>

--- a/glm/detail/type_vec1.hpp
+++ b/glm/detail/type_vec1.hpp
@@ -8,14 +8,14 @@
 /// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 /// copies of the Software, and to permit persons to whom the Software is
 /// furnished to do so, subject to the following conditions:
-/// 
+///
 /// The above copyright notice and this permission notice shall be included in
 /// all copies or substantial portions of the Software.
-/// 
+///
 /// Restrictions:
 ///		By making use of the Software for military purposes, you choose to make
 ///		a Bunny unhappy.
-/// 
+///
 /// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 /// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 /// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -54,7 +54,13 @@ namespace glm
 		typedef tvec1<T, P> type;
 		typedef tvec1<bool, P> bool_type;
 		typedef T value_type;
-
+#   if GLM_HAS_CONSTEXPR
+		static GLM_CONSTEXPR length_t components = 1;
+		static GLM_CONSTEXPR precision prec = P;
+#   else
+		static const length_t components = 1;
+		static const precision prec = P;
+#   endif
 		//////////////////////////////////////
 		// Data
 
@@ -120,7 +126,7 @@ namespace glm
 
 		//////////////////////////////////////
 		// Conversion vector constructors
-		
+
 		//! Explicit conversions (From section 5.4.1 Conversion and scalar constructors of GLSL 1.30.08 specification)
 		template <typename U, precision Q>
 		GLM_FUNC_DECL explicit tvec1(tvec2<U, Q> const & v);
@@ -157,23 +163,23 @@ namespace glm
 
 		GLM_FUNC_DECL tvec1<T, P> & operator=(tvec1<T, P> const & v);
 
-		template <typename U> 
+		template <typename U>
 		GLM_FUNC_DECL tvec1<T, P> & operator=(tvec1<U, P> const & v);
-		template <typename U> 
+		template <typename U>
 		GLM_FUNC_DECL tvec1<T, P> & operator+=(U const & s);
-		template <typename U> 
+		template <typename U>
 		GLM_FUNC_DECL tvec1<T, P> & operator+=(tvec1<U, P> const & v);
-		template <typename U> 
+		template <typename U>
 		GLM_FUNC_DECL tvec1<T, P> & operator-=(U const & s);
-		template <typename U> 
+		template <typename U>
 		GLM_FUNC_DECL tvec1<T, P> & operator-=(tvec1<U, P> const & v);
-		template <typename U> 
+		template <typename U>
 		GLM_FUNC_DECL tvec1<T, P> & operator*=(U const & s);
-		template <typename U> 
+		template <typename U>
 		GLM_FUNC_DECL tvec1<T, P> & operator*=(tvec1<U, P> const & v);
-		template <typename U> 
+		template <typename U>
 		GLM_FUNC_DECL tvec1<T, P> & operator/=(U const & s);
-		template <typename U> 
+		template <typename U>
 		GLM_FUNC_DECL tvec1<T, P> & operator/=(tvec1<U, P> const & v);
 
 		//////////////////////////////////////
@@ -187,29 +193,29 @@ namespace glm
 		//////////////////////////////////////
 		// Unary bit operators
 
-		template <typename U> 
+		template <typename U>
 		GLM_FUNC_DECL tvec1<T, P> & operator%=(U const & s);
-		template <typename U> 
+		template <typename U>
 		GLM_FUNC_DECL tvec1<T, P> & operator%=(tvec1<U, P> const & v);
-		template <typename U> 
+		template <typename U>
 		GLM_FUNC_DECL tvec1<T, P> & operator&=(U const & s);
-		template <typename U> 
+		template <typename U>
 		GLM_FUNC_DECL tvec1<T, P> & operator&=(tvec1<U, P> const & v);
-		template <typename U> 
+		template <typename U>
 		GLM_FUNC_DECL tvec1<T, P> & operator|=(U const & s);
-		template <typename U> 
+		template <typename U>
 		GLM_FUNC_DECL tvec1<T, P> & operator|=(tvec1<U, P> const & v);
-		template <typename U> 
+		template <typename U>
 		GLM_FUNC_DECL tvec1<T, P> & operator^=(U const & s);
-		template <typename U> 
+		template <typename U>
 		GLM_FUNC_DECL tvec1<T, P> & operator^=(tvec1<U, P> const & v);
-		template <typename U> 
+		template <typename U>
 		GLM_FUNC_DECL tvec1<T, P> & operator<<=(U const & s);
-		template <typename U> 
+		template <typename U>
 		GLM_FUNC_DECL tvec1<T, P> & operator<<=(tvec1<U, P> const & v);
-		template <typename U> 
+		template <typename U>
 		GLM_FUNC_DECL tvec1<T, P> & operator>>=(U const & s);
-		template <typename U> 
+		template <typename U>
 		GLM_FUNC_DECL tvec1<T, P> & operator>>=(tvec1<U, P> const & v);
 	};
 
@@ -313,7 +319,7 @@ namespace glm
 	template <typename T, precision P>
 	GLM_FUNC_DECL tvec1<T, P> operator>>(tvec1<T, P> const & v1, tvec1<T, P> const & v2);
 
-	template <typename T, precision P> 
+	template <typename T, precision P>
 	GLM_FUNC_DECL tvec1<T, P> operator~(tvec1<T, P> const & v);
 }//namespace glm
 

--- a/glm/detail/type_vec2.hpp
+++ b/glm/detail/type_vec2.hpp
@@ -54,6 +54,13 @@ namespace glm
 		typedef tvec2<T, P> type;
 		typedef tvec2<bool, P> bool_type;
 		typedef T value_type;
+#		if GLM_HAS_CONSTEXPR
+		static GLM_CONSTEXPR length_t components = 2;
+		static GLM_CONSTEXPR precision prec = P;
+#		else
+		static const length_t components = 2;
+		static const precision prec = P;
+#		endif
 
 		//////////////////////////////////////
 		// Data

--- a/glm/detail/type_vec3.hpp
+++ b/glm/detail/type_vec3.hpp
@@ -54,6 +54,13 @@ namespace glm
 		typedef tvec3<T, P> type;
 		typedef tvec3<bool, P> bool_type;
 		typedef T value_type;
+#		if GLM_HAS_CONSTEXPR
+		static GLM_CONSTEXPR length_t components = 3;
+		static GLM_CONSTEXPR precision prec = P;
+#		else
+		static const length_t components = 3;
+		static const precision prec = P;
+#		endif
 
 		//////////////////////////////////////
 		// Data

--- a/glm/detail/type_vec4.hpp
+++ b/glm/detail/type_vec4.hpp
@@ -108,6 +108,13 @@ namespace detail
 		typedef tvec4<T, P> type;
 		typedef tvec4<bool, P> bool_type;
 		typedef T value_type;
+#		if GLM_HAS_CONSTEXPR
+		static GLM_CONSTEXPR length_t components = 4;
+		static GLM_CONSTEXPR precision prec = P;
+#		else
+		static const length_t components = 4;
+		static const precision prec = P;
+#		endif
 
 		//////////////////////////////////////
 		// Data

--- a/glm/gtc/quaternion.hpp
+++ b/glm/gtc/quaternion.hpp
@@ -64,6 +64,13 @@ namespace glm
 	{
 		typedef tquat<T, P> type;
 		typedef T value_type;
+#		if GLM_HAS_CONSTEXPR
+		static GLM_CONSTEXPR length_t components = 4;
+		static GLM_CONSTEXPR precision prec = P;
+#		else
+		static const length_t components = 4;
+		static const precision prec = P;
+#		endif
 
 	public:
 		T x, y, z, w;

--- a/glm/gtx/dual_quaternion.hpp
+++ b/glm/gtx/dual_quaternion.hpp
@@ -15,7 +15,7 @@
 /// Restrictions:
 ///		By making use of the Software for military purposes, you choose to make
 ///		a Bunny unhappy.
-/// 
+///
 /// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 /// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 /// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -63,10 +63,17 @@ namespace glm
 	{
 		typedef T value_type;
 		typedef glm::tquat<T, P> part_type;
-		
+#		if GLM_HAS_CONSTEXPR
+		static GLM_CONSTEXPR length_t components = 8;
+		static GLM_CONSTEXPR precision prec = P;
+#		else
+		static const length_t components = 8;
+		static const precision prec = P;
+#		endif
+
 	public:
 		glm::tquat<T, P> real, dual;
-		
+
 		//////////////////////////////////////
 		// Component accesses
 
@@ -115,7 +122,7 @@ namespace glm
 
 		GLM_FUNC_DECL explicit tdualquat(tmat2x4<T, P> const & holder_mat);
 		GLM_FUNC_DECL explicit tdualquat(tmat3x4<T, P> const & aug_mat);
-		
+
 		// Operators
 		GLM_FUNC_DECL tdualquat<T, P> & operator=(tdualquat<T, P> const & m);
 
@@ -126,51 +133,51 @@ namespace glm
 		template <typename U>
 		GLM_FUNC_DECL tdualquat<T, P> & operator/=(U s);
 	};
-	
+
 	template <typename T, precision P>
 	GLM_FUNC_DECL tquat<T, P> operator- (
 		tquat<T, P> const & q);
-	
+
 	template <typename T, precision P>
 	GLM_FUNC_DECL tdualquat<T, P> operator+ (
 		tdualquat<T, P> const & q,
 		tdualquat<T, P> const & p);
-	
+
 	template <typename T, precision P>
 	GLM_FUNC_DECL tdualquat<T, P> operator* (
 		tdualquat<T, P> const & q,
 		tdualquat<T, P> const & p);
-	
+
 	template <typename T, precision P>
 	GLM_FUNC_DECL tvec3<T, P> operator* (
 		tquat<T, P> const & q,
 		tvec3<T, P> const & v);
-	
+
 	template <typename T, precision P>
 	GLM_FUNC_DECL tvec3<T, P> operator* (
 		tvec3<T, P> const & v,
 		tquat<T, P> const & q);
-	
+
 	template <typename T, precision P>
 	GLM_FUNC_DECL tvec4<T, P> operator* (
 		tquat<T, P> const & q,
 		tvec4<T, P> const & v);
-	
+
 	template <typename T, precision P>
 	GLM_FUNC_DECL tvec4<T, P> operator* (
 		tvec4<T, P> const & v,
 		tquat<T, P> const & q);
-	
+
 	template <typename T, precision P>
 	GLM_FUNC_DECL tdualquat<T, P> operator* (
 		tdualquat<T, P> const & q,
 		T const & s);
-	
+
 	template <typename T, precision P>
 	GLM_FUNC_DECL tdualquat<T, P> operator* (
 		T const & s,
 		tdualquat<T, P> const & q);
-	
+
 	template <typename T, precision P>
 	GLM_FUNC_DECL tdualquat<T, P> operator/ (
 		tdualquat<T, P> const & q,
@@ -227,17 +234,17 @@ namespace glm
 	GLM_FUNC_DECL tdualquat<T, P> dualquat_cast(
 		tmat3x4<T, P> const & x);
 
-	
+
 	/// Dual-quaternion of low single-precision floating-point numbers.
 	///
 	/// @see gtx_dual_quaternion
 	typedef tdualquat<float, lowp>		lowp_dualquat;
-	
+
 	/// Dual-quaternion of medium single-precision floating-point numbers.
 	///
 	/// @see gtx_dual_quaternion
 	typedef tdualquat<float, mediump>	mediump_dualquat;
-	
+
 	/// Dual-quaternion of high single-precision floating-point numbers.
 	///
 	/// @see gtx_dual_quaternion
@@ -248,40 +255,40 @@ namespace glm
 	///
 	/// @see gtx_dual_quaternion
 	typedef tdualquat<float, lowp>		lowp_fdualquat;
-	
+
 	/// Dual-quaternion of medium single-precision floating-point numbers.
 	///
 	/// @see gtx_dual_quaternion
 	typedef tdualquat<float, mediump>	mediump_fdualquat;
-	
+
 	/// Dual-quaternion of high single-precision floating-point numbers.
 	///
 	/// @see gtx_dual_quaternion
 	typedef tdualquat<float, highp>		highp_fdualquat;
-	
-	
+
+
 	/// Dual-quaternion of low double-precision floating-point numbers.
 	///
 	/// @see gtx_dual_quaternion
 	typedef tdualquat<double, lowp>		lowp_ddualquat;
-	
+
 	/// Dual-quaternion of medium double-precision floating-point numbers.
 	///
 	/// @see gtx_dual_quaternion
 	typedef tdualquat<double, mediump>	mediump_ddualquat;
-	
+
 	/// Dual-quaternion of high double-precision floating-point numbers.
 	///
 	/// @see gtx_dual_quaternion
 	typedef tdualquat<double, highp>	highp_ddualquat;
 
-	
+
 #if(!defined(GLM_PRECISION_HIGHP_FLOAT) && !defined(GLM_PRECISION_MEDIUMP_FLOAT) && !defined(GLM_PRECISION_LOWP_FLOAT))
 	/// Dual-quaternion of floating-point numbers.
 	///
 	/// @see gtx_dual_quaternion
 	typedef highp_fdualquat			dualquat;
-	
+
 	/// Dual-quaternion of single-precision floating-point numbers.
 	///
 	/// @see gtx_dual_quaternion
@@ -298,7 +305,7 @@ namespace glm
 #else
 #	error "GLM error: multiple default precision requested for single-precision floating-point types"
 #endif
-	
+
 
 #if(!defined(GLM_PRECISION_HIGHP_DOUBLE) && !defined(GLM_PRECISION_MEDIUMP_DOUBLE) && !defined(GLM_PRECISION_LOWP_DOUBLE))
 	/// Dual-quaternion of default double-precision floating-point numbers.

--- a/glm/gtx/simd_mat4.hpp
+++ b/glm/gtx/simd_mat4.hpp
@@ -8,14 +8,14 @@
 /// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 /// copies of the Software, and to permit persons to whom the Software is
 /// furnished to do so, subject to the following conditions:
-/// 
+///
 /// The above copyright notice and this permission notice shall be included in
 /// all copies or substantial portions of the Software.
-/// 
+///
 /// Restrictions:
 ///		By making use of the Software for military purposes, you choose to make
 ///		a Bunny unhappy.
-/// 
+///
 /// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 /// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 /// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -33,9 +33,9 @@
 ///
 /// @defgroup gtx_simd_mat4 GLM_GTX_simd_mat4
 /// @ingroup gtx
-/// 
+///
 /// @brief SIMD implementation of mat4 type.
-/// 
+///
 /// <glm/gtx/simd_mat4.hpp> need to be included to use these functionalities.
 ///////////////////////////////////////////////////////////////////////////////////
 
@@ -71,6 +71,18 @@ namespace detail
 		typedef fmat4x4SIMD type;
 		typedef fmat4x4SIMD transpose_type;
 
+#		if GLM_HAS_CONSTEXPR
+		static GLM_CONSTEXPR length_t components = 4;
+		static GLM_CONSTEXPR length_t cols = 4;
+		static GLM_CONSTEXPR length_t rows = 4;
+		static GLM_CONSTEXPR precision prec = defaultp;
+#		else
+		static const length_t components = 4;
+		static const length_t cols = 4;
+		static const length_t rows = 4;
+		static const precision prec = defaultp;
+#		endif
+
 		GLM_FUNC_DECL length_t length() const;
 
 		fvec4SIMD Data[4];
@@ -96,7 +108,7 @@ namespace detail
 			__m128 const in[4]);
 
 		// Conversions
-		//template <typename U> 
+		//template <typename U>
 		//explicit tmat4x4(tmat4x4<U> const & m);
 
 		//explicit tmat4x4(tmat2x2<T> const & x);

--- a/glm/gtx/simd_quat.hpp
+++ b/glm/gtx/simd_quat.hpp
@@ -8,14 +8,14 @@
 /// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 /// copies of the Software, and to permit persons to whom the Software is
 /// furnished to do so, subject to the following conditions:
-/// 
+///
 /// The above copyright notice and this permission notice shall be included in
 /// all copies or substantial portions of the Software.
-/// 
+///
 /// Restrictions:
 ///		By making use of the Software for military purposes, you choose to make
 ///		a Bunny unhappy.
-/// 
+///
 /// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 /// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 /// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -33,9 +33,9 @@
 ///
 /// @defgroup gtx_simd_quat GLM_GTX_simd_quat
 /// @ingroup gtx
-/// 
+///
 /// @brief SIMD implementation of quat type.
-/// 
+///
 /// <glm/gtx/simd_quat.hpp> need to be included to use these functionalities.
 ///////////////////////////////////////////////////////////////////////////////////
 
@@ -76,10 +76,10 @@ namespace detail
 		typedef fquatSIMD type;
 		typedef tquat<bool, defaultp> bool_type;
 #		if GLM_HAS_CONSTEXPR
-		static GLM_CONSTEXPR length_t components = 1;
+		static GLM_CONSTEXPR length_t components = 4;
 		static GLM_CONSTEXPR precision prec = defaultp;
 #		else
-		static const length_t components = 1;
+		static const length_t components = 4;
 		static const precision prec = defaultp;
 #		endif
 
@@ -106,15 +106,15 @@ namespace detail
 		explicit fquatSIMD(
 			ctor);
 		explicit fquatSIMD(
-			float const & w, 
-			float const & x, 
-			float const & y, 
+			float const & w,
+			float const & x,
+			float const & y,
 			float const & z);
 		explicit fquatSIMD(
 			quat const & v);
 		explicit fquatSIMD(
 			vec3 const & eulerAngles);
-		
+
 
 		//////////////////////////////////////
 		// Unary arithmetic operators
@@ -131,16 +131,16 @@ namespace detail
 	detail::fquatSIMD operator- (
 		detail::fquatSIMD const & q);
 
-	detail::fquatSIMD operator+ ( 
-		detail::fquatSIMD const & q, 
-		detail::fquatSIMD const & p); 
+	detail::fquatSIMD operator+ (
+		detail::fquatSIMD const & q,
+		detail::fquatSIMD const & p);
 
-	detail::fquatSIMD operator* ( 
-		detail::fquatSIMD const & q, 
-		detail::fquatSIMD const & p); 
+	detail::fquatSIMD operator* (
+		detail::fquatSIMD const & q,
+		detail::fquatSIMD const & p);
 
 	detail::fvec4SIMD operator* (
-		detail::fquatSIMD const & q, 
+		detail::fquatSIMD const & q,
 		detail::fvec4SIMD const & v);
 
 	detail::fvec4SIMD operator* (
@@ -148,7 +148,7 @@ namespace detail
 		detail::fquatSIMD const & q);
 
 	detail::fquatSIMD operator* (
-		detail::fquatSIMD const & q, 
+		detail::fquatSIMD const & q,
 		float s);
 
 	detail::fquatSIMD operator* (
@@ -156,7 +156,7 @@ namespace detail
 		detail::fquatSIMD const & q);
 
 	detail::fquatSIMD operator/ (
-		detail::fquatSIMD const & q, 
+		detail::fquatSIMD const & q,
 		float s);
 
 }//namespace detail
@@ -199,64 +199,64 @@ namespace detail
 		detail::fquatSIMD const & q);
 
 
-	/// Returns the length of the quaternion. 
-	/// 
+	/// Returns the length of the quaternion.
+	///
 	/// @see gtx_simd_quat
 	float length(
 		detail::fquatSIMD const & x);
 
-	/// Returns the normalized quaternion. 
-	/// 
+	/// Returns the normalized quaternion.
+	///
 	/// @see gtx_simd_quat
 	detail::fquatSIMD normalize(
 		detail::fquatSIMD const & x);
 
-	/// Returns dot product of q1 and q2, i.e., q1[0] * q2[0] + q1[1] * q2[1] + ... 
-	/// 
+	/// Returns dot product of q1 and q2, i.e., q1[0] * q2[0] + q1[1] * q2[1] + ...
+	///
 	/// @see gtx_simd_quat
 	float dot(
-		detail::fquatSIMD const & q1, 
+		detail::fquatSIMD const & q1,
 		detail::fquatSIMD const & q2);
 
 	/// Spherical linear interpolation of two quaternions.
 	/// The interpolation is oriented and the rotation is performed at constant speed.
 	/// For short path spherical linear interpolation, use the slerp function.
-	/// 
+	///
 	/// @param x A quaternion
 	/// @param y A quaternion
 	/// @param a Interpolation factor. The interpolation is defined beyond the range [0, 1].
 	/// @tparam T Value type used to build the quaternion. Supported: half, float or double.
 	/// @see gtx_simd_quat
-	/// @see - slerp(detail::fquatSIMD const & x, detail::fquatSIMD const & y, T const & a) 
+	/// @see - slerp(detail::fquatSIMD const & x, detail::fquatSIMD const & y, T const & a)
 	detail::fquatSIMD mix(
-		detail::fquatSIMD const & x, 
-		detail::fquatSIMD const & y, 
+		detail::fquatSIMD const & x,
+		detail::fquatSIMD const & y,
 		float const & a);
 
-	/// Linear interpolation of two quaternions. 
+	/// Linear interpolation of two quaternions.
 	/// The interpolation is oriented.
-	/// 
+	///
 	/// @param x A quaternion
 	/// @param y A quaternion
 	/// @param a Interpolation factor. The interpolation is defined in the range [0, 1].
 	/// @tparam T Value type used to build the quaternion. Supported: half, float or double.
 	/// @see gtx_simd_quat
 	detail::fquatSIMD lerp(
-		detail::fquatSIMD const & x, 
-		detail::fquatSIMD const & y, 
+		detail::fquatSIMD const & x,
+		detail::fquatSIMD const & y,
 		float const & a);
 
 	/// Spherical linear interpolation of two quaternions.
 	/// The interpolation always take the short path and the rotation is performed at constant speed.
-	/// 
+	///
 	/// @param x A quaternion
 	/// @param y A quaternion
 	/// @param a Interpolation factor. The interpolation is defined beyond the range [0, 1].
 	/// @tparam T Value type used to build the quaternion. Supported: half, float or double.
 	/// @see gtx_simd_quat
 	detail::fquatSIMD slerp(
-		detail::fquatSIMD const & x, 
-		detail::fquatSIMD const & y, 
+		detail::fquatSIMD const & x,
+		detail::fquatSIMD const & y,
 		float const & a);
 
 
@@ -269,10 +269,10 @@ namespace detail
 	/// This will use the equivalent to fastAcos() and fastSin().
 	///
 	/// @see gtx_simd_quat
-	/// @see - mix(detail::fquatSIMD const & x, detail::fquatSIMD const & y, T const & a) 
+	/// @see - mix(detail::fquatSIMD const & x, detail::fquatSIMD const & y, T const & a)
 	detail::fquatSIMD fastMix(
-		detail::fquatSIMD const & x, 
-		detail::fquatSIMD const & y, 
+		detail::fquatSIMD const & x,
+		detail::fquatSIMD const & y,
 		float const & a);
 
 	/// Identical to fastMix() except takes the shortest path.
@@ -280,22 +280,22 @@ namespace detail
 	/// The same rules apply here as those in fastMix(). Both quaternions must be unit length and 'a' must be
 	/// in the range [0, 1].
 	///
-	/// @see - fastMix(detail::fquatSIMD const & x, detail::fquatSIMD const & y, T const & a) 
-	/// @see - slerp(detail::fquatSIMD const & x, detail::fquatSIMD const & y, T const & a) 
+	/// @see - fastMix(detail::fquatSIMD const & x, detail::fquatSIMD const & y, T const & a)
+	/// @see - slerp(detail::fquatSIMD const & x, detail::fquatSIMD const & y, T const & a)
 	detail::fquatSIMD fastSlerp(
-		detail::fquatSIMD const & x, 
-		detail::fquatSIMD const & y, 
+		detail::fquatSIMD const & x,
+		detail::fquatSIMD const & y,
 		float const & a);
 
 
-	/// Returns the q conjugate. 
-	/// 
+	/// Returns the q conjugate.
+	///
 	/// @see gtx_simd_quat
 	detail::fquatSIMD conjugate(
 		detail::fquatSIMD const & q);
 
-	/// Returns the q inverse. 
-	/// 
+	/// Returns the q inverse.
+	///
 	/// @see gtx_simd_quat
 	detail::fquatSIMD inverse(
 		detail::fquatSIMD const & q);
@@ -303,14 +303,14 @@ namespace detail
 	/// Build a quaternion from an angle and a normalized axis.
 	///
 	/// @param angle Angle expressed in radians.
-	/// @param axis Axis of the quaternion, must be normalized. 
+	/// @param axis Axis of the quaternion, must be normalized.
 	///
 	/// @see gtx_simd_quat
 	detail::fquatSIMD angleAxisSIMD(
-		float const & angle, 
+		float const & angle,
 		vec3 const & axis);
 
-	/// Build a quaternion from an angle and a normalized axis. 
+	/// Build a quaternion from an angle and a normalized axis.
 	///
 	/// @param angle Angle expressed in radians.
 	/// @param x x component of the x-axis, x, y, z must be a normalized axis
@@ -319,9 +319,9 @@ namespace detail
 	///
 	/// @see gtx_simd_quat
 	detail::fquatSIMD angleAxisSIMD(
-		float const & angle, 
-		float const & x, 
-		float const & y, 
+		float const & angle,
+		float const & x,
+		float const & y,
 		float const & z);
 
 	// TODO: Move this to somewhere more appropriate. Used with fastMix() and fastSlerp().

--- a/glm/gtx/simd_quat.hpp
+++ b/glm/gtx/simd_quat.hpp
@@ -75,6 +75,13 @@ namespace detail
 
 		typedef fquatSIMD type;
 		typedef tquat<bool, defaultp> bool_type;
+#		if GLM_HAS_CONSTEXPR
+		static GLM_CONSTEXPR length_t components = 1;
+		static GLM_CONSTEXPR precision prec = defaultp;
+#		else
+		static const length_t components = 1;
+		static const precision prec = defaultp;
+#		endif
 
 #ifdef GLM_SIMD_ENABLE_XYZW_UNION
 		union

--- a/glm/gtx/simd_vec4.hpp
+++ b/glm/gtx/simd_vec4.hpp
@@ -98,6 +98,13 @@ namespace detail
 
 		typedef fvec4SIMD type;
 		typedef tvec4<bool, highp> bool_type;
+#		if GLM_HAS_CONSTEXPR
+		static GLM_CONSTEXPR length_t components = 1;
+		static GLM_CONSTEXPR precision prec = defaultp;
+#		else
+		static const length_t components = 1;
+		static const precision prec = defaultp;
+#		endif
 
 #ifdef GLM_SIMD_ENABLE_XYZW_UNION
 		union

--- a/glm/gtx/simd_vec4.hpp
+++ b/glm/gtx/simd_vec4.hpp
@@ -8,14 +8,14 @@
 /// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 /// copies of the Software, and to permit persons to whom the Software is
 /// furnished to do so, subject to the following conditions:
-/// 
+///
 /// The above copyright notice and this permission notice shall be included in
 /// all copies or substantial portions of the Software.
-/// 
+///
 /// Restrictions:
 ///		By making use of the Software for military purposes, you choose to make
 ///		a Bunny unhappy.
-/// 
+///
 /// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 /// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 /// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -33,9 +33,9 @@
 ///
 /// @defgroup gtx_simd_vec4 GLM_GTX_simd_vec4
 /// @ingroup gtx
-/// 
+///
 /// @brief SIMD implementation of vec4 type.
-/// 
+///
 /// <glm/gtx/simd_vec4.hpp> need to be included to use these functionalities.
 ///////////////////////////////////////////////////////////////////////////////////
 
@@ -99,10 +99,10 @@ namespace detail
 		typedef fvec4SIMD type;
 		typedef tvec4<bool, highp> bool_type;
 #		if GLM_HAS_CONSTEXPR
-		static GLM_CONSTEXPR length_t components = 1;
+		static GLM_CONSTEXPR length_t components = 4;
 		static GLM_CONSTEXPR precision prec = defaultp;
 #		else
-		static const length_t components = 1;
+		static const length_t components = 4;
 		static const precision prec = defaultp;
 #		endif
 
@@ -131,9 +131,9 @@ namespace detail
 		explicit fvec4SIMD(
 			float const & s);
 		explicit fvec4SIMD(
-			float const & x, 
-			float const & y, 
-			float const & z, 
+			float const & x,
+			float const & y,
+			float const & z,
 			float const & w);
 		explicit fvec4SIMD(
 			vec4 const & v);
@@ -220,13 +220,13 @@ namespace detail
 
 	//! Returns a value equal to the nearest integer to x.
 	//! A fractional part of 0.5 will round toward the nearest even
-	//! integer. (Both 3.5 and 4.5 for x will return 4.0.) 
+	//! integer. (Both 3.5 and 4.5 for x will return 4.0.)
 	///
 	/// @see gtx_simd_vec4
 	//detail::fvec4SIMD roundEven(detail::fvec4SIMD const & x);
 
-	//! Returns a value equal to the nearest integer 
-	//! that is greater than or equal to x. 
+	//! Returns a value equal to the nearest integer
+	//! that is greater than or equal to x.
 	/// @see gtx_simd_vec4
 	detail::fvec4SIMD ceil(detail::fvec4SIMD const & x);
 
@@ -240,7 +240,7 @@ namespace detail
 	///
 	/// @see gtx_simd_vec4
 	detail::fvec4SIMD mod(
-		detail::fvec4SIMD const & x, 
+		detail::fvec4SIMD const & x,
 		detail::fvec4SIMD const & y);
 
 	//! Modulus. Returns x - y * floor(x / y)
@@ -248,7 +248,7 @@ namespace detail
 	///
 	/// @see gtx_simd_vec4
 	detail::fvec4SIMD mod(
-		detail::fvec4SIMD const & x, 
+		detail::fvec4SIMD const & x,
 		float const & y);
 
 	//! Returns the fractional part of x and sets i to the integer
@@ -257,51 +257,51 @@ namespace detail
 	//! sign as x.
 	//! (From GLM_GTX_simd_vec4 extension, common function)
 	//detail::fvec4SIMD modf(
-	//	detail::fvec4SIMD const & x, 
+	//	detail::fvec4SIMD const & x,
 	//	detail::fvec4SIMD & i);
 
 	//! Returns y if y < x; otherwise, it returns x.
-	/// 
+	///
 	/// @see gtx_simd_vec4
 	detail::fvec4SIMD min(
-		detail::fvec4SIMD const & x, 
+		detail::fvec4SIMD const & x,
 		detail::fvec4SIMD const & y);
 
 	detail::fvec4SIMD min(
-		detail::fvec4SIMD const & x, 
+		detail::fvec4SIMD const & x,
 		float const & y);
 
 	//! Returns y if x < y; otherwise, it returns x.
 	///
 	/// @see gtx_simd_vec4
 	detail::fvec4SIMD max(
-		detail::fvec4SIMD const & x, 
+		detail::fvec4SIMD const & x,
 		detail::fvec4SIMD const & y);
 
 	detail::fvec4SIMD max(
-		detail::fvec4SIMD const & x, 
+		detail::fvec4SIMD const & x,
 		float const & y);
 
-	//! Returns min(max(x, minVal), maxVal) for each component in x 
+	//! Returns min(max(x, minVal), maxVal) for each component in x
 	//! using the floating-point values minVal and maxVal.
 	///
 	/// @see gtx_simd_vec4
 	detail::fvec4SIMD clamp(
-		detail::fvec4SIMD const & x, 
-		detail::fvec4SIMD const & minVal, 
-		detail::fvec4SIMD const & maxVal); 
+		detail::fvec4SIMD const & x,
+		detail::fvec4SIMD const & minVal,
+		detail::fvec4SIMD const & maxVal);
 
 	detail::fvec4SIMD clamp(
-		detail::fvec4SIMD const & x, 
-		float const & minVal, 
-		float const & maxVal); 
+		detail::fvec4SIMD const & x,
+		float const & minVal,
+		float const & maxVal);
 
-	//! \return If genTypeU is a floating scalar or vector: 
-	//! Returns x * (1.0 - a) + y * a, i.e., the linear blend of 
-	//! x and y using the floating-point value a. 
+	//! \return If genTypeU is a floating scalar or vector:
+	//! Returns x * (1.0 - a) + y * a, i.e., the linear blend of
+	//! x and y using the floating-point value a.
 	//! The value for a is not restricted to the range [0, 1].
 	//!
-	//! \return If genTypeU is a boolean scalar or vector: 
+	//! \return If genTypeU is a boolean scalar or vector:
 	//! Selects which vector each returned component comes
 	//! from. For a component of a that is false, the
 	//! corresponding component of x is returned. For a
@@ -312,9 +312,9 @@ namespace detail
 	//! provides different functionality than
 	//! genType mix(genType x, genType y, genType(a))
 	//! where a is a Boolean vector.
-	//! 
+	//!
 	//! From GLSL 1.30.08 specification, section 8.3
-	//! 
+	//!
 	//! \param[in]  x Floating point scalar or vector.
 	//! \param[in]  y Floating point scalar or vector.
 	//! \param[in]  a Floating point or boolean scalar or vector.
@@ -323,19 +323,19 @@ namespace detail
 	///
 	/// @see gtx_simd_vec4
 	detail::fvec4SIMD mix(
-		detail::fvec4SIMD const & x, 
-		detail::fvec4SIMD const & y, 
+		detail::fvec4SIMD const & x,
+		detail::fvec4SIMD const & y,
 		detail::fvec4SIMD const & a);
 
 	//! Returns 0.0 if x < edge, otherwise it returns 1.0.
 	///
 	/// @see gtx_simd_vec4
 	detail::fvec4SIMD step(
-		detail::fvec4SIMD const & edge, 
+		detail::fvec4SIMD const & edge,
 		detail::fvec4SIMD const & x);
 
 	detail::fvec4SIMD step(
-		float const & edge, 
+		float const & edge,
 		detail::fvec4SIMD const & x);
 
 	//! Returns 0.0 if x <= edge0 and 1.0 if x >= edge1 and
@@ -350,13 +350,13 @@ namespace detail
 	///
 	/// @see gtx_simd_vec4
 	detail::fvec4SIMD smoothstep(
-		detail::fvec4SIMD const & edge0, 
-		detail::fvec4SIMD const & edge1, 
+		detail::fvec4SIMD const & edge0,
+		detail::fvec4SIMD const & edge1,
 		detail::fvec4SIMD const & x);
 
 	detail::fvec4SIMD smoothstep(
-		float const & edge0, 
-		float const & edge1, 
+		float const & edge0,
+		float const & edge1,
 		detail::fvec4SIMD const & x);
 
 	//! Returns true if x holds a NaN (not a number)
@@ -397,8 +397,8 @@ namespace detail
 	///
 	/// @see gtx_simd_vec4
 	detail::fvec4SIMD fma(
-		detail::fvec4SIMD const & a, 
-		detail::fvec4SIMD const & b, 
+		detail::fvec4SIMD const & a,
+		detail::fvec4SIMD const & b,
 		detail::fvec4SIMD const & c);
 
 	//! Splits x into a floating-point significand in the range

--- a/test/core/core_type_vec1.cpp
+++ b/test/core/core_type_vec1.cpp
@@ -131,6 +131,7 @@ int test_vec1_size()
 	Error += 8 == sizeof(glm::highp_dvec1) ? 0 : 1;
 	Error += glm::vec1().length() == 1 ? 0 : 1;
 	Error += glm::dvec1().length() == 1 ? 0 : 1;
+	Error += glm::vec1::components == 1 ? 0 : 1;
 	
 	return Error;
 }
@@ -168,6 +169,7 @@ int main()
 
 	glm::vec1 v;
 	assert(v.length() == 1);
+	assert(glm::vec1::components == 1);
 
 	Error += test_vec1_size();
 	Error += test_vec1_ctor();

--- a/test/core/core_type_vec2.cpp
+++ b/test/core/core_type_vec2.cpp
@@ -8,14 +8,14 @@
 /// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 /// copies of the Software, and to permit persons to whom the Software is
 /// furnished to do so, subject to the following conditions:
-/// 
+///
 /// The above copyright notice and this permission notice shall be included in
 /// all copies or substantial portions of the Software.
-/// 
+///
 /// Restrictions:
 ///		By making use of the Software for military purposes, you choose to make
 ///		a Bunny unhappy.
-/// 
+///
 /// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 /// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 /// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -102,81 +102,81 @@ int test_vec2_operators()
 	{
 		glm::vec2 A(1.0f, 2.0f);
 		glm::vec2 B(4.0f, 5.0f);
-		
+
 		glm::vec2 C = A + B;
 		Error += C == glm::vec2(5, 7) ? 0 : 1;
-		
+
 		glm::vec2 D = B - A;
 		Error += D == glm::vec2(3, 3) ? 0 : 1;
-		
+
 		glm::vec2 E = A * B;
 		Error += E == glm::vec2(4, 10) ? 0 : 1;
-		
+
 		glm::vec2 F = B / A;
 		Error += F == glm::vec2(4, 2.5) ? 0 : 1;
-		
+
 		glm::vec2 G = A + 1.0f;
 		Error += G == glm::vec2(2, 3) ? 0 : 1;
-		
+
 		glm::vec2 H = B - 1.0f;
 		Error += H == glm::vec2(3, 4) ? 0 : 1;
-		
+
 		glm::vec2 I = A * 2.0f;
 		Error += I == glm::vec2(2, 4) ? 0 : 1;
-		
+
 		glm::vec2 J = B / 2.0f;
 		Error += J == glm::vec2(2, 2.5) ? 0 : 1;
-		
+
 		glm::vec2 K = 1.0f + A;
 		Error += K == glm::vec2(2, 3) ? 0 : 1;
-		
+
 		glm::vec2 L = 1.0f - B;
 		Error += L == glm::vec2(-3, -4) ? 0 : 1;
-		
+
 		glm::vec2 M = 2.0f * A;
 		Error += M == glm::vec2(2, 4) ? 0 : 1;
-		
+
 		glm::vec2 N = 2.0f / B;
 		Error += N == glm::vec2(0.5, 2.0 / 5.0) ? 0 : 1;
 	}
-	
+
 	{
 		glm::vec2 A(1.0f, 2.0f);
 		glm::vec2 B(4.0f, 5.0f);
-		
+
 		A += B;
 		Error += A == glm::vec2(5, 7) ? 0 : 1;
-		
+
 		A += 1.0f;
 		Error += A == glm::vec2(6, 8) ? 0 : 1;
 	}
 	{
 		glm::vec2 A(1.0f, 2.0f);
 		glm::vec2 B(4.0f, 5.0f);
-		
+
 		B -= A;
 		Error += B == glm::vec2(3, 3) ? 0 : 1;
-		
+
 		B -= 1.0f;
 		Error += B == glm::vec2(2, 2) ? 0 : 1;
 	}
 	{
 		glm::vec2 A(1.0f, 2.0f);
 		glm::vec2 B(4.0f, 5.0f);
-		
+
 		A *= B;
 		Error += A == glm::vec2(4, 10) ? 0 : 1;
-		
+
 		A *= 2.0f;
 		Error += A == glm::vec2(8, 20) ? 0 : 1;
 	}
 	{
 		glm::vec2 A(1.0f, 2.0f);
 		glm::vec2 B(4.0f, 5.0f);
-		
+
 		B /= A;
 		Error += B == glm::vec2(4, 2.5) ? 0 : 1;
-		
+
 		B /= 2.0f;
 		Error += B == glm::vec2(2, 1.25) ? 0 : 1;
 	}
@@ -186,39 +186,39 @@ int test_vec2_operators()
 		B /= B.y;
 		Error += B == glm::vec2(1.0f) ? 0 : 1;
 	}
-	
+
 	{
 		glm::vec2 A(1.0f, 2.0f);
 		glm::vec2 B = -A;
 		Error += B == glm::vec2(-1.0f, -2.0f) ? 0 : 1;
 	}
-	
+
 	{
 		glm::vec2 A(1.0f, 2.0f);
 		glm::vec2 B = --A;
 		Error += B == glm::vec2(0.0f, 1.0f) ? 0 : 1;
 	}
-	
+
 	{
 		glm::vec2 A(1.0f, 2.0f);
 		glm::vec2 B = A--;
 		Error += B == glm::vec2(1.0f, 2.0f) ? 0 : 1;
 		Error += A == glm::vec2(0.0f, 1.0f) ? 0 : 1;
 	}
-	
+
 	{
 		glm::vec2 A(1.0f, 2.0f);
 		glm::vec2 B = ++A;
 		Error += B == glm::vec2(2.0f, 3.0f) ? 0 : 1;
 	}
-	
+
 	{
 		glm::vec2 A(1.0f, 2.0f);
 		glm::vec2 B = A++;
 		Error += B == glm::vec2(1.0f, 2.0f) ? 0 : 1;
 		Error += A == glm::vec2(2.0f, 3.0f) ? 0 : 1;
 	}
-	
+
 	return Error;
 }
 
@@ -283,14 +283,15 @@ int test_vec2_ctor()
 int test_vec2_size()
 {
 	int Error = 0;
-	
+
 	Error += sizeof(glm::vec2) == sizeof(glm::mediump_vec2) ? 0 : 1;
 	Error += 8 == sizeof(glm::mediump_vec2) ? 0 : 1;
 	Error += sizeof(glm::dvec2) == sizeof(glm::highp_dvec2) ? 0 : 1;
 	Error += 16 == sizeof(glm::highp_dvec2) ? 0 : 1;
 	Error += glm::vec2().length() == 2 ? 0 : 1;
 	Error += glm::dvec2().length() == 2 ? 0 : 1;
-	
+	Error += glm::vec2::components == 2 ? 0 : 1;
+
 	return Error;
 }
 
@@ -327,6 +328,7 @@ int main()
 
 	glm::vec2 v;
 	assert(v.length() == 2);
+	assert(glm::vec2::components == 2);
 
 	Error += test_vec2_size();
 	Error += test_vec2_ctor();

--- a/test/core/core_type_vec3.cpp
+++ b/test/core/core_type_vec3.cpp
@@ -263,7 +263,7 @@ int test_vec3_size()
 	Error += 24 == sizeof(glm::highp_dvec3) ? 0 : 1;
 	Error += glm::vec3().length() == 3 ? 0 : 1;
 	Error += glm::dvec3().length() == 3 ? 0 : 1;
-	
+	Error += glm::vec3::components == 3 ? 0 : 1;
 	return Error;
 }
 
@@ -493,6 +493,10 @@ int test_operator_increment()
 int main()
 {
 	int Error = 0;
+
+	glm::vec3 v;
+	assert(v.length() == 3);
+	assert(glm::vec3::components == 3);
 
 	Error += test_vec3_ctor();
 	Error += test_vec3_operators();

--- a/test/core/core_type_vec4.cpp
+++ b/test/core/core_type_vec4.cpp
@@ -446,9 +446,12 @@ int main()
 {
 	int Error(0);
 
-	std::size_t const Size(1000000);
+	glm::vec4 v;
+	assert(v.length() == 4);
+	assert(glm::vec4::components == 4);
 
 #	ifdef NDEBUG
+		std::size_t const Size(1000000);
 		Error += test_vec4_perf_AoS(Size);
 		Error += test_vec4_perf_SoA(Size);
 #	endif//NDEBUG

--- a/test/gtc/gtc_quaternion.cpp
+++ b/test/gtc/gtc_quaternion.cpp
@@ -8,14 +8,14 @@
 /// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 /// copies of the Software, and to permit persons to whom the Software is
 /// furnished to do so, subject to the following conditions:
-/// 
+///
 /// The above copyright notice and this permission notice shall be included in
 /// all copies or substantial portions of the Software.
-/// 
+///
 /// Restrictions:
 ///		By making use of the Software for military purposes, you choose to make
 ///		a Bunny unhappy.
-/// 
+///
 /// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 /// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 /// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -323,6 +323,8 @@ int test_quat_ctr()
 int main()
 {
 	int Error(0);
+
+	assert(glm::quat::components == 4);
 
 	Error += test_quat_ctr();
 	Error += test_quat_mul_vec();


### PR DESCRIPTION
Makes it easier to do some template metaprogramming; if I want to write a class that works with any vector type, but needs to know said type at compile-time (as opposed to at runtime with the `length()`) method, this PR will allow that.

Also, I added in `static` members that describe `precision`, because why not.