### PR TITLE
Simplify some preprocessor declarations

### DIFF
--- a/glm/detail/setup.hpp
+++ b/glm/detail/setup.hpp
@@ -8,14 +8,14 @@
 /// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 /// copies of the Software, and to permit persons to whom the Software is
 /// furnished to do so, subject to the following conditions:
-/// 
+///
 /// The above copyright notice and this permission notice shall be included in
 /// all copies or substantial portions of the Software.
-/// 
+///
 /// Restrictions:
 ///		By making use of the Software for military purposes, you choose to make
 ///		a Bunny unhappy.
-/// 
+///
 /// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 /// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 /// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -117,7 +117,7 @@
 // Compiler
 
 // User defines: GLM_FORCE_COMPILER_UNKNOWN
-// TODO ? __llvm__ 
+// TODO ? __llvm__
 
 #define GLM_COMPILER_UNKNOWN		0x00000000
 
@@ -210,7 +210,7 @@
 // CUDA
 #elif defined(__CUDACC__)
 #	if !defined(CUDA_VERSION) && !defined(GLM_FORCE_CUDA)
-#		include <cuda.h>  // make sure version is defined since nvcc does not define it itself! 
+#		include <cuda.h>  // make sure version is defined since nvcc does not define it itself!
 #	endif
 #	if CUDA_VERSION < 3000
 #		error "GLM requires CUDA 3.0 or higher"
@@ -284,7 +284,7 @@
 #		endif
 #	endif
 
-// G++ 
+// G++
 #elif defined(__GNUC__) || defined(__MINGW32__)
 #	if (__GNUC__ == 4) && (__GNUC_MINOR__ == 2)
 #		define GLM_COMPILER (GLM_COMPILER_GCC42)
@@ -669,7 +669,7 @@
 		((GLM_COMPILER & GLM_COMPILER_VC) && (GLM_COMPILER >= GLM_COMPILER_VC2012)))
 #endif
 
-// 
+//
 #if GLM_LANG & GLM_LANG_CXX11_FLAG
 #	define GLM_HAS_ASSIGNABLE 1
 #else
@@ -677,10 +677,10 @@
 		((GLM_COMPILER & GLM_COMPILER_GCC) && (GLM_COMPILER >= GLM_COMPILER_GCC49)))
 #endif
 
-// 
+//
 #define GLM_HAS_TRIVIAL_QUERIES 0
 
-// 
+//
 #if GLM_LANG & GLM_LANG_CXX11_FLAG
 #	define GLM_HAS_MAKE_SIGNED 1
 #else
@@ -688,7 +688,7 @@
 		((GLM_COMPILER & GLM_COMPILER_VC) && (GLM_COMPILER >= GLM_COMPILER_VC2013)))
 #endif
 
-// 
+//
 #if GLM_ARCH == GLM_ARCH_PURE
 #	define GLM_HAS_BITSCAN_WINDOWS 0
 #else
@@ -697,7 +697,7 @@
 #endif
 
 // OpenMP
-#ifdef _OPENMP 
+#ifdef _OPENMP
 #	if GLM_COMPILER & GLM_COMPILER_GCC
 #		if GLM_COMPILER >= GLM_COMPILER_GCC47
 #			define GLM_HAS_OPENMP 31
@@ -719,7 +719,7 @@
 #define GLM_HAS_ANONYMOUS_UNION (GLM_LANG & GLM_LANG_CXXMS_FLAG)
 
 ///////////////////////////////////////////////////////////////////////////////////
-// Platform 
+// Platform
 
 // User defines: GLM_FORCE_PURE GLM_FORCE_SSE2 GLM_FORCE_SSE3 GLM_FORCE_AVX GLM_FORCE_AVX2
 
@@ -769,7 +769,7 @@
 #		define GLM_ARCH (GLM_ARCH_PURE)
 #	endif
 #elif (GLM_COMPILER & GLM_COMPILER_GCC) && (defined(__i386__) || defined(__x86_64__))
-#	if defined(__AVX2__) 
+#	if defined(__AVX2__)
 #		define GLM_ARCH (GLM_ARCH_AVX2 | GLM_ARCH_AVX | GLM_ARCH_SSE4 | GLM_ARCH_SSE3 | GLM_ARCH_SSE2)
 #	elif defined(__AVX__)
 #		define GLM_ARCH (GLM_ARCH_AVX | GLM_ARCH_SSE4 | GLM_ARCH_SSE3 | GLM_ARCH_SSE2)
@@ -925,8 +925,16 @@
 
 #if GLM_HAS_CONSTEXPR
 #	define GLM_CONSTEXPR constexpr
+# define GLM_CONSTEXPR_MAYBE constexpr
 #else
 #	define GLM_CONSTEXPR
+# define GLM_CONSTEXPR_MAYBE const
+#endif
+
+#ifdef GLM_FORCE_EXPLICIT_CTOR
+# define GLM_EXPLICIT_CTOR_MAYBE explicit
+#else
+# define GLM_EXPLICIT_CTOR_MAYBE
 #endif
 
 ///////////////////////////////////////////////////////////////////////////////////

--- a/glm/detail/type_mat2x2.hpp
+++ b/glm/detail/type_mat2x2.hpp
@@ -55,17 +55,10 @@ namespace glm
 		friend tvec2<U, Q> operator/(tvec2<U, Q> const & v, tmat2x2<U, Q> const & m);
 
 #		ifdef GLM_META_PROG_HELPERS
-#			if GLM_HAS_CONSTEXPR
-				static GLM_CONSTEXPR length_t components = 2;
-				static GLM_CONSTEXPR length_t columns = 2;
-				static GLM_CONSTEXPR length_t rows = 2;
-				static GLM_CONSTEXPR precision prec = P;
-#			else
-				static const length_t components = 2;
-				static const length_t columns = 2;
-				static const length_t rows = 2;
-				static const precision prec = P;
-#			endif//GLM_HAS_CONSTEXPR
+			static GLM_CONSTEXPR_MAYBE length_t components = 2;
+			static GLM_CONSTEXPR_MAYBE length_t columns = 2;
+			static GLM_CONSTEXPR_MAYBE length_t rows = 2;
+			static GLM_CONSTEXPR_MAYBE precision prec = P;
 #		endif//GLM_META_PROG_HELPERS
 
 	private:

--- a/glm/detail/type_mat2x2.hpp
+++ b/glm/detail/type_mat2x2.hpp
@@ -98,13 +98,8 @@ namespace glm
 		//////////////////////////////////////
 		// Matrix conversions
 
-#		ifdef GLM_FORCE_EXPLICIT_CTOR
-			template <typename U, precision Q>
-			GLM_FUNC_DECL explicit tmat2x2(tmat2x2<U, Q> const & m);
-#		else
-			template <typename U, precision Q>
-			GLM_FUNC_DECL tmat2x2(tmat2x2<U, Q> const & m);
-#		endif
+		template <typename U, precision Q>
+		GLM_FUNC_DECL GLM_EXPLICIT_CTOR_MAYBE tmat2x2(tmat2x2<U, Q> const & m);
 
 		GLM_FUNC_DECL explicit tmat2x2(tmat3x3<T, P> const & x);
 		GLM_FUNC_DECL explicit tmat2x2(tmat4x4<T, P> const & x);

--- a/glm/detail/type_mat2x3.hpp
+++ b/glm/detail/type_mat2x3.hpp
@@ -94,13 +94,8 @@ namespace glm
 		//////////////////////////////////////
 		// Matrix conversion
 
-#		ifdef GLM_FORCE_EXPLICIT_CTOR
-			template <typename U, precision Q>
-			GLM_FUNC_DECL explicit tmat2x3(tmat2x3<U, Q> const & m);
-#		else
-			template <typename U, precision Q>
-			GLM_FUNC_DECL tmat2x3(tmat2x3<U, Q> const & m);
-#		endif
+		template <typename U, precision Q>
+		GLM_FUNC_DECL GLM_EXPLICIT_CTOR_MAYBE tmat2x3(tmat2x3<U, Q> const & m);
 
 		GLM_FUNC_DECL explicit tmat2x3(tmat2x2<T, P> const & x);
 		GLM_FUNC_DECL explicit tmat2x3(tmat3x3<T, P> const & x);

--- a/glm/detail/type_mat2x3.hpp
+++ b/glm/detail/type_mat2x3.hpp
@@ -51,17 +51,10 @@ namespace glm
 		typedef T value_type;
 
 #		ifdef GLM_META_PROG_HELPERS
-#			if GLM_HAS_CONSTEXPR
-				static GLM_CONSTEXPR length_t components = 2;
-				static GLM_CONSTEXPR length_t cols = 3;
-				static GLM_CONSTEXPR length_t rows = 2;
-				static GLM_CONSTEXPR precision prec = P;
-#			else
-				static const length_t components = 2;
-				static const length_t cols = 3;
-				static const length_t rows = 2;
-				static const precision prec = P;
-#			endif//GLM_HAS_CONSTEXPR
+			static GLM_CONSTEXPR_MAYBE length_t components = 2;
+			static GLM_CONSTEXPR_MAYBE length_t cols = 3;
+			static GLM_CONSTEXPR_MAYBE length_t rows = 2;
+			static GLM_CONSTEXPR_MAYBE precision prec = P;
 #		endif//GLM_META_PROG_HELPERS
 
 	private:

--- a/glm/detail/type_mat2x4.hpp
+++ b/glm/detail/type_mat2x4.hpp
@@ -95,13 +95,8 @@ namespace glm
 		//////////////////////////////////////
 		// Matrix conversions
 
-#		ifdef GLM_FORCE_EXPLICIT_CTOR
-			template <typename U, precision Q>
-			GLM_FUNC_DECL explicit tmat2x4(tmat2x4<U, Q> const & m);
-#		else
-			template <typename U, precision Q>
-			GLM_FUNC_DECL tmat2x4(tmat2x4<U, Q> const & m);
-#		endif
+		template <typename U, precision Q>
+		GLM_FUNC_DECL GLM_EXPLICIT_CTOR_MAYBE tmat2x4(tmat2x4<U, Q> const & m);
 
 		GLM_FUNC_DECL explicit tmat2x4(tmat2x2<T, P> const & x);
 		GLM_FUNC_DECL explicit tmat2x4(tmat3x3<T, P> const & x);

--- a/glm/detail/type_mat2x4.hpp
+++ b/glm/detail/type_mat2x4.hpp
@@ -51,17 +51,10 @@ namespace glm
 		typedef T value_type;
 
 #		ifdef GLM_META_PROG_HELPERS
-#			if GLM_HAS_CONSTEXPR
-				static GLM_CONSTEXPR length_t components = 2;
-				static GLM_CONSTEXPR length_t cols = 4;
-				static GLM_CONSTEXPR length_t rows = 2;
-				static GLM_CONSTEXPR precision prec = P;
-#			else
-				static const length_t components = 2;
-				static const length_t cols = 4;
-				static const length_t rows = 2;
-				static const precision prec = P;
-#			endif
+			static GLM_CONSTEXPR_MAYBE length_t components = 2;
+			static GLM_CONSTEXPR_MAYBE length_t cols = 4;
+			static GLM_CONSTEXPR_MAYBE length_t rows = 2;
+			static GLM_CONSTEXPR_MAYBE precision prec = P;
 #		endif//GLM_META_PROG_HELPERS
 
 	private:

--- a/glm/detail/type_mat3x2.hpp
+++ b/glm/detail/type_mat3x2.hpp
@@ -101,13 +101,8 @@ namespace glm
 		//////////////////////////////////////
 		// Matrix conversions
 
-#		ifdef GLM_FORCE_EXPLICIT_CTOR
-			template <typename U, precision Q>
-			GLM_FUNC_DECL explicit tmat3x2(tmat3x2<U, Q> const & m);
-#		else
-			template <typename U, precision Q>
-			GLM_FUNC_DECL tmat3x2(tmat3x2<U, Q> const & m);
-#		endif
+		template <typename U, precision Q>
+		GLM_FUNC_DECL GLM_EXPLICIT_CTOR_MAYBE tmat3x2(tmat3x2<U, Q> const & m);
 
 		GLM_FUNC_DECL explicit tmat3x2(tmat2x2<T, P> const & x);
 		GLM_FUNC_DECL explicit tmat3x2(tmat3x3<T, P> const & x);

--- a/glm/detail/type_mat3x2.hpp
+++ b/glm/detail/type_mat3x2.hpp
@@ -51,17 +51,10 @@ namespace glm
 		typedef T value_type;
 
 #		ifdef GLM_META_PROG_HELPERS
-#			if GLM_HAS_CONSTEXPR
-				static GLM_CONSTEXPR length_t components = 3;
-				static GLM_CONSTEXPR length_t cols = 2;
-				static GLM_CONSTEXPR length_t rows = 3;
-				static GLM_CONSTEXPR precision prec = P;
-#			else
-				static const length_t components = 3;
-				static const length_t cols = 2;
-				static const length_t rows = 3;
-				static const precision prec = P;
-#			endif//GLM_HAS_CONSTEXPR
+			static GLM_CONSTEXPR_MAYBE length_t components = 3;
+			static GLM_CONSTEXPR_MAYBE length_t cols = 2;
+			static GLM_CONSTEXPR_MAYBE length_t rows = 3;
+			static GLM_CONSTEXPR_MAYBE precision prec = P;
 #		endif//GLM_META_PROG_HELPERS
 
 	private:

--- a/glm/detail/type_mat3x3.hpp
+++ b/glm/detail/type_mat3x3.hpp
@@ -105,13 +105,8 @@ namespace glm
 		//////////////////////////////////////
 		// Matrix conversions
 
-#		ifdef GLM_FORCE_EXPLICIT_CTOR
-			template <typename U, precision Q>
-			GLM_FUNC_DECL explicit tmat3x3(tmat3x3<U, Q> const & m);
-#		else
-			template <typename U, precision Q>
-			GLM_FUNC_DECL tmat3x3(tmat3x3<U, Q> const & m);
-#		endif
+		template <typename U, precision Q>
+		GLM_FUNC_DECL GLM_EXPLICIT_CTOR_MAYBE tmat3x3(tmat3x3<U, Q> const & m);
 
 		GLM_FUNC_DECL explicit tmat3x3(tmat2x2<T, P> const & x);
 		GLM_FUNC_DECL explicit tmat3x3(tmat4x4<T, P> const & x);

--- a/glm/detail/type_mat3x3.hpp
+++ b/glm/detail/type_mat3x3.hpp
@@ -49,17 +49,12 @@ namespace glm
 		typedef tmat3x3<T, P> transpose_type;
 		typedef T value_type;
 
-#		if GLM_HAS_CONSTEXPR
-		static GLM_CONSTEXPR length_t components = 3;
-		static GLM_CONSTEXPR length_t cols = 3;
-		static GLM_CONSTEXPR length_t rows = 3;
-		static GLM_CONSTEXPR precision prec = P;
-#		else
-		static const length_t components = 3;
-		static const length_t cols = 3;
-		static const length_t rows = 3;
-		static const precision prec = P;
-#		endif
+#		ifdef GLM_META_PROG_HELPERS
+			static GLM_CONSTEXPR_MAYBE length_t components = 3;
+			static GLM_CONSTEXPR_MAYBE length_t cols = 3;
+			static GLM_CONSTEXPR_MAYBE length_t rows = 3;
+			static GLM_CONSTEXPR_MAYBE precision prec = P;
+#		endif//GLM_META_PROG_HELPERS
 
 		template <typename U, precision Q>
 		friend tvec3<U, Q> operator/(tmat3x3<U, Q> const & m, tvec3<U, Q> const & v);

--- a/glm/detail/type_mat3x4.hpp
+++ b/glm/detail/type_mat3x4.hpp
@@ -100,13 +100,8 @@ namespace glm
 		//////////////////////////////////////
 		// Matrix conversion
 
-#		ifdef GLM_FORCE_EXPLICIT_CTOR
-			template <typename U, precision Q>
-			GLM_FUNC_DECL explicit tmat3x4(tmat3x4<U, Q> const & m);
-#		else
-			template <typename U, precision Q>
-			GLM_FUNC_DECL tmat3x4(tmat3x4<U, Q> const & m);
-#		endif
+		template <typename U, precision Q>
+		GLM_FUNC_DECL GLM_EXPLICIT_CTOR_MAYBE tmat3x4(tmat3x4<U, Q> const & m);
 
 		GLM_FUNC_DECL explicit tmat3x4(tmat2x2<T, P> const & x);
 		GLM_FUNC_DECL explicit tmat3x4(tmat3x3<T, P> const & x);

--- a/glm/detail/type_mat3x4.hpp
+++ b/glm/detail/type_mat3x4.hpp
@@ -51,17 +51,10 @@ namespace glm
 		typedef T value_type;
 
 #		ifdef GLM_META_PROG_HELPERS
-#			if GLM_HAS_CONSTEXPR
-				static GLM_CONSTEXPR length_t components = 3;
-				static GLM_CONSTEXPR length_t cols = 4;
-				static GLM_CONSTEXPR length_t rows = 3;
-				static GLM_CONSTEXPR precision prec = P;
-#			else
-				static const length_t components = 3;
-				static const length_t cols = 4;
-				static const length_t rows = 3;
-				static const precision prec = P;
-#			endif//GLM_HAS_CONSTEXPR
+			static GLM_CONSTEXPR_MAYBE length_t components = 3;
+			static GLM_CONSTEXPR_MAYBE length_t cols = 4;
+			static GLM_CONSTEXPR_MAYBE length_t rows = 3;
+			static GLM_CONSTEXPR_MAYBE precision prec = P;
 #		endif//GLM_META_PROG_HELPERS
 
 	private:

--- a/glm/detail/type_mat4x2.hpp
+++ b/glm/detail/type_mat4x2.hpp
@@ -106,13 +106,8 @@ namespace glm
 		//////////////////////////////////////
 		// Matrix conversions
 
-#		ifdef GLM_FORCE_EXPLICIT_CTOR
-			template <typename U, precision Q>
-			GLM_FUNC_DECL explicit tmat4x2(tmat4x2<U, Q> const & m);
-#		else
-			template <typename U, precision Q>
-			GLM_FUNC_DECL tmat4x2(tmat4x2<U, Q> const & m);
-#		endif
+		template <typename U, precision Q>
+		GLM_FUNC_DECL GLM_EXPLICIT_CTOR_MAYBE tmat4x2(tmat4x2<U, Q> const & m);
 
 		GLM_FUNC_DECL explicit tmat4x2(tmat2x2<T, P> const & x);
 		GLM_FUNC_DECL explicit tmat4x2(tmat3x3<T, P> const & x);

--- a/glm/detail/type_mat4x2.hpp
+++ b/glm/detail/type_mat4x2.hpp
@@ -51,17 +51,10 @@ namespace glm
 		typedef T value_type;
 
 #		ifdef GLM_META_PROG_HELPERS
-#			if GLM_HAS_CONSTEXPR
-				static GLM_CONSTEXPR length_t components = 4;
-				static GLM_CONSTEXPR length_t cols = 2;
-				static GLM_CONSTEXPR length_t rows = 4;
-				static GLM_CONSTEXPR precision prec = P;
-#			else
-				static const length_t components = 4;
-				static const length_t cols = 2;
-				static const length_t rows = 4;
-				static const precision prec = P;
-#			endif//GLM_HAS_CONSTEXPR
+			static GLM_CONSTEXPR_MAYBE length_t components = 4;
+			static GLM_CONSTEXPR_MAYBE length_t cols = 2;
+			static GLM_CONSTEXPR_MAYBE length_t rows = 4;
+			static GLM_CONSTEXPR_MAYBE precision prec = P;
 #		endif//GLM_META_PROG_HELPERS
 
 	private:

--- a/glm/detail/type_mat4x3.hpp
+++ b/glm/detail/type_mat4x3.hpp
@@ -105,13 +105,8 @@ namespace glm
 		//////////////////////////////////////
 		// Matrix conversions
 
-#		ifdef GLM_FORCE_EXPLICIT_CTOR
-			template <typename U, precision Q>
-			GLM_FUNC_DECL explicit tmat4x3(tmat4x3<U, Q> const & m);
-#		else
-			template <typename U, precision Q>
-			GLM_FUNC_DECL tmat4x3(tmat4x3<U, Q> const & m);
-#		endif
+		template <typename U, precision Q>
+		GLM_FUNC_DECL GLM_EXPLICIT_CTOR_MAYBE tmat4x3(tmat4x3<U, Q> const & m);
 
 		GLM_FUNC_DECL explicit tmat4x3(tmat2x2<T, P> const & x);
 		GLM_FUNC_DECL explicit tmat4x3(tmat3x3<T, P> const & x);

--- a/glm/detail/type_mat4x3.hpp
+++ b/glm/detail/type_mat4x3.hpp
@@ -51,17 +51,10 @@ namespace glm
 		typedef T value_type;
 
 #		ifdef GLM_META_PROG_HELPERS
-#			if GLM_HAS_CONSTEXPR
-				static GLM_CONSTEXPR length_t components = 4;
-				static GLM_CONSTEXPR length_t cols = 3;
-				static GLM_CONSTEXPR length_t rows = 4;
-				static GLM_CONSTEXPR precision prec = P;
-#			else
-				static const length_t components = 4;
-				static const length_t cols = 3;
-				static const length_t rows = 4;
-				static const precision prec = P;
-#			endif//GLM_HAS_CONSTEXPR
+			static GLM_CONSTEXPR_MAYBE length_t components = 4;
+			static GLM_CONSTEXPR_MAYBE length_t cols = 3;
+			static GLM_CONSTEXPR_MAYBE length_t rows = 4;
+			static GLM_CONSTEXPR_MAYBE precision prec = P;
 #		endif//GLM_META_PROG_HELPERS
 
 	private:

--- a/glm/detail/type_mat4x4.hpp
+++ b/glm/detail/type_mat4x4.hpp
@@ -50,17 +50,10 @@ namespace glm
 		typedef T value_type;
 
 #		ifdef GLM_META_PROG_HELPERS
-#			if GLM_HAS_CONSTEXPR
-				static GLM_CONSTEXPR length_t components = 4;
-				static GLM_CONSTEXPR length_t cols = 4;
-				static GLM_CONSTEXPR length_t rows = 4;
-				static GLM_CONSTEXPR precision prec = P;
-#			else
-				static const length_t components = 4;
-				static const length_t cols = 4;
-				static const length_t rows = 4;
-				static const precision prec = P;
-#			endif//GLM_HAS_CONSTEXPR
+			static GLM_CONSTEXPR_MAYBE length_t components = 4;
+			static GLM_CONSTEXPR_MAYBE length_t cols = 4;
+			static GLM_CONSTEXPR_MAYBE length_t rows = 4;
+			static GLM_CONSTEXPR_MAYBE precision prec = P;
 #		endif//GLM_META_PROG_HELPERS
 
 		template <typename U, precision Q>

--- a/glm/detail/type_mat4x4.hpp
+++ b/glm/detail/type_mat4x4.hpp
@@ -110,13 +110,8 @@ namespace glm
 		//////////////////////////////////////
 		// Matrix conversions
 
-#		ifdef GLM_FORCE_EXPLICIT_CTOR
-			template <typename U, precision Q>
-			GLM_FUNC_DECL explicit tmat4x4(tmat4x4<U, Q> const & m);
-#		else
-			template <typename U, precision Q>
-			GLM_FUNC_DECL tmat4x4(tmat4x4<U, Q> const & m);
-#		endif
+		template <typename U, precision Q>
+		GLM_FUNC_DECL GLM_EXPLICIT_CTOR_MAYBE tmat4x4(tmat4x4<U, Q> const & m);
 
 		GLM_FUNC_DECL explicit tmat4x4(tmat2x2<T, P> const & x);
 		GLM_FUNC_DECL explicit tmat4x4(tmat3x3<T, P> const & x);

--- a/glm/detail/type_vec1.hpp
+++ b/glm/detail/type_vec1.hpp
@@ -136,15 +136,9 @@ namespace glm
 		template <typename U, precision Q>
 		GLM_FUNC_DECL explicit tvec1(tvec4<U, Q> const & v);
 
-#		ifdef GLM_FORCE_EXPLICIT_CTOR
-			//! Explicit conversions (From section 5.4.1 Conversion and scalar constructors of GLSL 1.30.08 specification)
-			template <typename U, precision Q>
-			GLM_FUNC_DECL explicit tvec1(tvec1<U, Q> const & v);
-#		else
-			//! Explicit conversions (From section 5.4.1 Conversion and scalar constructors of GLSL 1.30.08 specification)
-			template <typename U, precision Q>
-			GLM_FUNC_DECL tvec1(tvec1<U, Q> const & v);
-#		endif
+		//! Explicit conversions (From section 5.4.1 Conversion and scalar constructors of GLSL 1.30.08 specification)
+		template <typename U, precision Q>
+		GLM_FUNC_DECL GLM_EXPLICIT_CTOR_MAYBE tvec1(tvec1<U, Q> const & v);
 
 		//////////////////////////////////////
 		// Swizzle constructors

--- a/glm/detail/type_vec1.hpp
+++ b/glm/detail/type_vec1.hpp
@@ -56,13 +56,8 @@ namespace glm
 		typedef T value_type;
 
 #		ifdef GLM_META_PROG_HELPERS
-#			if GLM_HAS_CONSTEXPR
-				static GLM_CONSTEXPR length_t components = 1;
-				static GLM_CONSTEXPR precision prec = P;
-#			else
-				static const length_t components = 1;
-				static const precision prec = P;
-#			endif
+			static GLM_CONSTEXPR_MAYBE length_t components = 1;
+			static GLM_CONSTEXPR_MAYBE precision prec = P;
 #		endif//GLM_META_PROG_HELPERS
 
 		//////////////////////////////////////

--- a/glm/detail/type_vec2.hpp
+++ b/glm/detail/type_vec2.hpp
@@ -56,13 +56,8 @@ namespace glm
 		typedef T value_type;
 
 #		ifdef GLM_META_PROG_HELPERS
-#			if GLM_HAS_CONSTEXPR
-				static GLM_CONSTEXPR length_t components = 2;
-				static GLM_CONSTEXPR precision prec = P;
-#			else
-				static const length_t components = 2;
-				static const precision prec = P;
-#			endif//GLM_HAS_CONSTEXPR
+			static GLM_CONSTEXPR_MAYBE length_t components = 2;
+			static GLM_CONSTEXPR_MAYBE precision prec = P;
 #		endif//GLM_META_PROG_HELPERS
 
 		//////////////////////////////////////

--- a/glm/detail/type_vec2.hpp
+++ b/glm/detail/type_vec2.hpp
@@ -144,15 +144,9 @@ namespace glm
 		template <typename U, precision Q>
 		GLM_FUNC_DECL explicit tvec2(tvec4<U, Q> const & v);
 
-#		ifdef GLM_FORCE_EXPLICIT_CTOR
-			//! Explicit conversions (From section 5.4.1 Conversion and scalar constructors of GLSL 1.30.08 specification)
-			template <typename U, precision Q>
-			GLM_FUNC_DECL explicit tvec2(tvec2<U, Q> const & v);
-#		else
-			//! Explicit conversions (From section 5.4.1 Conversion and scalar constructors of GLSL 1.30.08 specification)
-			template <typename U, precision Q>
-			GLM_FUNC_DECL tvec2(tvec2<U, Q> const & v);
-#		endif
+		//! Explicit conversions (From section 5.4.1 Conversion and scalar constructors of GLSL 1.30.08 specification)
+		template <typename U, precision Q>
+		GLM_FUNC_DECL GLM_EXPLICIT_CTOR_MAYBE tvec2(tvec2<U, Q> const & v);
 
 		//////////////////////////////////////
 		// Swizzle constructors

--- a/glm/detail/type_vec3.hpp
+++ b/glm/detail/type_vec3.hpp
@@ -154,15 +154,9 @@ namespace glm
 		template <typename U, precision Q>
 		GLM_FUNC_DECL explicit tvec3(tvec4<U, Q> const & v);
 
-#		ifdef GLM_FORCE_EXPLICIT_CTOR
-			//! Explicit conversions (From section 5.4.1 Conversion and scalar constructors of GLSL 1.30.08 specification)
-			template <typename U, precision Q>
-			GLM_FUNC_DECL explicit tvec3(tvec3<U, Q> const & v);
-#		else
-			//! Explicit conversions (From section 5.4.1 Conversion and scalar constructors of GLSL 1.30.08 specification)
-			template <typename U, precision Q>
-			GLM_FUNC_DECL tvec3(tvec3<U, Q> const & v);
-#		endif
+		//! Explicit conversions (From section 5.4.1 Conversion and scalar constructors of GLSL 1.30.08 specification)
+		template <typename U, precision Q>
+		GLM_FUNC_DECL GLM_EXPLICIT_CTOR_MAYBE tvec3(tvec3<U, Q> const & v);
 
 		//////////////////////////////////////
 		// Swizzle constructors

--- a/glm/detail/type_vec3.hpp
+++ b/glm/detail/type_vec3.hpp
@@ -47,7 +47,7 @@ namespace glm
 {
 	template <typename T, precision P = defaultp>
 	struct tvec3
-	{	
+	{
 		//////////////////////////////////////
 		// Implementation detail
 
@@ -56,13 +56,8 @@ namespace glm
 		typedef T value_type;
 
 #		ifdef GLM_META_PROG_HELPERS
-#			if GLM_HAS_CONSTEXPR
-				static GLM_CONSTEXPR length_t components = 3;
-				static GLM_CONSTEXPR precision prec = P;
-#			else
-				static const length_t components = 3;
-				static const precision prec = P;
-#			endif//GLM_HAS_CONSTEXPR
+			static GLM_CONSTEXPR_MAYBE length_t components = 3;
+			static GLM_CONSTEXPR_MAYBE precision prec = P;
 #		endif//GLM_META_PROG_HELPERS
 
 		//////////////////////////////////////

--- a/glm/detail/type_vec4.hpp
+++ b/glm/detail/type_vec4.hpp
@@ -229,16 +229,10 @@ namespace detail
 		//! Explicit conversions (From section 5.4.1 Conversion and scalar constructors of GLSL 1.30.08 specification)
 		template <typename A, typename B, precision Q>
 		GLM_FUNC_DECL explicit tvec4(tvec2<A, Q> const & a, tvec2<B, Q> const & b);
-		
-#		ifdef GLM_FORCE_EXPLICIT_CTOR
-			//! Explicit conversions (From section 5.4.1 Conversion and scalar constructors of GLSL 1.30.08 specification)
-			template <typename U, precision Q>
-			GLM_FUNC_DECL explicit tvec4(tvec4<U, Q> const & v);
-#		else
-			//! Explicit conversions (From section 5.4.1 Conversion and scalar constructors of GLSL 1.30.08 specification)
-			template <typename U, precision Q>
-			GLM_FUNC_DECL tvec4(tvec4<U, Q> const & v);
-#		endif
+
+		//! Explicit conversions (From section 5.4.1 Conversion and scalar constructors of GLSL 1.30.08 specification)
+		template <typename U, precision Q>
+		GLM_FUNC_DECL GLM_EXPLICIT_CTOR_MAYBE tvec4(tvec4<U, Q> const & v);
 
 		//////////////////////////////////////
 		// Swizzle constructors

--- a/glm/detail/type_vec4.hpp
+++ b/glm/detail/type_vec4.hpp
@@ -110,13 +110,8 @@ namespace detail
 		typedef T value_type;
 
 #		ifdef GLM_META_PROG_HELPERS
-#			if GLM_HAS_CONSTEXPR
-				static GLM_CONSTEXPR length_t components = 4;
-				static GLM_CONSTEXPR precision prec = P;
-#			else
-				static const length_t components = 4;
-				static const precision prec = P;
-#			endif//GLM_HAS_CONSTEXPR
+			static GLM_CONSTEXPR_MAYBE length_t components = 4;
+			static GLM_CONSTEXPR_MAYBE precision prec = P;
 #		endif//GLM_META_PROG_HELPERS
 
 		//////////////////////////////////////

--- a/glm/gtc/quaternion.hpp
+++ b/glm/gtc/quaternion.hpp
@@ -66,13 +66,8 @@ namespace glm
 		typedef T value_type;
 
 #		ifdef GLM_META_PROG_HELPERS
-#			if GLM_HAS_CONSTEXPR
-				static GLM_CONSTEXPR length_t components = 4;
-				static GLM_CONSTEXPR precision prec = P;
-#			else
-				static const length_t components = 4;
-				static const precision prec = P;
-#			endif//GLM_HAS_CONSTEXPR
+			static GLM_CONSTEXPR_MAYBE length_t components = 4;
+			static GLM_CONSTEXPR_MAYBE precision prec = P;
 #		endif//GLM_META_PROG_HELPERS
 
 	public:

--- a/glm/gtc/quaternion.hpp
+++ b/glm/gtc/quaternion.hpp
@@ -108,24 +108,19 @@ namespace glm
 		GLM_FUNC_DECL tquat(T const & w, T const & x, T const & y, T const & z);
 
 		//////////////////////////////////////
-		// Convertions
+		// Conversions
 
-#		ifdef GLM_FORCE_EXPLICIT_CTOR
-			template <typename U, precision Q>
-			GLM_FUNC_DECL explicit tquat(tquat<U, Q> const & q);
-#		else
-			template <typename U, precision Q>
-			GLM_FUNC_DECL tquat(tquat<U, Q> const & q);
-#		endif
-		
+		template <typename U, precision Q>
+		GLM_FUNC_DECL GLM_EXPLICIT_CTOR_MAYBE tquat(tquat<U, Q> const & q);
+
 		// explicit conversion operators
 #		if GLM_HAS_EXPLICIT_CONVERSION_OPERATORS
 			GLM_FUNC_DECL explicit operator tmat3x3<T, P>();
 			GLM_FUNC_DECL explicit operator tmat4x4<T, P>();
 #		endif
-		
+
 		/// Create a quaternion from two normalized axis
-		/// 
+		///
 		/// @param u A first normalized axis
 		/// @param v A second normalized axis
 		/// @see gtc_quaternion

--- a/glm/gtx/dual_quaternion.hpp
+++ b/glm/gtx/dual_quaternion.hpp
@@ -110,13 +110,8 @@ namespace glm
 		//////////////////////////////////////////////////////////////
 		// tdualquat conversions
 
-#		ifdef GLM_FORCE_EXPLICIT_CTOR
-			template <typename U, precision Q>
-			GLM_FUNC_DECL explicit tdualquat(tdualquat<U, Q> const & q);
-#		else
-			template <typename U, precision Q>
-			GLM_FUNC_DECL tdualquat(tdualquat<U, Q> const & q);
-#		endif
+		template <typename U, precision Q>
+		GLM_FUNC_DECL GLM_EXPLICIT_CTOR_MAYBE tdualquat(tdualquat<U, Q> const & q);
 
 		GLM_FUNC_DECL explicit tdualquat(tmat2x4<T, P> const & holder_mat);
 		GLM_FUNC_DECL explicit tdualquat(tmat3x4<T, P> const & aug_mat);

--- a/glm/gtx/dual_quaternion.hpp
+++ b/glm/gtx/dual_quaternion.hpp
@@ -65,13 +65,8 @@ namespace glm
 		typedef glm::tquat<T, P> part_type;
 
 #		ifdef GLM_META_PROG_HELPERS
-#			if GLM_HAS_CONSTEXPR
-				static GLM_CONSTEXPR length_t components = 8;
-				static GLM_CONSTEXPR precision prec = P;
-#			else
-				static const length_t components = 8;
-				static const precision prec = P;
-#			endif//GLM_HAS_CONSTEXPR
+			static GLM_CONSTEXPR_MAYBE length_t components = 8;
+			static GLM_CONSTEXPR_MAYBE precision prec = P;
 #		endif//GLM_META_PROG_HELPERS
 
 	public:

--- a/glm/gtx/simd_mat4.hpp
+++ b/glm/gtx/simd_mat4.hpp
@@ -72,17 +72,10 @@ namespace detail
 		typedef fmat4x4SIMD transpose_type;
 
 #		ifdef GLM_META_PROG_HELPERS
-#			if GLM_HAS_CONSTEXPR
-				static GLM_CONSTEXPR length_t components = 4;
-				static GLM_CONSTEXPR length_t cols = 4;
-				static GLM_CONSTEXPR length_t rows = 4;
-				static GLM_CONSTEXPR precision prec = defaultp;
-#			else
-				static const length_t components = 4;
-				static const length_t cols = 4;
-				static const length_t rows = 4;
-				static const precision prec = defaultp;
-#			endif//GLM_HAS_CONSTEXPR
+			static GLM_CONSTEXPR_MAYBE length_t components = 4;
+			static GLM_CONSTEXPR_MAYBE length_t cols = 4;
+			static GLM_CONSTEXPR_MAYBE length_t rows = 4;
+			static GLM_CONSTEXPR_MAYBE precision prec = defaultp;
 #		endif//GLM_META_PROG_HELPERS
 
 		GLM_FUNC_DECL length_t length() const;

--- a/glm/gtx/simd_quat.hpp
+++ b/glm/gtx/simd_quat.hpp
@@ -77,13 +77,8 @@ namespace detail
 		typedef tquat<bool, defaultp> bool_type;
 
 #		ifdef GLM_META_PROG_HELPERS
-#			if GLM_HAS_CONSTEXPR
-				static GLM_CONSTEXPR length_t components = 4;
-				static GLM_CONSTEXPR precision prec = defaultp;
-#			else
-				static const length_t components = 4;
-				static const precision prec = defaultp;
-#			endif//GLM_HAS_CONSTEXPR
+			static GLM_CONSTEXPR_MAYBE length_t components = 4;
+			static GLM_CONSTEXPR_MAYBE precision prec = defaultp;
 #		endif//GLM_META_PROG_HELPERS
 
 #ifdef GLM_SIMD_ENABLE_XYZW_UNION

--- a/glm/gtx/simd_vec4.hpp
+++ b/glm/gtx/simd_vec4.hpp
@@ -100,13 +100,8 @@ namespace detail
 		typedef tvec4<bool, highp> bool_type;
 
 #		ifdef GLM_META_PROG_HELPERS
-#			if GLM_HAS_CONSTEXPR
-				static GLM_CONSTEXPR length_t components = 4;
-				static GLM_CONSTEXPR precision prec = defaultp;
-#			else
-				static const length_t components = 4;
-				static const precision prec = defaultp;
-#			endif//GLM_HAS_CONSTEXPR
+			static GLM_CONSTEXPR_MAYBE length_t components = 4;
+			static GLM_CONSTEXPR_MAYBE precision prec = defaultp;
 #		endif//GLM_META_PROG_HELPERS
 
 #ifdef GLM_SIMD_ENABLE_XYZW_UNION


### PR DESCRIPTION
Won't affect the users, but it does make some code a bit easier to maintain; no more duplicated declarations that might accidentally not be kept in sync.