### PR TITLE
Fixed some of my own metaprogramming-helper mistakes

### DIFF
--- a/glm/detail/type_mat2x2.hpp
+++ b/glm/detail/type_mat2x2.hpp
@@ -56,7 +56,7 @@ namespace glm
 
 #		ifdef GLM_META_PROG_HELPERS
 			static GLM_RELAXED_CONSTEXPR length_t components = 2;
-			static GLM_RELAXED_CONSTEXPR length_t columns = 2;
+			static GLM_RELAXED_CONSTEXPR length_t cols = 2;
 			static GLM_RELAXED_CONSTEXPR length_t rows = 2;
 			static GLM_RELAXED_CONSTEXPR precision prec = P;
 #		endif//GLM_META_PROG_HELPERS

--- a/glm/detail/type_mat2x3.hpp
+++ b/glm/detail/type_mat2x3.hpp
@@ -52,8 +52,8 @@ namespace glm
 
 #		ifdef GLM_META_PROG_HELPERS
 			static GLM_RELAXED_CONSTEXPR length_t components = 2;
-			static GLM_RELAXED_CONSTEXPR length_t cols = 3;
-			static GLM_RELAXED_CONSTEXPR length_t rows = 2;
+			static GLM_RELAXED_CONSTEXPR length_t cols = 2;
+			static GLM_RELAXED_CONSTEXPR length_t rows = 3;
 			static GLM_RELAXED_CONSTEXPR precision prec = P;
 #		endif//GLM_META_PROG_HELPERS
 

--- a/glm/detail/type_mat2x4.hpp
+++ b/glm/detail/type_mat2x4.hpp
@@ -52,8 +52,8 @@ namespace glm
 
 #		ifdef GLM_META_PROG_HELPERS
 			static GLM_RELAXED_CONSTEXPR length_t components = 2;
-			static GLM_RELAXED_CONSTEXPR length_t cols = 4;
-			static GLM_RELAXED_CONSTEXPR length_t rows = 2;
+			static GLM_RELAXED_CONSTEXPR length_t cols = 2;
+			static GLM_RELAXED_CONSTEXPR length_t rows = 4;
 			static GLM_RELAXED_CONSTEXPR precision prec = P;
 #		endif//GLM_META_PROG_HELPERS
 

--- a/glm/detail/type_mat3x2.hpp
+++ b/glm/detail/type_mat3x2.hpp
@@ -52,8 +52,8 @@ namespace glm
 
 #		ifdef GLM_META_PROG_HELPERS
 			static GLM_RELAXED_CONSTEXPR length_t components = 3;
-			static GLM_RELAXED_CONSTEXPR length_t cols = 2;
-			static GLM_RELAXED_CONSTEXPR length_t rows = 3;
+			static GLM_RELAXED_CONSTEXPR length_t cols = 3;
+			static GLM_RELAXED_CONSTEXPR length_t rows = 2;
 			static GLM_RELAXED_CONSTEXPR precision prec = P;
 #		endif//GLM_META_PROG_HELPERS
 

--- a/glm/detail/type_mat3x4.hpp
+++ b/glm/detail/type_mat3x4.hpp
@@ -52,8 +52,8 @@ namespace glm
 
 #		ifdef GLM_META_PROG_HELPERS
 			static GLM_RELAXED_CONSTEXPR length_t components = 3;
-			static GLM_RELAXED_CONSTEXPR length_t cols = 4;
-			static GLM_RELAXED_CONSTEXPR length_t rows = 3;
+			static GLM_RELAXED_CONSTEXPR length_t cols = 3;
+			static GLM_RELAXED_CONSTEXPR length_t rows = 4;
 			static GLM_RELAXED_CONSTEXPR precision prec = P;
 #		endif//GLM_META_PROG_HELPERS
 

--- a/glm/detail/type_mat4x2.hpp
+++ b/glm/detail/type_mat4x2.hpp
@@ -52,8 +52,8 @@ namespace glm
 
 #		ifdef GLM_META_PROG_HELPERS
 			static GLM_RELAXED_CONSTEXPR length_t components = 4;
-			static GLM_RELAXED_CONSTEXPR length_t cols = 2;
-			static GLM_RELAXED_CONSTEXPR length_t rows = 4;
+			static GLM_RELAXED_CONSTEXPR length_t cols = 4;
+			static GLM_RELAXED_CONSTEXPR length_t rows = 2;
 			static GLM_RELAXED_CONSTEXPR precision prec = P;
 #		endif//GLM_META_PROG_HELPERS
 

--- a/glm/detail/type_mat4x3.hpp
+++ b/glm/detail/type_mat4x3.hpp
@@ -52,8 +52,8 @@ namespace glm
 
 #		ifdef GLM_META_PROG_HELPERS
 			static GLM_RELAXED_CONSTEXPR length_t components = 4;
-			static GLM_RELAXED_CONSTEXPR length_t cols = 3;
-			static GLM_RELAXED_CONSTEXPR length_t rows = 4;
+			static GLM_RELAXED_CONSTEXPR length_t cols = 4;
+			static GLM_RELAXED_CONSTEXPR length_t rows = 3;
 			static GLM_RELAXED_CONSTEXPR precision prec = P;
 #		endif//GLM_META_PROG_HELPERS
 

--- a/glm/gtx/dual_quaternion.hpp
+++ b/glm/gtx/dual_quaternion.hpp
@@ -65,7 +65,7 @@ namespace glm
 		typedef glm::tquat<T, P> part_type;
 
 #		ifdef GLM_META_PROG_HELPERS
-			static GLM_RELAXED_CONSTEXPR length_t components = 8;
+			static GLM_RELAXED_CONSTEXPR length_t components = 2;
 			static GLM_RELAXED_CONSTEXPR precision prec = P;
 #		endif//GLM_META_PROG_HELPERS
 

--- a/glm/gtx/simd_mat4.hpp
+++ b/glm/gtx/simd_mat4.hpp
@@ -71,6 +71,11 @@ namespace detail
 		typedef fmat4x4SIMD type;
 		typedef fmat4x4SIMD transpose_type;
 
+		typedef tmat4x4<float, defaultp> pure_type;
+		typedef tvec4<float, defaultp> pure_row_type;
+		typedef tvec4<float, defaultp> pure_col_type;
+		typedef tmat4x4<float, defaultp> pure_transpose_type;
+
 #		ifdef GLM_META_PROG_HELPERS
 			static GLM_RELAXED_CONSTEXPR length_t components = 4;
 			static GLM_RELAXED_CONSTEXPR length_t cols = 4;

--- a/glm/gtx/simd_quat.hpp
+++ b/glm/gtx/simd_quat.hpp
@@ -74,6 +74,7 @@ namespace detail
 
 		typedef fquatSIMD type;
 		typedef tquat<bool, defaultp> bool_type;
+		typedef tquat<float, defaultp> pure_type;
 
 #		ifdef GLM_META_PROG_HELPERS
 			static GLM_RELAXED_CONSTEXPR length_t components = 4;

--- a/glm/gtx/simd_quat.hpp
+++ b/glm/gtx/simd_quat.hpp
@@ -69,7 +69,7 @@ namespace detail
 {
 	GLM_ALIGNED_STRUCT(16) fquatSIMD
 	{
-		typedef __m128 value_type;
+		typedef float value_type;
 		typedef std::size_t size_type;
 		static size_type value_size();
 

--- a/glm/gtx/simd_quat.hpp
+++ b/glm/gtx/simd_quat.hpp
@@ -71,7 +71,6 @@ namespace detail
 	{
 		typedef float value_type;
 		typedef std::size_t size_type;
-		static size_type value_size();
 
 		typedef fquatSIMD type;
 		typedef tquat<bool, defaultp> bool_type;

--- a/glm/gtx/simd_vec4.hpp
+++ b/glm/gtx/simd_vec4.hpp
@@ -96,6 +96,7 @@ namespace detail
 		typedef std::size_t size_type;
 
 		typedef fvec4SIMD type;
+		typedef tvec4<float, defaultp> pure_type;
 		typedef tvec4<bool, highp> bool_type;
 
 #		ifdef GLM_META_PROG_HELPERS

--- a/glm/gtx/simd_vec4.hpp
+++ b/glm/gtx/simd_vec4.hpp
@@ -94,7 +94,6 @@ namespace detail
 	{
 		typedef float value_type;
 		typedef std::size_t size_type;
-		static size_type value_size();
 
 		typedef fvec4SIMD type;
 		typedef tvec4<bool, highp> bool_type;

--- a/glm/gtx/simd_vec4.hpp
+++ b/glm/gtx/simd_vec4.hpp
@@ -92,7 +92,7 @@ namespace detail
 	/// \ingroup gtx_simd_vec4
 	GLM_ALIGNED_STRUCT(16) fvec4SIMD
 	{
-		typedef __m128 value_type;
+		typedef float value_type;
 		typedef std::size_t size_type;
 		static size_type value_size();
 

--- a/test/core/core_type_mat2x2.cpp
+++ b/test/core/core_type_mat2x2.cpp
@@ -124,6 +124,11 @@ int main()
 {
 	int Error(0);
 
+#ifdef GLM_META_PROG_HELPERS
+		assert(glm::mat2::rows == glm::mat2::row_type::components);
+		assert(glm::mat2::cols == glm::mat2::col_type::components);
+#endif
+
 	Error += test_ctr();
 	Error += test_operators();
 	Error += test_inverse();

--- a/test/core/core_type_mat2x3.cpp
+++ b/test/core/core_type_mat2x3.cpp
@@ -98,6 +98,11 @@ int main()
 {
 	int Error = 0;
 
+#ifdef GLM_META_PROG_HELPERS
+		assert(glm::mat2x3::rows == glm::mat2x3::row_type::components);
+		assert(glm::mat2x3::cols == glm::mat2x3::col_type::components);
+#endif
+
 	Error += test_ctr();
 	Error += test_operators();
 

--- a/test/core/core_type_mat2x4.cpp
+++ b/test/core/core_type_mat2x4.cpp
@@ -98,6 +98,11 @@ int main()
 {
 	int Error = 0;
 
+#ifdef GLM_META_PROG_HELPERS
+		assert(glm::mat2x4::rows == glm::mat2x4::row_type::components);
+		assert(glm::mat2x4::cols == glm::mat2x4::col_type::components);
+#endif
+
 	Error += test_ctr();
 	Error += test_operators();
 

--- a/test/core/core_type_mat3x2.cpp
+++ b/test/core/core_type_mat3x2.cpp
@@ -102,6 +102,11 @@ int main()
 {
 	int Error = 0;
 
+#ifdef GLM_META_PROG_HELPERS
+		assert(glm::mat3x2::rows == glm::mat3x2::row_type::components);
+		assert(glm::mat3x2::cols == glm::mat3x2::col_type::components);
+#endif
+
 	Error += test_ctr();
 	Error += test_operators();
 

--- a/test/core/core_type_mat3x3.cpp
+++ b/test/core/core_type_mat3x3.cpp
@@ -161,6 +161,11 @@ int main()
 {
 	int Error = 0;
 
+#ifdef GLM_META_PROG_HELPERS
+		assert(glm::mat3::rows == glm::mat3::row_type::components);
+		assert(glm::mat3::cols == glm::mat3::col_type::components);
+#endif
+
 	Error += test_ctr();
 	Error += test_mat3x3();
 	Error += test_operators();

--- a/test/core/core_type_mat3x4.cpp
+++ b/test/core/core_type_mat3x4.cpp
@@ -101,7 +101,12 @@ int test_ctr()
 int main()
 {
 	int Error = 0;
-	
+
+#ifdef GLM_META_PROG_HELPERS
+		assert(glm::mat3x4::rows == glm::mat3x4::row_type::components);
+		assert(glm::mat3x4::cols == glm::mat3x4::col_type::components);
+#endif
+
 	Error += test_ctr();
 	Error += test_operators();
 

--- a/test/core/core_type_mat4x2.cpp
+++ b/test/core/core_type_mat4x2.cpp
@@ -106,6 +106,11 @@ int main()
 {
 	int Error = 0;
 
+#ifdef GLM_META_PROG_HELPERS
+		assert(glm::mat4x2::rows == glm::mat4x2::row_type::components);
+		assert(glm::mat4x2::cols == glm::mat4x2::col_type::components);
+#endif
+
 	Error += test_ctr();
 	Error += test_operators();
 

--- a/test/core/core_type_mat4x3.cpp
+++ b/test/core/core_type_mat4x3.cpp
@@ -106,6 +106,11 @@ int main()
 {
 	int Error = 0;
 
+#ifdef GLM_META_PROG_HELPERS
+		assert(glm::mat4x3::rows == glm::mat4x3::row_type::components);
+		assert(glm::mat4x3::cols == glm::mat4x3::col_type::components);
+#endif
+
 	Error += test_ctr();
 	Error += test_operators();
 

--- a/test/core/core_type_mat4x4.cpp
+++ b/test/core/core_type_mat4x4.cpp
@@ -278,6 +278,11 @@ int main()
 {
 	int Error = 0;
 
+#ifdef GLM_META_PROG_HELPERS
+		assert(glm::mat4::rows == glm::mat4::row_type::components);
+		assert(glm::mat4::cols == glm::mat4::col_type::components);
+#endif
+
 	Error += test_ctr();
 	Error += test_inverse_dmat4x4();
 	Error += test_inverse_mat4x4();

--- a/test/core/core_type_vec1.cpp
+++ b/test/core/core_type_vec1.cpp
@@ -190,6 +190,7 @@ int main()
 	assert(v.length() == 1);
 
 #	ifdef GLM_META_PROG_HELPERS
+		assert(glm::vec1::components == glm::vec1().length());
 		assert(glm::vec1::components == 1);
 #	endif
 

--- a/test/core/core_type_vec2.cpp
+++ b/test/core/core_type_vec2.cpp
@@ -349,6 +349,7 @@ int main()
 	assert(v.length() == 2);
 
 #	ifdef GLM_META_PROG_HELPERS
+		assert(glm::vec2::components == glm::vec2().length());
 		assert(glm::vec2::components == 2);
 #	endif
 

--- a/test/core/core_type_vec3.cpp
+++ b/test/core/core_type_vec3.cpp
@@ -517,6 +517,7 @@ int main()
 	assert(v.length() == 3);
 
 #	ifdef GLM_META_PROG_HELPERS
+		assert(glm::vec3::components == glm::vec3().length());
 		assert(glm::vec3::components == 3);
 #	endif
 

--- a/test/core/core_type_vec4.cpp
+++ b/test/core/core_type_vec4.cpp
@@ -493,6 +493,7 @@ int main()
 	assert(v.length() == 4);
 
 #	ifdef GLM_META_PROG_HELPERS
+		assert(glm::vec4::components == glm::vec4().length());
 		assert(glm::vec4::components == 4);
 #	endif
 

--- a/test/gtc/gtc_quaternion.cpp
+++ b/test/gtc/gtc_quaternion.cpp
@@ -325,7 +325,10 @@ int main()
 {
 	int Error(0);
 
-	assert(glm::quat::components == 4);
+#ifdef GLM_META_PROG_HELPERS
+		assert(glm::quat::components == 4);
+		assert(glm::quat::components == glm::quat().length());
+#endif
 
 	Error += test_quat_ctr();
 	Error += test_quat_mul_vec();

--- a/test/gtx/gtx_dual_quaternion.cpp
+++ b/test/gtx/gtx_dual_quaternion.cpp
@@ -209,6 +209,10 @@ int main()
 {
 	int Error(0);
 
+#ifdef GLM_META_PROG_HELPERS
+		assert(glm::dualquat::components == glm::dualquat().length());
+#endif
+
 	Error += test_dual_quat_ctr();
 	Error += test_dquat_type();
 	Error += test_scalars();

--- a/test/gtx/gtx_simd_mat4.cpp
+++ b/test/gtx/gtx_simd_mat4.cpp
@@ -256,6 +256,15 @@ int main()
 {
 	int Error = 0;
 
+#ifdef GLM_META_PROG_HELPERS
+		assert(glm::simdMat4::rows == glm::simdMat4::row_type::components);
+		assert(glm::simdMat4::cols == glm::simdMat4::col_type::components);
+
+		assert(glm::simdMat4::components == glm::simdMat4::pure_type::components);
+		assert(glm::simdMat4::rows == glm::simdMat4::pure_row_type::components);
+		assert(glm::simdMat4::cols == glm::simdMat4::pure_col_type::components);
+#endif
+
 	std::vector<glm::mat4> Data(64 * 64 * 1);
 	for(std::size_t i = 0; i < Data.size(); ++i)
 		Data[i] = glm::mat4(

--- a/test/gtx/gtx_simd_vec4.cpp
+++ b/test/gtx/gtx_simd_vec4.cpp
@@ -37,6 +37,11 @@
 
 int main()
 {
+
+#ifdef GLM_META_PROG_HELPERS
+		assert(glm::simdVec4::components == glm::simdVec4::pure_type::components);
+#endif
+
 	glm::simdVec4 A1(0.0f, 0.1f, 0.2f, 0.3f);
 	glm::simdVec4 B1(0.4f, 0.5f, 0.6f, 0.7f);
 	glm::simdVec4 C1 = A1 + B1;


### PR DESCRIPTION
Notably, I accidentally got the `type::rows` and `type::cols` constants backwards.  So I reversed them.  I also fixed the naming for `mat2::columns` (it should've been `cols`).  Lastly, I added some more tests.

Sorry about that.