### PR TITLE
Fixed typo resulting in warnings when building with -Wpedantic.

### DIFF
--- a/glm/detail/type_mat2x2.hpp
+++ b/glm/detail/type_mat2x2.hpp
@@ -125,7 +125,7 @@ namespace glm
 
 		// -- Unary arithmetic operators --
 
-		GLM_FUNC_DECL tmat2x2<T, P> & operator=(tmat2x2<T, P> const & v) GLM_DEFAULT;;
+		GLM_FUNC_DECL tmat2x2<T, P> & operator=(tmat2x2<T, P> const & v) GLM_DEFAULT;
 
 		template <typename U>
 		GLM_FUNC_DECL tmat2x2<T, P> & operator=(tmat2x2<U, P> const & m);


### PR DESCRIPTION
Probably the most insignificant pull request ever, but the warnings since upgrading glm occluded my terminal. And thanks for the great work btw :+1: 