### PR TITLE
add glm::ortho_2d

### DIFF
--- a/glm/gtc/matrix_transform.hpp
+++ b/glm/gtc/matrix_transform.hpp
@@ -151,6 +151,21 @@ namespace glm
 		T right,
 		T bottom,
 		T top);
+		
+	/// Creates a matrix for projecting two-dimensional coordinates onto the screen.
+	/// 
+	/// @param left 
+	/// @param right 
+	/// @param bottom 
+	/// @param top 
+	/// @tparam T Value type used to build the matrix. Currently supported: half (not recommanded), float or double.
+	/// @see gtc_matrix_transform
+	template <typename T>
+	GLM_FUNC_DECL tmat3x3<T, defaultp> ortho_2d(
+		T left,
+		T right,
+		T bottom,
+		T top);
 
 	/// Creates a frustum matrix.
 	/// 

--- a/glm/gtc/matrix_transform.inl
+++ b/glm/gtc/matrix_transform.inl
@@ -185,6 +185,23 @@ namespace glm
 		Result[3][1] = - (top + bottom) / (top - bottom);
 		return Result;
 	}
+	
+	template <typename T> 
+	GLM_FUNC_QUALIFIER tmat3x3<T, defaultp> ortho_2d
+	(
+		T left, 
+		T right, 
+		T bottom, 
+		T top
+	)
+	{
+		tmat3x3<T, defaultp> Result(1);
+		Result[0][0] = static_cast<T>(2) / (right - left);
+		Result[1][1] = static_cast<T>(2) / (top - bottom);
+		Result[2][0] = -(right + left) / (right - left);
+		Result[2][1] = -(top + bottom) / (top - bottom);
+		return Result;
+	}
 
 	template <typename T>
 	GLM_FUNC_QUALIFIER tmat4x4<T, defaultp> frustum


### PR DESCRIPTION
This pull request allows the creation of `glm::mat3`s from the `glm::ortho` command, which must be renamed to `glm::ortho_2d`. This helps because not all projects need `mat4` matrices, and in order to support a similar pipeline for them, it is necessary to have this.