### PR TITLE
rename scalar parameters in vec1, vec2, vec3, and vec4 (fixes C4458 in MSVC 2015)

### DIFF
--- a/glm/detail/type_vec1.hpp
+++ b/glm/detail/type_vec1.hpp
@@ -116,7 +116,7 @@ namespace glm
 		// -- Explicit basic constructors --
 
 		GLM_FUNC_DECL explicit tvec1(ctor);
-		GLM_FUNC_DECL explicit tvec1(T const & s);
+		GLM_FUNC_DECL explicit tvec1(T const & scalar);
 
 		// -- Conversion vector constructors --
 
@@ -151,19 +151,19 @@ namespace glm
 		template <typename U>
 		GLM_FUNC_DECL tvec1<T, P> & operator=(tvec1<U, P> const & v);
 		template <typename U>
-		GLM_FUNC_DECL tvec1<T, P> & operator+=(U const & s);
+		GLM_FUNC_DECL tvec1<T, P> & operator+=(U const & scalar);
 		template <typename U>
 		GLM_FUNC_DECL tvec1<T, P> & operator+=(tvec1<U, P> const & v);
 		template <typename U>
-		GLM_FUNC_DECL tvec1<T, P> & operator-=(U const & s);
+		GLM_FUNC_DECL tvec1<T, P> & operator-=(U const & scalar);
 		template <typename U>
 		GLM_FUNC_DECL tvec1<T, P> & operator-=(tvec1<U, P> const & v);
 		template <typename U>
-		GLM_FUNC_DECL tvec1<T, P> & operator*=(U const & s);
+		GLM_FUNC_DECL tvec1<T, P> & operator*=(U const & scalar);
 		template <typename U>
 		GLM_FUNC_DECL tvec1<T, P> & operator*=(tvec1<U, P> const & v);
 		template <typename U>
-		GLM_FUNC_DECL tvec1<T, P> & operator/=(U const & s);
+		GLM_FUNC_DECL tvec1<T, P> & operator/=(U const & scalar);
 		template <typename U>
 		GLM_FUNC_DECL tvec1<T, P> & operator/=(tvec1<U, P> const & v);
 
@@ -177,27 +177,27 @@ namespace glm
 		// -- Unary bit operators --
 
 		template <typename U>
-		GLM_FUNC_DECL tvec1<T, P> & operator%=(U const & s);
+		GLM_FUNC_DECL tvec1<T, P> & operator%=(U const & scalar);
 		template <typename U>
 		GLM_FUNC_DECL tvec1<T, P> & operator%=(tvec1<U, P> const & v);
 		template <typename U>
-		GLM_FUNC_DECL tvec1<T, P> & operator&=(U const & s);
+		GLM_FUNC_DECL tvec1<T, P> & operator&=(U const & scalar);
 		template <typename U>
 		GLM_FUNC_DECL tvec1<T, P> & operator&=(tvec1<U, P> const & v);
 		template <typename U>
-		GLM_FUNC_DECL tvec1<T, P> & operator|=(U const & s);
+		GLM_FUNC_DECL tvec1<T, P> & operator|=(U const & scalar);
 		template <typename U>
 		GLM_FUNC_DECL tvec1<T, P> & operator|=(tvec1<U, P> const & v);
 		template <typename U>
-		GLM_FUNC_DECL tvec1<T, P> & operator^=(U const & s);
+		GLM_FUNC_DECL tvec1<T, P> & operator^=(U const & scalar);
 		template <typename U>
 		GLM_FUNC_DECL tvec1<T, P> & operator^=(tvec1<U, P> const & v);
 		template <typename U>
-		GLM_FUNC_DECL tvec1<T, P> & operator<<=(U const & s);
+		GLM_FUNC_DECL tvec1<T, P> & operator<<=(U const & scalar);
 		template <typename U>
 		GLM_FUNC_DECL tvec1<T, P> & operator<<=(tvec1<U, P> const & v);
 		template <typename U>
-		GLM_FUNC_DECL tvec1<T, P> & operator>>=(U const & s);
+		GLM_FUNC_DECL tvec1<T, P> & operator>>=(U const & scalar);
 		template <typename U>
 		GLM_FUNC_DECL tvec1<T, P> & operator>>=(tvec1<U, P> const & v);
 	};
@@ -210,91 +210,91 @@ namespace glm
 	// -- Binary operators --
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec1<T, P> operator+(tvec1<T, P> const & v, T const & s);
+	GLM_FUNC_DECL tvec1<T, P> operator+(tvec1<T, P> const & v, T const & scalar);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec1<T, P> operator+(T const & s, tvec1<T, P> const & v);
+	GLM_FUNC_DECL tvec1<T, P> operator+(T const & scalar, tvec1<T, P> const & v);
 
 	template <typename T, precision P>
 	GLM_FUNC_DECL tvec1<T, P> operator+(tvec1<T, P> const & v1, tvec1<T, P> const & v2);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec1<T, P> operator-(tvec1<T, P> const & v, T const & s);
+	GLM_FUNC_DECL tvec1<T, P> operator-(tvec1<T, P> const & v, T const & scalar);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec1<T, P> operator-(T const & s, tvec1<T, P> const & v);
+	GLM_FUNC_DECL tvec1<T, P> operator-(T const & scalar, tvec1<T, P> const & v);
 
 	template <typename T, precision P>
 	GLM_FUNC_DECL tvec1<T, P> operator-	(tvec1<T, P> const & v1, tvec1<T, P> const & v2);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec1<T, P> operator*(tvec1<T, P> const & v, T const & s);
+	GLM_FUNC_DECL tvec1<T, P> operator*(tvec1<T, P> const & v, T const & scalar);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec1<T, P> operator*(T const & s, tvec1<T, P> const & v);
+	GLM_FUNC_DECL tvec1<T, P> operator*(T const & scalar, tvec1<T, P> const & v);
 
 	template <typename T, precision P>
 	GLM_FUNC_DECL tvec1<T, P> operator*(tvec1<T, P> const & v1, tvec1<T, P> const & v2);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec1<T, P> operator/(tvec1<T, P> const & v, T const & s);
+	GLM_FUNC_DECL tvec1<T, P> operator/(tvec1<T, P> const & v, T const & scalar);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec1<T, P> operator/(T const & s, tvec1<T, P> const & v);
+	GLM_FUNC_DECL tvec1<T, P> operator/(T const & scalar, tvec1<T, P> const & v);
 
 	template <typename T, precision P>
 	GLM_FUNC_DECL tvec1<T, P> operator/(tvec1<T, P> const & v1, tvec1<T, P> const & v2);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec1<T, P> operator%(tvec1<T, P> const & v, T const & s);
+	GLM_FUNC_DECL tvec1<T, P> operator%(tvec1<T, P> const & v, T const & scalar);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec1<T, P> operator%(T const & s, tvec1<T, P> const & v);
+	GLM_FUNC_DECL tvec1<T, P> operator%(T const & scalar, tvec1<T, P> const & v);
 
 	template <typename T, precision P>
 	GLM_FUNC_DECL tvec1<T, P> operator%(tvec1<T, P> const & v1, tvec1<T, P> const & v2);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec1<T, P> operator&(tvec1<T, P> const & v, T const & s);
+	GLM_FUNC_DECL tvec1<T, P> operator&(tvec1<T, P> const & v, T const & scalar);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec1<T, P> operator&(T const & s, tvec1<T, P> const & v);
+	GLM_FUNC_DECL tvec1<T, P> operator&(T const & scalar, tvec1<T, P> const & v);
 
 	template <typename T, precision P>
 	GLM_FUNC_DECL tvec1<T, P> operator&(tvec1<T, P> const & v1, tvec1<T, P> const & v2);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec1<T, P> operator|(tvec1<T, P> const & v, T const & s);
+	GLM_FUNC_DECL tvec1<T, P> operator|(tvec1<T, P> const & v, T const & scalar);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec1<T, P> operator|(T const & s, tvec1<T, P> const & v);
+	GLM_FUNC_DECL tvec1<T, P> operator|(T const & scalar, tvec1<T, P> const & v);
 
 	template <typename T, precision P>
 	GLM_FUNC_DECL tvec1<T, P> operator|(tvec1<T, P> const & v1, tvec1<T, P> const & v2);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec1<T, P> operator^(tvec1<T, P> const & v, T const & s);
+	GLM_FUNC_DECL tvec1<T, P> operator^(tvec1<T, P> const & v, T const & scalar);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec1<T, P> operator^(T const & s, tvec1<T, P> const & v);
+	GLM_FUNC_DECL tvec1<T, P> operator^(T const & scalar, tvec1<T, P> const & v);
 
 	template <typename T, precision P>
 	GLM_FUNC_DECL tvec1<T, P> operator^(tvec1<T, P> const & v1, tvec1<T, P> const & v2);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec1<T, P> operator<<(tvec1<T, P> const & v, T const & s);
+	GLM_FUNC_DECL tvec1<T, P> operator<<(tvec1<T, P> const & v, T const & scalar);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec1<T, P> operator<<(T const & s, tvec1<T, P> const & v);
+	GLM_FUNC_DECL tvec1<T, P> operator<<(T const & scalar, tvec1<T, P> const & v);
 
 	template <typename T, precision P>
 	GLM_FUNC_DECL tvec1<T, P> operator<<(tvec1<T, P> const & v1, tvec1<T, P> const & v2);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec1<T, P> operator>>(tvec1<T, P> const & v, T const & s);
+	GLM_FUNC_DECL tvec1<T, P> operator>>(tvec1<T, P> const & v, T const & scalar);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec1<T, P> operator>>(T const & s, tvec1<T, P> const & v);
+	GLM_FUNC_DECL tvec1<T, P> operator>>(T const & scalar, tvec1<T, P> const & v);
 
 	template <typename T, precision P>
 	GLM_FUNC_DECL tvec1<T, P> operator>>(tvec1<T, P> const & v1, tvec1<T, P> const & v2);

--- a/glm/detail/type_vec1.inl
+++ b/glm/detail/type_vec1.inl
@@ -63,8 +63,8 @@ namespace glm
 	{}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER  tvec1<T, P>::tvec1(T const & s)
-		: x(s)
+	GLM_FUNC_QUALIFIER  tvec1<T, P>::tvec1(T const & scalar)
+		: x(scalar)
 	{}
 
 	// -- Conversion vector constructors --
@@ -158,9 +158,9 @@ namespace glm
 
 	template <typename T, precision P>
 	template <typename U> 
-	GLM_FUNC_QUALIFIER tvec1<T, P> & tvec1<T, P>::operator+=(U const & s)
+	GLM_FUNC_QUALIFIER tvec1<T, P> & tvec1<T, P>::operator+=(U const & scalar)
 	{
-		this->x += static_cast<T>(s);
+		this->x += static_cast<T>(scalar);
 		return *this;
 	}
 
@@ -174,9 +174,9 @@ namespace glm
 
 	template <typename T, precision P>
 	template <typename U> 
-	GLM_FUNC_QUALIFIER tvec1<T, P> & tvec1<T, P>::operator-=(U const & s)
+	GLM_FUNC_QUALIFIER tvec1<T, P> & tvec1<T, P>::operator-=(U const & scalar)
 	{
-		this->x -= static_cast<T>(s);
+		this->x -= static_cast<T>(scalar);
 		return *this;
 	}
 
@@ -190,9 +190,9 @@ namespace glm
 
 	template <typename T, precision P>
 	template <typename U> 
-	GLM_FUNC_QUALIFIER tvec1<T, P> & tvec1<T, P>::operator*=(U const & s)
+	GLM_FUNC_QUALIFIER tvec1<T, P> & tvec1<T, P>::operator*=(U const & scalar)
 	{
-		this->x *= static_cast<T>(s);
+		this->x *= static_cast<T>(scalar);
 		return *this;
 	}
 
@@ -206,9 +206,9 @@ namespace glm
 
 	template <typename T, precision P>
 	template <typename U> 
-	GLM_FUNC_QUALIFIER tvec1<T, P> & tvec1<T, P>::operator/=(U const & s)
+	GLM_FUNC_QUALIFIER tvec1<T, P> & tvec1<T, P>::operator/=(U const & scalar)
 	{
-		this->x /= static_cast<T>(s);
+		this->x /= static_cast<T>(scalar);
 		return *this;
 	}
 
@@ -256,9 +256,9 @@ namespace glm
 
 	template <typename T, precision P>
 	template <typename U> 
-	GLM_FUNC_QUALIFIER tvec1<T, P> & tvec1<T, P>::operator%=(U const & s)
+	GLM_FUNC_QUALIFIER tvec1<T, P> & tvec1<T, P>::operator%=(U const & scalar)
 	{
-		this->x %= static_cast<T>(s);
+		this->x %= static_cast<T>(scalar);
 		return *this;
 	}
 
@@ -272,9 +272,9 @@ namespace glm
 
 	template <typename T, precision P>
 	template <typename U> 
-	GLM_FUNC_QUALIFIER tvec1<T, P> & tvec1<T, P>::operator&=(U const & s)
+	GLM_FUNC_QUALIFIER tvec1<T, P> & tvec1<T, P>::operator&=(U const & scalar)
 	{
-		this->x &= static_cast<T>(s);
+		this->x &= static_cast<T>(scalar);
 		return *this;
 	}
 
@@ -288,9 +288,9 @@ namespace glm
 
 	template <typename T, precision P>
 	template <typename U> 
-	GLM_FUNC_QUALIFIER tvec1<T, P> & tvec1<T, P>::operator|=(U const & s)
+	GLM_FUNC_QUALIFIER tvec1<T, P> & tvec1<T, P>::operator|=(U const & scalar)
 	{
-		this->x |= static_cast<T>(s);
+		this->x |= static_cast<T>(scalar);
 		return *this;
 	}
 
@@ -304,9 +304,9 @@ namespace glm
 
 	template <typename T, precision P>
 	template <typename U> 
-	GLM_FUNC_QUALIFIER tvec1<T, P> & tvec1<T, P>::operator^=(U const & s)
+	GLM_FUNC_QUALIFIER tvec1<T, P> & tvec1<T, P>::operator^=(U const & scalar)
 	{
-		this->x ^= static_cast<T>(s);
+		this->x ^= static_cast<T>(scalar);
 		return *this;
 	}
 
@@ -320,9 +320,9 @@ namespace glm
 
 	template <typename T, precision P>
 	template <typename U> 
-	GLM_FUNC_QUALIFIER tvec1<T, P> & tvec1<T, P>::operator<<=(U const & s)
+	GLM_FUNC_QUALIFIER tvec1<T, P> & tvec1<T, P>::operator<<=(U const & scalar)
 	{
-		this->x <<= static_cast<T>(s);
+		this->x <<= static_cast<T>(scalar);
 		return *this;
 	}
 
@@ -336,9 +336,9 @@ namespace glm
 
 	template <typename T, precision P>
 	template <typename U> 
-	GLM_FUNC_QUALIFIER tvec1<T, P> & tvec1<T, P>::operator>>=(U const & s)
+	GLM_FUNC_QUALIFIER tvec1<T, P> & tvec1<T, P>::operator>>=(U const & scalar)
 	{
-		this->x >>= static_cast<T>(s);
+		this->x >>= static_cast<T>(scalar);
 		return *this;
 	}
 
@@ -362,17 +362,17 @@ namespace glm
 	// -- Binary arithmetic operators --
 
 	template <typename T, precision P> 
-	GLM_FUNC_QUALIFIER tvec1<T, P> operator+(tvec1<T, P> const & v, T const & s)
+	GLM_FUNC_QUALIFIER tvec1<T, P> operator+(tvec1<T, P> const & v, T const & scalar)
 	{
 		return tvec1<T, P>(
-			v.x + s);
+			v.x + scalar);
 	}
 
 	template <typename T, precision P> 
-	GLM_FUNC_QUALIFIER tvec1<T, P> operator+(T const & s, tvec1<T, P> const & v)
+	GLM_FUNC_QUALIFIER tvec1<T, P> operator+(T const & scalar, tvec1<T, P> const & v)
 	{
 		return tvec1<T, P>(
-			s + v.x);
+			scalar + v.x);
 	}
 
 	template <typename T, precision P>
@@ -384,17 +384,17 @@ namespace glm
 
 	//operator-
 	template <typename T, precision P> 
-	GLM_FUNC_QUALIFIER tvec1<T, P> operator-(tvec1<T, P> const & v, T const & s)
+	GLM_FUNC_QUALIFIER tvec1<T, P> operator-(tvec1<T, P> const & v, T const & scalar)
 	{
 		return tvec1<T, P>(
-			v.x - s);
+			v.x - scalar);
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tvec1<T, P> operator-(T const & s, tvec1<T, P> const & v)
+	GLM_FUNC_QUALIFIER tvec1<T, P> operator-(T const & scalar, tvec1<T, P> const & v)
 	{
 		return tvec1<T, P>(
-			s - v.x);
+			scalar - v.x);
 	}
 
 	template <typename T, precision P>
@@ -405,17 +405,17 @@ namespace glm
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tvec1<T, P> operator*(tvec1<T, P> const & v, T const & s)
+	GLM_FUNC_QUALIFIER tvec1<T, P> operator*(tvec1<T, P> const & v, T const & scalar)
 	{
 		return tvec1<T, P>(
-			v.x * s);
+			v.x * scalar);
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tvec1<T, P> operator*(T const & s, tvec1<T, P> const & v)
+	GLM_FUNC_QUALIFIER tvec1<T, P> operator*(T const & scalar, tvec1<T, P> const & v)
 	{
 		return tvec1<T, P>(
-			s * v.x);
+			scalar * v.x);
 	}
 
 	template <typename T, precision P>
@@ -426,17 +426,17 @@ namespace glm
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tvec1<T, P> operator/(tvec1<T, P> const & v,	T const & s)
+	GLM_FUNC_QUALIFIER tvec1<T, P> operator/(tvec1<T, P> const & v,	T const & scalar)
 	{
 		return tvec1<T, P>(
-			v.x / s);
+			v.x / scalar);
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tvec1<T, P> operator/(T const & s, tvec1<T, P> const & v)
+	GLM_FUNC_QUALIFIER tvec1<T, P> operator/(T const & scalar, tvec1<T, P> const & v)
 	{
 		return tvec1<T, P>(
-			s / v.x);
+			scalar / v.x);
 	}
 
 	template <typename T, precision P>
@@ -449,17 +449,17 @@ namespace glm
 	// -- Binary bit operators --
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tvec1<T, P> operator%(tvec1<T, P> const & v, T const & s)
+	GLM_FUNC_QUALIFIER tvec1<T, P> operator%(tvec1<T, P> const & v, T const & scalar)
 	{
 		return tvec1<T, P>(
-			v.x % s);
+			v.x % scalar);
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tvec1<T, P> operator%(T const & s, tvec1<T, P> const & v)
+	GLM_FUNC_QUALIFIER tvec1<T, P> operator%(T const & scalar, tvec1<T, P> const & v)
 	{
 		return tvec1<T, P>(
-			s % v.x);
+			scalar % v.x);
 	}
 
 	template <typename T, precision P>
@@ -470,17 +470,17 @@ namespace glm
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tvec1<T, P> operator&(tvec1<T, P> const & v, T const & s)
+	GLM_FUNC_QUALIFIER tvec1<T, P> operator&(tvec1<T, P> const & v, T const & scalar)
 	{
 		return tvec1<T, P>(
-			v.x & s);
+			v.x & scalar);
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tvec1<T, P> operator&(T const & s, tvec1<T, P> const & v)
+	GLM_FUNC_QUALIFIER tvec1<T, P> operator&(T const & scalar, tvec1<T, P> const & v)
 	{
 		return tvec1<T, P>(
-			s & v.x);
+			scalar & v.x);
 	}
 
 	template <typename T, precision P>
@@ -491,17 +491,17 @@ namespace glm
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tvec1<T, P> operator|(tvec1<T, P> const & v, T const & s)
+	GLM_FUNC_QUALIFIER tvec1<T, P> operator|(tvec1<T, P> const & v, T const & scalar)
 	{
 		return tvec1<T, P>(
-			v.x | s);
+			v.x | scalar);
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tvec1<T, P> operator|(T const & s, tvec1<T, P> const & v)
+	GLM_FUNC_QUALIFIER tvec1<T, P> operator|(T const & scalar, tvec1<T, P> const & v)
 	{
 		return tvec1<T, P>(
-			s | v.x);
+			scalar | v.x);
 	}
 
 	template <typename T, precision P>
@@ -512,17 +512,17 @@ namespace glm
 	}
 		
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tvec1<T, P> operator^(tvec1<T, P> const & v, T const & s)
+	GLM_FUNC_QUALIFIER tvec1<T, P> operator^(tvec1<T, P> const & v, T const & scalar)
 	{
 		return tvec1<T, P>(
-			v.x ^ s);
+			v.x ^ scalar);
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tvec1<T, P> operator^(T const & s, tvec1<T, P> const & v)
+	GLM_FUNC_QUALIFIER tvec1<T, P> operator^(T const & scalar, tvec1<T, P> const & v)
 	{
 		return tvec1<T, P>(
-			s ^ v.x);
+			scalar ^ v.x);
 	}
 
 	template <typename T, precision P>
@@ -533,17 +533,17 @@ namespace glm
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tvec1<T, P> operator<<(tvec1<T, P> const & v, T const & s)
+	GLM_FUNC_QUALIFIER tvec1<T, P> operator<<(tvec1<T, P> const & v, T const & scalar)
 	{
 		return tvec1<T, P>(
-			v.x << s);
+			v.x << scalar);
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tvec1<T, P> operator<<(T const & s, tvec1<T, P> const & v)
+	GLM_FUNC_QUALIFIER tvec1<T, P> operator<<(T const & scalar, tvec1<T, P> const & v)
 	{
 		return tvec1<T, P>(
-			s << v.x);
+			scalar << v.x);
 	}
 
 	template <typename T, precision P>
@@ -554,17 +554,17 @@ namespace glm
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tvec1<T, P> operator>>(tvec1<T, P> const & v, T const & s)
+	GLM_FUNC_QUALIFIER tvec1<T, P> operator>>(tvec1<T, P> const & v, T const & scalar)
 	{
 		return tvec1<T, P>(
-			v.x >> s);
+			v.x >> scalar);
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tvec1<T, P> operator>>(T const & s, tvec1<T, P> const & v)
+	GLM_FUNC_QUALIFIER tvec1<T, P> operator>>(T const & scalar, tvec1<T, P> const & v)
 	{
 		return tvec1<T, P>(
-			s >> v.x);
+			scalar >> v.x);
 	}
 
 	template <typename T, precision P>

--- a/glm/detail/type_vec2.hpp
+++ b/glm/detail/type_vec2.hpp
@@ -116,7 +116,7 @@ namespace glm
 		// -- Explicit basic constructors --
 
 		GLM_FUNC_DECL explicit tvec2(ctor);
-		GLM_FUNC_DECL explicit tvec2(T const & s);
+		GLM_FUNC_DECL explicit tvec2(T const & scalar);
 		GLM_FUNC_DECL tvec2(T const & s1, T const & s2);
 
 		// -- Conversion constructors --
@@ -157,25 +157,25 @@ namespace glm
 		template <typename U>
 		GLM_FUNC_DECL tvec2<T, P>& operator=(tvec2<U, P> const & v);
 		template <typename U>
-		GLM_FUNC_DECL tvec2<T, P>& operator+=(U s);
+		GLM_FUNC_DECL tvec2<T, P>& operator+=(U scalar);
 		template <typename U>
 		GLM_FUNC_DECL tvec2<T, P>& operator+=(tvec1<U, P> const & v);
 		template <typename U>
 		GLM_FUNC_DECL tvec2<T, P>& operator+=(tvec2<U, P> const & v);
 		template <typename U>
-		GLM_FUNC_DECL tvec2<T, P>& operator-=(U s);
+		GLM_FUNC_DECL tvec2<T, P>& operator-=(U scalar);
 		template <typename U>
 		GLM_FUNC_DECL tvec2<T, P>& operator-=(tvec1<U, P> const & v);
 		template <typename U>
 		GLM_FUNC_DECL tvec2<T, P>& operator-=(tvec2<U, P> const & v);
 		template <typename U>
-		GLM_FUNC_DECL tvec2<T, P>& operator*=(U s);
+		GLM_FUNC_DECL tvec2<T, P>& operator*=(U scalar);
 		template <typename U>
 		GLM_FUNC_DECL tvec2<T, P>& operator*=(tvec1<U, P> const & v);
 		template <typename U>
 		GLM_FUNC_DECL tvec2<T, P>& operator*=(tvec2<U, P> const & v);
 		template <typename U>
-		GLM_FUNC_DECL tvec2<T, P>& operator/=(U s);
+		GLM_FUNC_DECL tvec2<T, P>& operator/=(U scalar);
 		template <typename U>
 		GLM_FUNC_DECL tvec2<T, P>& operator/=(tvec1<U, P> const & v);
 		template <typename U>
@@ -191,37 +191,37 @@ namespace glm
 		// -- Unary bit operators --
 
 		template <typename U> 
-		GLM_FUNC_DECL tvec2<T, P> & operator%=(U s);
+		GLM_FUNC_DECL tvec2<T, P> & operator%=(U scalar);
 		template <typename U> 
 		GLM_FUNC_DECL tvec2<T, P> & operator%=(tvec1<U, P> const & v);
 		template <typename U> 
 		GLM_FUNC_DECL tvec2<T, P> & operator%=(tvec2<U, P> const & v);
 		template <typename U> 
-		GLM_FUNC_DECL tvec2<T, P> & operator&=(U s);
+		GLM_FUNC_DECL tvec2<T, P> & operator&=(U scalar);
 		template <typename U> 
 		GLM_FUNC_DECL tvec2<T, P> & operator&=(tvec1<U, P> const & v);
 		template <typename U> 
 		GLM_FUNC_DECL tvec2<T, P> & operator&=(tvec2<U, P> const & v);
 		template <typename U> 
-		GLM_FUNC_DECL tvec2<T, P> & operator|=(U s);
+		GLM_FUNC_DECL tvec2<T, P> & operator|=(U scalar);
 		template <typename U> 
 		GLM_FUNC_DECL tvec2<T, P> & operator|=(tvec1<U, P> const & v);
 		template <typename U> 
 		GLM_FUNC_DECL tvec2<T, P> & operator|=(tvec2<U, P> const & v);
 		template <typename U> 
-		GLM_FUNC_DECL tvec2<T, P> & operator^=(U s);
+		GLM_FUNC_DECL tvec2<T, P> & operator^=(U scalar);
 		template <typename U> 
 		GLM_FUNC_DECL tvec2<T, P> & operator^=(tvec1<U, P> const & v);
 		template <typename U> 
 		GLM_FUNC_DECL tvec2<T, P> & operator^=(tvec2<U, P> const & v);
 		template <typename U> 
-		GLM_FUNC_DECL tvec2<T, P> & operator<<=(U s);
+		GLM_FUNC_DECL tvec2<T, P> & operator<<=(U scalar);
 		template <typename U> 
 		GLM_FUNC_DECL tvec2<T, P> & operator<<=(tvec1<U, P> const & v);
 		template <typename U> 
 		GLM_FUNC_DECL tvec2<T, P> & operator<<=(tvec2<U, P> const & v);
 		template <typename U> 
-		GLM_FUNC_DECL tvec2<T, P> & operator>>=(U s);
+		GLM_FUNC_DECL tvec2<T, P> & operator>>=(U scalar);
 		template <typename U> 
 		GLM_FUNC_DECL tvec2<T, P> & operator>>=(tvec1<U, P> const & v);
 		template <typename U> 
@@ -236,13 +236,13 @@ namespace glm
 	// -- Binary operators --
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec2<T, P> operator+(tvec2<T, P> const & v, T const & s);
+	GLM_FUNC_DECL tvec2<T, P> operator+(tvec2<T, P> const & v, T const & scalar);
 
 	template <typename T, precision P>
 	GLM_FUNC_DECL tvec2<T, P> operator+(tvec2<T, P> const & v1, tvec1<T, P> const & v2);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec2<T, P> operator+(T const & s, tvec2<T, P> const & v);
+	GLM_FUNC_DECL tvec2<T, P> operator+(T const & scalar, tvec2<T, P> const & v);
 
 	template <typename T, precision P>
 	GLM_FUNC_DECL tvec2<T, P> operator+(tvec1<T, P> const & v1, tvec2<T, P> const & v2);
@@ -251,13 +251,13 @@ namespace glm
 	GLM_FUNC_DECL tvec2<T, P> operator+(tvec2<T, P> const & v1, tvec2<T, P> const & v2);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec2<T, P> operator-(tvec2<T, P> const & v, T const & s);
+	GLM_FUNC_DECL tvec2<T, P> operator-(tvec2<T, P> const & v, T const & scalar);
 
 	template <typename T, precision P>
 	GLM_FUNC_DECL tvec2<T, P> operator-(tvec2<T, P> const & v1, tvec1<T, P> const & v2);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec2<T, P> operator-(T const & s, tvec2<T, P> const & v);
+	GLM_FUNC_DECL tvec2<T, P> operator-(T const & scalar, tvec2<T, P> const & v);
 
 	template <typename T, precision P>
 	GLM_FUNC_DECL tvec2<T, P> operator-(tvec1<T, P> const & v1, tvec2<T, P> const & v2);
@@ -266,13 +266,13 @@ namespace glm
 	GLM_FUNC_DECL tvec2<T, P> operator-(tvec2<T, P> const & v1, tvec2<T, P> const & v2);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec2<T, P> operator*(tvec2<T, P> const & v, T const & s);
+	GLM_FUNC_DECL tvec2<T, P> operator*(tvec2<T, P> const & v, T const & scalar);
 
 	template <typename T, precision P>
 	GLM_FUNC_DECL tvec2<T, P> operator*(tvec2<T, P> const & v1, tvec1<T, P> const & v2);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec2<T, P> operator*(T const & s, tvec2<T, P> const & v);
+	GLM_FUNC_DECL tvec2<T, P> operator*(T const & scalar, tvec2<T, P> const & v);
 
 	template <typename T, precision P>
 	GLM_FUNC_DECL tvec2<T, P> operator*(tvec1<T, P> const & v1, tvec2<T, P> const & v2);
@@ -281,13 +281,13 @@ namespace glm
 	GLM_FUNC_DECL tvec2<T, P> operator*(tvec2<T, P> const & v1, tvec2<T, P> const & v2);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec2<T, P> operator/(tvec2<T, P> const & v, T const & s);
+	GLM_FUNC_DECL tvec2<T, P> operator/(tvec2<T, P> const & v, T const & scalar);
 
 	template <typename T, precision P>
 	GLM_FUNC_DECL tvec2<T, P> operator/(tvec2<T, P> const & v1, tvec1<T, P> const & v2);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec2<T, P> operator/(T const & s, tvec2<T, P> const & v);
+	GLM_FUNC_DECL tvec2<T, P> operator/(T const & scalar, tvec2<T, P> const & v);
 
 	template <typename T, precision P>
 	GLM_FUNC_DECL tvec2<T, P> operator/(tvec1<T, P> const & v1, tvec2<T, P> const & v2);
@@ -299,13 +299,13 @@ namespace glm
 	GLM_FUNC_DECL tvec2<T, P> operator-(tvec2<T, P> const & v);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec2<T, P> operator%(tvec2<T, P> const & v, T const & s);
+	GLM_FUNC_DECL tvec2<T, P> operator%(tvec2<T, P> const & v, T const & scalar);
 
 	template <typename T, precision P>
 	GLM_FUNC_DECL tvec2<T, P> operator%(tvec2<T, P> const & v1, tvec1<T, P> const & v2);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec2<T, P> operator%(T const & s, tvec2<T, P> const & v);
+	GLM_FUNC_DECL tvec2<T, P> operator%(T const & scalar, tvec2<T, P> const & v);
 
 	template <typename T, precision P>
 	GLM_FUNC_DECL tvec2<T, P> operator%(tvec1<T, P> const & v1, tvec2<T, P> const & v2);
@@ -314,13 +314,13 @@ namespace glm
 	GLM_FUNC_DECL tvec2<T, P> operator%(tvec2<T, P> const & v1, tvec2<T, P> const & v2);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec2<T, P> operator&(tvec2<T, P> const & v, T const & s);
+	GLM_FUNC_DECL tvec2<T, P> operator&(tvec2<T, P> const & v, T const & scalar);
 
 	template <typename T, precision P>
 	GLM_FUNC_DECL tvec2<T, P> operator&(tvec2<T, P> const & v1, tvec1<T, P> const & v2);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec2<T, P> operator&(T const & s, tvec2<T, P> const & v);
+	GLM_FUNC_DECL tvec2<T, P> operator&(T const & scalar, tvec2<T, P> const & v);
 
 	template <typename T, precision P>
 	GLM_FUNC_DECL tvec2<T, P> operator&(tvec1<T, P> const & v1, tvec2<T, P> const & v2);
@@ -329,13 +329,13 @@ namespace glm
 	GLM_FUNC_DECL tvec2<T, P> operator&(tvec2<T, P> const & v1, tvec2<T, P> const & v2);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec2<T, P> operator|(tvec2<T, P> const & v, T const & s);
+	GLM_FUNC_DECL tvec2<T, P> operator|(tvec2<T, P> const & v, T const & scalar);
 
 	template <typename T, precision P>
 	GLM_FUNC_DECL tvec2<T, P> operator|(tvec2<T, P> const & v1, tvec1<T, P> const & v2);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec2<T, P> operator|(T const & s, tvec2<T, P> const & v);
+	GLM_FUNC_DECL tvec2<T, P> operator|(T const & scalar, tvec2<T, P> const & v);
 
 	template <typename T, precision P>
 	GLM_FUNC_DECL tvec2<T, P> operator|(tvec1<T, P> const & v1, tvec2<T, P> const & v2);
@@ -344,13 +344,13 @@ namespace glm
 	GLM_FUNC_DECL tvec2<T, P> operator|(tvec2<T, P> const & v1, tvec2<T, P> const & v2);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec2<T, P> operator^(tvec2<T, P> const & v, T const & s);
+	GLM_FUNC_DECL tvec2<T, P> operator^(tvec2<T, P> const & v, T const & scalar);
 
 	template <typename T, precision P>
 	GLM_FUNC_DECL tvec2<T, P> operator^(tvec2<T, P> const & v1, tvec1<T, P> const & v2);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec2<T, P> operator^(T const & s, tvec2<T, P> const & v);
+	GLM_FUNC_DECL tvec2<T, P> operator^(T const & scalar, tvec2<T, P> const & v);
 
 	template <typename T, precision P>
 	GLM_FUNC_DECL tvec2<T, P> operator^(tvec1<T, P> const & v1, tvec2<T, P> const & v2);
@@ -359,13 +359,13 @@ namespace glm
 	GLM_FUNC_DECL tvec2<T, P> operator^(tvec2<T, P> const & v1, tvec2<T, P> const & v2);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec2<T, P> operator<<(tvec2<T, P> const & v, T const & s);
+	GLM_FUNC_DECL tvec2<T, P> operator<<(tvec2<T, P> const & v, T const & scalar);
 
 	template <typename T, precision P>
 	GLM_FUNC_DECL tvec2<T, P> operator<<(tvec2<T, P> const & v1, tvec1<T, P> const & v2);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec2<T, P> operator<<(T const & s, tvec2<T, P> const & v);
+	GLM_FUNC_DECL tvec2<T, P> operator<<(T const & scalar, tvec2<T, P> const & v);
 
 	template <typename T, precision P>
 	GLM_FUNC_DECL tvec2<T, P> operator<<(tvec1<T, P> const & v1, tvec2<T, P> const & v2);
@@ -374,13 +374,13 @@ namespace glm
 	GLM_FUNC_DECL tvec2<T, P> operator<<(tvec2<T, P> const & v1, tvec2<T, P> const & v2);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec2<T, P> operator>>(tvec2<T, P> const & v, T const & s);
+	GLM_FUNC_DECL tvec2<T, P> operator>>(tvec2<T, P> const & v, T const & scalar);
 
 	template <typename T, precision P>
 	GLM_FUNC_DECL tvec2<T, P> operator>>(tvec2<T, P> const & v1, tvec1<T, P> const & v2);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec2<T, P> operator>>(T const & s, tvec2<T, P> const & v);
+	GLM_FUNC_DECL tvec2<T, P> operator>>(T const & scalar, tvec2<T, P> const & v);
 
 	template <typename T, precision P>
 	GLM_FUNC_DECL tvec2<T, P> operator>>(tvec1<T, P> const & v1, tvec2<T, P> const & v2);

--- a/glm/detail/type_vec2.inl
+++ b/glm/detail/type_vec2.inl
@@ -59,8 +59,8 @@ namespace glm
 	{}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tvec2<T, P>::tvec2(T const & s)
-		: x(s), y(s)
+	GLM_FUNC_QUALIFIER tvec2<T, P>::tvec2(T const & scalar)
+		: x(scalar), y(scalar)
 	{}
 
 	template <typename T, precision P>
@@ -174,10 +174,10 @@ namespace glm
 
 	template <typename T, precision P>
 	template <typename U>
-	GLM_FUNC_QUALIFIER tvec2<T, P> & tvec2<T, P>::operator+=(U s)
+	GLM_FUNC_QUALIFIER tvec2<T, P> & tvec2<T, P>::operator+=(U scalar)
 	{
-		this->x += static_cast<T>(s);
-		this->y += static_cast<T>(s);
+		this->x += static_cast<T>(scalar);
+		this->y += static_cast<T>(scalar);
 		return *this;
 	}
 
@@ -201,10 +201,10 @@ namespace glm
 
 	template <typename T, precision P>
 	template <typename U>
-	GLM_FUNC_QUALIFIER tvec2<T, P> & tvec2<T, P>::operator-=(U s)
+	GLM_FUNC_QUALIFIER tvec2<T, P> & tvec2<T, P>::operator-=(U scalar)
 	{
-		this->x -= static_cast<T>(s);
-		this->y -= static_cast<T>(s);
+		this->x -= static_cast<T>(scalar);
+		this->y -= static_cast<T>(scalar);
 		return *this;
 	}
 
@@ -228,10 +228,10 @@ namespace glm
 
 	template <typename T, precision P>
 	template <typename U>
-	GLM_FUNC_QUALIFIER tvec2<T, P> & tvec2<T, P>::operator*=(U s)
+	GLM_FUNC_QUALIFIER tvec2<T, P> & tvec2<T, P>::operator*=(U scalar)
 	{
-		this->x *= static_cast<T>(s);
-		this->y *= static_cast<T>(s);
+		this->x *= static_cast<T>(scalar);
+		this->y *= static_cast<T>(scalar);
 		return *this;
 	}
 
@@ -255,10 +255,10 @@ namespace glm
 
 	template <typename T, precision P>
 	template <typename U>
-	GLM_FUNC_QUALIFIER tvec2<T, P> & tvec2<T, P>::operator/=(U s)
+	GLM_FUNC_QUALIFIER tvec2<T, P> & tvec2<T, P>::operator/=(U scalar)
 	{
-		this->x /= static_cast<T>(s);
-		this->y /= static_cast<T>(s);
+		this->x /= static_cast<T>(scalar);
+		this->y /= static_cast<T>(scalar);
 		return *this;
 	}
 
@@ -318,10 +318,10 @@ namespace glm
 
 	template <typename T, precision P>
 	template <typename U>
-	GLM_FUNC_QUALIFIER tvec2<T, P> & tvec2<T, P>::operator%=(U s)
+	GLM_FUNC_QUALIFIER tvec2<T, P> & tvec2<T, P>::operator%=(U scalar)
 	{
-		this->x %= static_cast<T>(s);
-		this->y %= static_cast<T>(s);
+		this->x %= static_cast<T>(scalar);
+		this->y %= static_cast<T>(scalar);
 		return *this;
 	}
 
@@ -345,10 +345,10 @@ namespace glm
 
 	template <typename T, precision P>
 	template <typename U>
-	GLM_FUNC_QUALIFIER tvec2<T, P> & tvec2<T, P>::operator&=(U s)
+	GLM_FUNC_QUALIFIER tvec2<T, P> & tvec2<T, P>::operator&=(U scalar)
 	{
-		this->x &= static_cast<T>(s);
-		this->y &= static_cast<T>(s);
+		this->x &= static_cast<T>(scalar);
+		this->y &= static_cast<T>(scalar);
 		return *this;
 	}
 
@@ -372,10 +372,10 @@ namespace glm
 
 	template <typename T, precision P>
 	template <typename U>
-	GLM_FUNC_QUALIFIER tvec2<T, P> & tvec2<T, P>::operator|=(U s)
+	GLM_FUNC_QUALIFIER tvec2<T, P> & tvec2<T, P>::operator|=(U scalar)
 	{
-		this->x |= static_cast<T>(s);
-		this->y |= static_cast<T>(s);
+		this->x |= static_cast<T>(scalar);
+		this->y |= static_cast<T>(scalar);
 		return *this;
 	}
 
@@ -399,10 +399,10 @@ namespace glm
 
 	template <typename T, precision P>
 	template <typename U>
-	GLM_FUNC_QUALIFIER tvec2<T, P> & tvec2<T, P>::operator^=(U s)
+	GLM_FUNC_QUALIFIER tvec2<T, P> & tvec2<T, P>::operator^=(U scalar)
 	{
-		this->x ^= static_cast<T>(s);
-		this->y ^= static_cast<T>(s);
+		this->x ^= static_cast<T>(scalar);
+		this->y ^= static_cast<T>(scalar);
 		return *this;
 	}
 
@@ -426,10 +426,10 @@ namespace glm
 
 	template <typename T, precision P>
 	template <typename U>
-	GLM_FUNC_QUALIFIER tvec2<T, P> & tvec2<T, P>::operator<<=(U s)
+	GLM_FUNC_QUALIFIER tvec2<T, P> & tvec2<T, P>::operator<<=(U scalar)
 	{
-		this->x <<= static_cast<T>(s);
-		this->y <<= static_cast<T>(s);
+		this->x <<= static_cast<T>(scalar);
+		this->y <<= static_cast<T>(scalar);
 		return *this;
 	}
 
@@ -453,10 +453,10 @@ namespace glm
 
 	template <typename T, precision P>
 	template <typename U>
-	GLM_FUNC_QUALIFIER tvec2<T, P> & tvec2<T, P>::operator>>=(U s)
+	GLM_FUNC_QUALIFIER tvec2<T, P> & tvec2<T, P>::operator>>=(U scalar)
 	{
-		this->x >>= static_cast<T>(s);
-		this->y >>= static_cast<T>(s);
+		this->x >>= static_cast<T>(scalar);
+		this->y >>= static_cast<T>(scalar);
 		return *this;
 	}
 
@@ -491,11 +491,11 @@ namespace glm
 	// -- Binary arithmetic operators --
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tvec2<T, P> operator+(tvec2<T, P> const & v, T const & s)
+	GLM_FUNC_QUALIFIER tvec2<T, P> operator+(tvec2<T, P> const & v, T const & scalar)
 	{
 		return tvec2<T, P>(
-			v.x + s,
-			v.y + s);
+			v.x + scalar,
+			v.y + scalar);
 	}
 
 	template <typename T, precision P>
@@ -507,11 +507,11 @@ namespace glm
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tvec2<T, P> operator+(T const & s, tvec2<T, P> const & v)
+	GLM_FUNC_QUALIFIER tvec2<T, P> operator+(T const & scalar, tvec2<T, P> const & v)
 	{
 		return tvec2<T, P>(
-			s + v.x,
-			s + v.y);
+			scalar + v.x,
+			scalar + v.y);
 	}
 
 	template <typename T, precision P>
@@ -531,11 +531,11 @@ namespace glm
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tvec2<T, P> operator-(tvec2<T, P> const & v, T const & s)
+	GLM_FUNC_QUALIFIER tvec2<T, P> operator-(tvec2<T, P> const & v, T const & scalar)
 	{
 		return tvec2<T, P>(
-			v.x - s,
-			v.y - s);
+			v.x - scalar,
+			v.y - scalar);
 	}
 
 	template <typename T, precision P>
@@ -547,11 +547,11 @@ namespace glm
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tvec2<T, P> operator-(T const & s, tvec2<T, P> const & v)
+	GLM_FUNC_QUALIFIER tvec2<T, P> operator-(T const & scalar, tvec2<T, P> const & v)
 	{
 		return tvec2<T, P>(
-			s - v.x,
-			s - v.y);
+			scalar - v.x,
+			scalar - v.y);
 	}
 
 	template <typename T, precision P>
@@ -587,11 +587,11 @@ namespace glm
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tvec2<T, P> operator*(T const & s, tvec2<T, P> const & v)
+	GLM_FUNC_QUALIFIER tvec2<T, P> operator*(T const & scalar, tvec2<T, P> const & v)
 	{
 		return tvec2<T, P>(
-			s * v.x,
-			s * v.y);
+			scalar * v.x,
+			scalar * v.y);
 	}
 
 	template <typename T, precision P>
@@ -611,11 +611,11 @@ namespace glm
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tvec2<T, P> operator/(tvec2<T, P> const & v, T const & s)
+	GLM_FUNC_QUALIFIER tvec2<T, P> operator/(tvec2<T, P> const & v, T const & scalar)
 	{
 		return tvec2<T, P>(
-			v.x / s,
-			v.y / s);
+			v.x / scalar,
+			v.y / scalar);
 	}
 
 	template <typename T, precision P>
@@ -627,11 +627,11 @@ namespace glm
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tvec2<T, P> operator/(T const & s, tvec2<T, P> const & v)
+	GLM_FUNC_QUALIFIER tvec2<T, P> operator/(T const & scalar, tvec2<T, P> const & v)
 	{
 		return tvec2<T, P>(
-			s / v.x,
-			s / v.y);
+			scalar / v.x,
+			scalar / v.y);
 	}
 
 	template <typename T, precision P>
@@ -653,11 +653,11 @@ namespace glm
 	// -- Binary bit operators --
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tvec2<T, P> operator%(tvec2<T, P> const & v, T const & s)
+	GLM_FUNC_QUALIFIER tvec2<T, P> operator%(tvec2<T, P> const & v, T const & scalar)
 	{
 		return tvec2<T, P>(
-			v.x % s,
-			v.y % s);
+			v.x % scalar,
+			v.y % scalar);
 	}
 
 	template <typename T, precision P>
@@ -669,11 +669,11 @@ namespace glm
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tvec2<T, P> operator%(T const & s, tvec2<T, P> const & v)
+	GLM_FUNC_QUALIFIER tvec2<T, P> operator%(T const & scalar, tvec2<T, P> const & v)
 	{
 		return tvec2<T, P>(
-			s % v.x,
-			s % v.y);
+			scalar % v.x,
+			scalar % v.y);
 	}
 
 	template <typename T, precision P>
@@ -693,11 +693,11 @@ namespace glm
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tvec2<T, P> operator&(tvec2<T, P> const & v, T const & s)
+	GLM_FUNC_QUALIFIER tvec2<T, P> operator&(tvec2<T, P> const & v, T const & scalar)
 	{
 		return tvec2<T, P>(
-			v.x & s,
-			v.y & s);
+			v.x & scalar,
+			v.y & scalar);
 	}
 
 	template <typename T, precision P>
@@ -709,11 +709,11 @@ namespace glm
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tvec2<T, P> operator&(T const & s, tvec2<T, P> const & v)
+	GLM_FUNC_QUALIFIER tvec2<T, P> operator&(T const & scalar, tvec2<T, P> const & v)
 	{
 		return tvec2<T, P>(
-			s & v.x,
-			s & v.y);
+			scalar & v.x,
+			scalar & v.y);
 	}
 
 	template <typename T, precision P>
@@ -733,11 +733,11 @@ namespace glm
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tvec2<T, P> operator|(tvec2<T, P> const & v, T const & s)
+	GLM_FUNC_QUALIFIER tvec2<T, P> operator|(tvec2<T, P> const & v, T const & scalar)
 	{
 		return tvec2<T, P>(
-			v.x | s,
-			v.y | s);
+			v.x | scalar,
+			v.y | scalar);
 	}
 
 	template <typename T, precision P>
@@ -749,11 +749,11 @@ namespace glm
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tvec2<T, P> operator|(T const & s, tvec2<T, P> const & v)
+	GLM_FUNC_QUALIFIER tvec2<T, P> operator|(T const & scalar, tvec2<T, P> const & v)
 	{
 		return tvec2<T, P>(
-			s | v.x,
-			s | v.y);
+			scalar | v.x,
+			scalar | v.y);
 	}
 
 	template <typename T, precision P>
@@ -773,11 +773,11 @@ namespace glm
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tvec2<T, P> operator^(tvec2<T, P> const & v, T const & s)
+	GLM_FUNC_QUALIFIER tvec2<T, P> operator^(tvec2<T, P> const & v, T const & scalar)
 	{
 		return tvec2<T, P>(
-			v.x ^ s,
-			v.y ^ s);
+			v.x ^ scalar,
+			v.y ^ scalar);
 	}
 
 	template <typename T, precision P>
@@ -789,11 +789,11 @@ namespace glm
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tvec2<T, P> operator^(T const & s, tvec2<T, P> const & v)
+	GLM_FUNC_QUALIFIER tvec2<T, P> operator^(T const & scalar, tvec2<T, P> const & v)
 	{
 		return tvec2<T, P>(
-			s ^ v.x,
-			s ^ v.y);
+			scalar ^ v.x,
+			scalar ^ v.y);
 	}
 
 	template <typename T, precision P>
@@ -813,11 +813,11 @@ namespace glm
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tvec2<T, P> operator<<(tvec2<T, P> const & v, T const & s)
+	GLM_FUNC_QUALIFIER tvec2<T, P> operator<<(tvec2<T, P> const & v, T const & scalar)
 	{
 		return tvec2<T, P>(
-			v.x << s,
-			v.y << s);
+			v.x << scalar,
+			v.y << scalar);
 	}
 
 	template <typename T, precision P>
@@ -829,11 +829,11 @@ namespace glm
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tvec2<T, P> operator<<(T const & s, tvec2<T, P> const & v)
+	GLM_FUNC_QUALIFIER tvec2<T, P> operator<<(T const & scalar, tvec2<T, P> const & v)
 	{
 		return tvec2<T, P>(
-			s << v.x,
-			s << v.y);
+			scalar << v.x,
+			scalar << v.y);
 	}
 
 	template <typename T, precision P>
@@ -853,11 +853,11 @@ namespace glm
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tvec2<T, P> operator>>(tvec2<T, P> const & v, T const & s)
+	GLM_FUNC_QUALIFIER tvec2<T, P> operator>>(tvec2<T, P> const & v, T const & scalar)
 	{
 		return tvec2<T, P>(
-			v.x >> s,
-			v.y >> s);
+			v.x >> scalar,
+			v.y >> scalar);
 	}
 
 	template <typename T, precision P>
@@ -869,11 +869,11 @@ namespace glm
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tvec2<T, P> operator>>(T const & s, tvec2<T, P> const & v)
+	GLM_FUNC_QUALIFIER tvec2<T, P> operator>>(T const & scalar, tvec2<T, P> const & v)
 	{
 		return tvec2<T, P>(
-			s >> v.x,
-			s >> v.y);
+			scalar >> v.x,
+			scalar >> v.y);
 	}
 
 	template <typename T, precision P>

--- a/glm/detail/type_vec3.hpp
+++ b/glm/detail/type_vec3.hpp
@@ -117,7 +117,7 @@ namespace glm
 		// -- Explicit basic constructors --
 
 		GLM_FUNC_DECL explicit tvec3(ctor);
-		GLM_FUNC_DECL explicit tvec3(T const & s);
+		GLM_FUNC_DECL explicit tvec3(T const & scalar);
 		GLM_FUNC_DECL tvec3(T const & a, T const & b, T const & c);
 
 		// -- Conversion scalar constructors --
@@ -160,15 +160,15 @@ namespace glm
 			}
 
 			template <int E0, int E1>
-			GLM_FUNC_DECL tvec3(detail::_swizzle<2, T, P, tvec2<T, P>, E0, E1, -1, -2> const & v, T const & s)
+			GLM_FUNC_DECL tvec3(detail::_swizzle<2, T, P, tvec2<T, P>, E0, E1, -1, -2> const & v, T const & scalar)
 			{
-				*this = tvec3<T, P>(v(), s);
+				*this = tvec3<T, P>(v(), scalar);
 			}
 
 			template <int E0, int E1>
-			GLM_FUNC_DECL tvec3(T const & s, detail::_swizzle<2, T, P, tvec2<T, P>, E0, E1, -1, -2> const & v)
+			GLM_FUNC_DECL tvec3(T const & scalar, detail::_swizzle<2, T, P, tvec2<T, P>, E0, E1, -1, -2> const & v)
 			{
-				*this = tvec3<T, P>(s, v());
+				*this = tvec3<T, P>(scalar, v());
 			}
 #		endif// GLM_HAS_ANONYMOUS_UNION && defined(GLM_SWIZZLE)
 
@@ -179,25 +179,25 @@ namespace glm
 		template <typename U>
 		GLM_FUNC_DECL tvec3<T, P> & operator=(tvec3<U, P> const & v);
 		template <typename U>
-		GLM_FUNC_DECL tvec3<T, P> & operator+=(U s);
+		GLM_FUNC_DECL tvec3<T, P> & operator+=(U scalar);
 		template <typename U>
 		GLM_FUNC_DECL tvec3<T, P> & operator+=(tvec1<U, P> const & v);
 		template <typename U>
 		GLM_FUNC_DECL tvec3<T, P> & operator+=(tvec3<U, P> const & v);
 		template <typename U>
-		GLM_FUNC_DECL tvec3<T, P> & operator-=(U s);
+		GLM_FUNC_DECL tvec3<T, P> & operator-=(U scalar);
 		template <typename U>
 		GLM_FUNC_DECL tvec3<T, P> & operator-=(tvec1<U, P> const & v);
 		template <typename U>
 		GLM_FUNC_DECL tvec3<T, P> & operator-=(tvec3<U, P> const & v);
 		template <typename U>
-		GLM_FUNC_DECL tvec3<T, P> & operator*=(U s);
+		GLM_FUNC_DECL tvec3<T, P> & operator*=(U scalar);
 		template <typename U>
 		GLM_FUNC_DECL tvec3<T, P> & operator*=(tvec1<U, P> const & v);
 		template <typename U>
 		GLM_FUNC_DECL tvec3<T, P> & operator*=(tvec3<U, P> const & v);
 		template <typename U>
-		GLM_FUNC_DECL tvec3<T, P> & operator/=(U s);
+		GLM_FUNC_DECL tvec3<T, P> & operator/=(U scalar);
 		template <typename U>
 		GLM_FUNC_DECL tvec3<T, P> & operator/=(tvec1<U, P> const & v);
 		template <typename U>
@@ -213,37 +213,37 @@ namespace glm
 		// -- Unary bit operators --
 
 		template <typename U>
-		GLM_FUNC_DECL tvec3<T, P> & operator%=(U s);
+		GLM_FUNC_DECL tvec3<T, P> & operator%=(U scalar);
 		template <typename U>
 		GLM_FUNC_DECL tvec3<T, P> & operator%=(tvec1<U, P> const & v);
 		template <typename U>
 		GLM_FUNC_DECL tvec3<T, P> & operator%=(tvec3<U, P> const & v);
 		template <typename U>
-		GLM_FUNC_DECL tvec3<T, P> & operator&=(U s);
+		GLM_FUNC_DECL tvec3<T, P> & operator&=(U scalar);
 		template <typename U>
 		GLM_FUNC_DECL tvec3<T, P> & operator&=(tvec1<U, P> const & v);
 		template <typename U>
 		GLM_FUNC_DECL tvec3<T, P> & operator&=(tvec3<U, P> const & v);
 		template <typename U>
-		GLM_FUNC_DECL tvec3<T, P> & operator|=(U s);
+		GLM_FUNC_DECL tvec3<T, P> & operator|=(U scalar);
 		template <typename U>
 		GLM_FUNC_DECL tvec3<T, P> & operator|=(tvec1<U, P> const & v);
 		template <typename U>
 		GLM_FUNC_DECL tvec3<T, P> & operator|=(tvec3<U, P> const & v);
 		template <typename U>
-		GLM_FUNC_DECL tvec3<T, P> & operator^=(U s);
+		GLM_FUNC_DECL tvec3<T, P> & operator^=(U scalar);
 		template <typename U>
 		GLM_FUNC_DECL tvec3<T, P> & operator^=(tvec1<U, P> const & v);
 		template <typename U>
 		GLM_FUNC_DECL tvec3<T, P> & operator^=(tvec3<U, P> const & v);
 		template <typename U>
-		GLM_FUNC_DECL tvec3<T, P> & operator<<=(U s);
+		GLM_FUNC_DECL tvec3<T, P> & operator<<=(U scalar);
 		template <typename U>
 		GLM_FUNC_DECL tvec3<T, P> & operator<<=(tvec1<U, P> const & v);
 		template <typename U>
 		GLM_FUNC_DECL tvec3<T, P> & operator<<=(tvec3<U, P> const & v);
 		template <typename U>
-		GLM_FUNC_DECL tvec3<T, P> & operator>>=(U s);
+		GLM_FUNC_DECL tvec3<T, P> & operator>>=(U scalar);
 		template <typename U>
 		GLM_FUNC_DECL tvec3<T, P> & operator>>=(tvec1<U, P> const & v);
 		template <typename U>
@@ -258,151 +258,151 @@ namespace glm
 	// -- Binary operators --
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec3<T, P> operator+(tvec3<T, P> const & v, T const & s);
+	GLM_FUNC_DECL tvec3<T, P> operator+(tvec3<T, P> const & v, T const & scalar);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec3<T, P> operator+(tvec3<T, P> const & v, tvec1<T, P> const & s);
+	GLM_FUNC_DECL tvec3<T, P> operator+(tvec3<T, P> const & v, tvec1<T, P> const & scalar);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec3<T, P> operator+(T const & s, tvec3<T, P> const & v);
+	GLM_FUNC_DECL tvec3<T, P> operator+(T const & scalar, tvec3<T, P> const & v);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec3<T, P> operator+(tvec1<T, P> const & s, tvec3<T, P> const & v);
+	GLM_FUNC_DECL tvec3<T, P> operator+(tvec1<T, P> const & scalar, tvec3<T, P> const & v);
 
 	template <typename T, precision P>
 	GLM_FUNC_DECL tvec3<T, P> operator+(tvec3<T, P> const & v1, tvec3<T, P> const & v2);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec3<T, P> operator-(tvec3<T, P> const & v, T const & s);
+	GLM_FUNC_DECL tvec3<T, P> operator-(tvec3<T, P> const & v, T const & scalar);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec3<T, P> operator-(tvec3<T, P> const & v, tvec1<T, P> const & s);
+	GLM_FUNC_DECL tvec3<T, P> operator-(tvec3<T, P> const & v, tvec1<T, P> const & scalar);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec3<T, P> operator-(T const & s, tvec3<T, P> const & v);
+	GLM_FUNC_DECL tvec3<T, P> operator-(T const & scalar, tvec3<T, P> const & v);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec3<T, P> operator-(tvec1<T, P> const & s, tvec3<T, P> const & v);
+	GLM_FUNC_DECL tvec3<T, P> operator-(tvec1<T, P> const & scalar, tvec3<T, P> const & v);
 
 	template <typename T, precision P>
 	GLM_FUNC_DECL tvec3<T, P> operator-(tvec3<T, P> const & v1, tvec3<T, P> const & v2);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec3<T, P> operator*(tvec3<T, P> const & v, T const & s);
+	GLM_FUNC_DECL tvec3<T, P> operator*(tvec3<T, P> const & v, T const & scalar);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec3<T, P> operator*(tvec3<T, P> const & v, tvec1<T, P> const & s);
+	GLM_FUNC_DECL tvec3<T, P> operator*(tvec3<T, P> const & v, tvec1<T, P> const & scalar);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec3<T, P> operator*(T const & s, tvec3<T, P> const & v);
+	GLM_FUNC_DECL tvec3<T, P> operator*(T const & scalar, tvec3<T, P> const & v);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec3<T, P> operator*(tvec1<T, P> const & s, tvec3<T, P> const & v);
+	GLM_FUNC_DECL tvec3<T, P> operator*(tvec1<T, P> const & scalar, tvec3<T, P> const & v);
 
 	template <typename T, precision P>
 	GLM_FUNC_DECL tvec3<T, P> operator*(tvec3<T, P> const & v1, tvec3<T, P> const & v2);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec3<T, P> operator/(tvec3<T, P> const & v, T const & s);
+	GLM_FUNC_DECL tvec3<T, P> operator/(tvec3<T, P> const & v, T const & scalar);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec3<T, P> operator/(tvec3<T, P> const & v, tvec1<T, P> const & s);
+	GLM_FUNC_DECL tvec3<T, P> operator/(tvec3<T, P> const & v, tvec1<T, P> const & scalar);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec3<T, P> operator/(T const & s, tvec3<T, P> const & v);
+	GLM_FUNC_DECL tvec3<T, P> operator/(T const & scalar, tvec3<T, P> const & v);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec3<T, P> operator/(tvec1<T, P> const & s, tvec3<T, P> const & v);
+	GLM_FUNC_DECL tvec3<T, P> operator/(tvec1<T, P> const & scalar, tvec3<T, P> const & v);
 
 	template <typename T, precision P>
 	GLM_FUNC_DECL tvec3<T, P> operator/(tvec3<T, P> const & v1, tvec3<T, P> const & v2);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec3<T, P> operator%(tvec3<T, P> const & v, T const & s);
+	GLM_FUNC_DECL tvec3<T, P> operator%(tvec3<T, P> const & v, T const & scalar);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec3<T, P> operator%(tvec3<T, P> const & v, tvec1<T, P> const & s);
+	GLM_FUNC_DECL tvec3<T, P> operator%(tvec3<T, P> const & v, tvec1<T, P> const & scalar);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec3<T, P> operator%(T const & s, tvec3<T, P> const & v);
+	GLM_FUNC_DECL tvec3<T, P> operator%(T const & scalar, tvec3<T, P> const & v);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec3<T, P> operator%(tvec1<T, P> const & s, tvec3<T, P> const & v);
+	GLM_FUNC_DECL tvec3<T, P> operator%(tvec1<T, P> const & scalar, tvec3<T, P> const & v);
 
 	template <typename T, precision P>
 	GLM_FUNC_DECL tvec3<T, P> operator%(tvec3<T, P> const & v1, tvec3<T, P> const & v2);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec3<T, P> operator&(tvec3<T, P> const & v, T const & s);
+	GLM_FUNC_DECL tvec3<T, P> operator&(tvec3<T, P> const & v, T const & scalar);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec3<T, P> operator&(tvec3<T, P> const & v, tvec1<T, P> const & s);
+	GLM_FUNC_DECL tvec3<T, P> operator&(tvec3<T, P> const & v, tvec1<T, P> const & scalar);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec3<T, P> operator&(T const & s, tvec3<T, P> const & v);
+	GLM_FUNC_DECL tvec3<T, P> operator&(T const & scalar, tvec3<T, P> const & v);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec3<T, P> operator&(tvec1<T, P> const & s, tvec3<T, P> const & v);
+	GLM_FUNC_DECL tvec3<T, P> operator&(tvec1<T, P> const & scalar, tvec3<T, P> const & v);
 
 	template <typename T, precision P>
 	GLM_FUNC_DECL tvec3<T, P> operator&(tvec3<T, P> const & v1, tvec3<T, P> const & v2);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec3<T, P> operator|(tvec3<T, P> const & v, T const & s);
+	GLM_FUNC_DECL tvec3<T, P> operator|(tvec3<T, P> const & v, T const & scalar);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec3<T, P> operator|(tvec3<T, P> const & v, tvec1<T, P> const & s);
+	GLM_FUNC_DECL tvec3<T, P> operator|(tvec3<T, P> const & v, tvec1<T, P> const & scalar);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec3<T, P> operator|(T const & s, tvec3<T, P> const & v);
+	GLM_FUNC_DECL tvec3<T, P> operator|(T const & scalar, tvec3<T, P> const & v);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec3<T, P> operator|(tvec1<T, P> const & s, tvec3<T, P> const & v);
+	GLM_FUNC_DECL tvec3<T, P> operator|(tvec1<T, P> const & scalar, tvec3<T, P> const & v);
 
 	template <typename T, precision P>
 	GLM_FUNC_DECL tvec3<T, P> operator|(tvec3<T, P> const & v1, tvec3<T, P> const & v2);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec3<T, P> operator^(tvec3<T, P> const & v, T const & s);
+	GLM_FUNC_DECL tvec3<T, P> operator^(tvec3<T, P> const & v, T const & scalar);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec3<T, P> operator^(tvec3<T, P> const & v, tvec1<T, P> const & s);
+	GLM_FUNC_DECL tvec3<T, P> operator^(tvec3<T, P> const & v, tvec1<T, P> const & scalar);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec3<T, P> operator^(T const & s, tvec3<T, P> const & v);
+	GLM_FUNC_DECL tvec3<T, P> operator^(T const & scalar, tvec3<T, P> const & v);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec3<T, P> operator^(tvec1<T, P> const & s, tvec3<T, P> const & v);
+	GLM_FUNC_DECL tvec3<T, P> operator^(tvec1<T, P> const & scalar, tvec3<T, P> const & v);
 
 	template <typename T, precision P>
 	GLM_FUNC_DECL tvec3<T, P> operator^(tvec3<T, P> const & v1, tvec3<T, P> const & v2);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec3<T, P> operator<<(tvec3<T, P> const & v, T const & s);
+	GLM_FUNC_DECL tvec3<T, P> operator<<(tvec3<T, P> const & v, T const & scalar);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec3<T, P> operator<<(tvec3<T, P> const & v, tvec1<T, P> const & s);
+	GLM_FUNC_DECL tvec3<T, P> operator<<(tvec3<T, P> const & v, tvec1<T, P> const & scalar);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec3<T, P> operator<<(T const & s, tvec3<T, P> const & v);
+	GLM_FUNC_DECL tvec3<T, P> operator<<(T const & scalar, tvec3<T, P> const & v);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec3<T, P> operator<<(tvec1<T, P> const & s, tvec3<T, P> const & v);
+	GLM_FUNC_DECL tvec3<T, P> operator<<(tvec1<T, P> const & scalar, tvec3<T, P> const & v);
 
 	template <typename T, precision P>
 	GLM_FUNC_DECL tvec3<T, P> operator<<(tvec3<T, P> const & v1, tvec3<T, P> const & v2);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec3<T, P> operator>>(tvec3<T, P> const & v, T const & s);
+	GLM_FUNC_DECL tvec3<T, P> operator>>(tvec3<T, P> const & v, T const & scalar);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec3<T, P> operator>>(tvec3<T, P> const & v, tvec1<T, P> const & s);
+	GLM_FUNC_DECL tvec3<T, P> operator>>(tvec3<T, P> const & v, tvec1<T, P> const & scalar);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec3<T, P> operator>>(T const & s, tvec3<T, P> const & v);
+	GLM_FUNC_DECL tvec3<T, P> operator>>(T const & scalar, tvec3<T, P> const & v);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec3<T, P> operator>>(tvec1<T, P> const & s, tvec3<T, P> const & v);
+	GLM_FUNC_DECL tvec3<T, P> operator>>(tvec1<T, P> const & scalar, tvec3<T, P> const & v);
 
 	template <typename T, precision P>
 	GLM_FUNC_DECL tvec3<T, P> operator>>(tvec3<T, P> const & v1, tvec3<T, P> const & v2);

--- a/glm/detail/type_vec3.inl
+++ b/glm/detail/type_vec3.inl
@@ -63,8 +63,8 @@ namespace glm
 	{}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tvec3<T, P>::tvec3(T const & s)
-		: x(s), y(s), z(s)
+	GLM_FUNC_QUALIFIER tvec3<T, P>::tvec3(T const & scalar)
+		: x(scalar), y(scalar), z(scalar)
 	{}
 
 	template <typename T, precision P>
@@ -209,11 +209,11 @@ namespace glm
 
 	template <typename T, precision P>
 	template <typename U>
-	GLM_FUNC_QUALIFIER tvec3<T, P> & tvec3<T, P>::operator+=(U s)
+	GLM_FUNC_QUALIFIER tvec3<T, P> & tvec3<T, P>::operator+=(U scalar)
 	{
-		this->x += static_cast<T>(s);
-		this->y += static_cast<T>(s);
-		this->z += static_cast<T>(s);
+		this->x += static_cast<T>(scalar);
+		this->y += static_cast<T>(scalar);
+		this->z += static_cast<T>(scalar);
 		return *this;
 	}
 
@@ -239,11 +239,11 @@ namespace glm
 
 	template <typename T, precision P>
 	template <typename U>
-	GLM_FUNC_QUALIFIER tvec3<T, P> & tvec3<T, P>::operator-=(U s)
+	GLM_FUNC_QUALIFIER tvec3<T, P> & tvec3<T, P>::operator-=(U scalar)
 	{
-		this->x -= static_cast<T>(s);
-		this->y -= static_cast<T>(s);
-		this->z -= static_cast<T>(s);
+		this->x -= static_cast<T>(scalar);
+		this->y -= static_cast<T>(scalar);
+		this->z -= static_cast<T>(scalar);
 		return *this;
 	}
 
@@ -269,11 +269,11 @@ namespace glm
 
 	template <typename T, precision P>
 	template <typename U>
-	GLM_FUNC_QUALIFIER tvec3<T, P> & tvec3<T, P>::operator*=(U s)
+	GLM_FUNC_QUALIFIER tvec3<T, P> & tvec3<T, P>::operator*=(U scalar)
 	{
-		this->x *= static_cast<T>(s);
-		this->y *= static_cast<T>(s);
-		this->z *= static_cast<T>(s);
+		this->x *= static_cast<T>(scalar);
+		this->y *= static_cast<T>(scalar);
+		this->z *= static_cast<T>(scalar);
 		return *this;
 	}
 
@@ -299,11 +299,11 @@ namespace glm
 
 	template <typename T, precision P>
 	template <typename U>
-	GLM_FUNC_QUALIFIER tvec3<T, P> & tvec3<T, P>::operator/=(U s)
+	GLM_FUNC_QUALIFIER tvec3<T, P> & tvec3<T, P>::operator/=(U v)
 	{
-		this->x /= static_cast<T>(s);
-		this->y /= static_cast<T>(s);
-		this->z /= static_cast<T>(s);
+		this->x /= static_cast<T>(v);
+		this->y /= static_cast<T>(v);
+		this->z /= static_cast<T>(v);
 		return *this;
 	}
 
@@ -367,11 +367,11 @@ namespace glm
 
 	template <typename T, precision P>
 	template <typename U>
-	GLM_FUNC_QUALIFIER tvec3<T, P> & tvec3<T, P>::operator%=(U s)
+	GLM_FUNC_QUALIFIER tvec3<T, P> & tvec3<T, P>::operator%=(U scalar)
 	{
-		this->x %= s;
-		this->y %= s;
-		this->z %= s;
+		this->x %= scalar;
+		this->y %= scalar;
+		this->z %= scalar;
 		return *this;
 	}
 
@@ -397,11 +397,11 @@ namespace glm
 
 	template <typename T, precision P>
 	template <typename U>
-	GLM_FUNC_QUALIFIER tvec3<T, P> & tvec3<T, P>::operator&=(U s)
+	GLM_FUNC_QUALIFIER tvec3<T, P> & tvec3<T, P>::operator&=(U scalar)
 	{
-		this->x &= s;
-		this->y &= s;
-		this->z &= s;
+		this->x &= scalar;
+		this->y &= scalar;
+		this->z &= scalar;
 		return *this;
 	}
 
@@ -427,11 +427,11 @@ namespace glm
 
 	template <typename T, precision P>
 	template <typename U>
-	GLM_FUNC_QUALIFIER tvec3<T, P> & tvec3<T, P>::operator|=(U s)
+	GLM_FUNC_QUALIFIER tvec3<T, P> & tvec3<T, P>::operator|=(U scalar)
 	{
-		this->x |= s;
-		this->y |= s;
-		this->z |= s;
+		this->x |= scalar;
+		this->y |= scalar;
+		this->z |= scalar;
 		return *this;
 	}
 
@@ -457,11 +457,11 @@ namespace glm
 
 	template <typename T, precision P>
 	template <typename U> 
-	GLM_FUNC_QUALIFIER tvec3<T, P> & tvec3<T, P>::operator^=(U s)
+	GLM_FUNC_QUALIFIER tvec3<T, P> & tvec3<T, P>::operator^=(U scalar)
 	{
-		this->x ^= s;
-		this->y ^= s;
-		this->z ^= s;
+		this->x ^= scalar;
+		this->y ^= scalar;
+		this->z ^= scalar;
 		return *this;
 	}
 
@@ -487,11 +487,11 @@ namespace glm
 
 	template <typename T, precision P>
 	template <typename U> 
-	GLM_FUNC_QUALIFIER tvec3<T, P> & tvec3<T, P>::operator<<=(U s)
+	GLM_FUNC_QUALIFIER tvec3<T, P> & tvec3<T, P>::operator<<=(U scalar)
 	{
-		this->x <<= s;
-		this->y <<= s;
-		this->z <<= s;
+		this->x <<= scalar;
+		this->y <<= scalar;
+		this->z <<= scalar;
 		return *this;
 	}
 
@@ -517,11 +517,11 @@ namespace glm
 
 	template <typename T, precision P>
 	template <typename U> 
-	GLM_FUNC_QUALIFIER tvec3<T, P> & tvec3<T, P>::operator>>=(U s)
+	GLM_FUNC_QUALIFIER tvec3<T, P> & tvec3<T, P>::operator>>=(U scalar)
 	{
-		this->x >>= static_cast<T>(s);
-		this->y >>= static_cast<T>(s);
-		this->z >>= static_cast<T>(s);
+		this->x >>= static_cast<T>(scalar);
+		this->y >>= static_cast<T>(scalar);
+		this->z >>= static_cast<T>(scalar);
 		return *this;
 	}
 
@@ -559,39 +559,39 @@ namespace glm
 	// -- Binary arithmetic operators --
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tvec3<T, P> operator+(tvec3<T, P> const & v, T const & s)
+	GLM_FUNC_QUALIFIER tvec3<T, P> operator+(tvec3<T, P> const & v, T const & scalar)
 	{
 		return tvec3<T, P>(
-			v.x + s,
-			v.y + s,
-			v.z + s);
+			v.x + scalar,
+			v.y + scalar,
+			v.z + scalar);
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tvec3<T, P> operator+(tvec3<T, P> const & v, tvec1<T, P> const & s)
+	GLM_FUNC_QUALIFIER tvec3<T, P> operator+(tvec3<T, P> const & v, tvec1<T, P> const & scalar)
 	{
 		return tvec3<T, P>(
-			v.x + s.x,
-			v.y + s.x,
-			v.z + s.x);
+			v.x + scalar.x,
+			v.y + scalar.x,
+			v.z + scalar.x);
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tvec3<T, P> operator+(T const & s, tvec3<T, P> const & v)
+	GLM_FUNC_QUALIFIER tvec3<T, P> operator+(T const & scalar, tvec3<T, P> const & v)
 	{
 		return tvec3<T, P>(
-			s + v.x,
-			s + v.y,
-			s + v.z);
+			scalar + v.x,
+			scalar + v.y,
+			scalar + v.z);
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tvec3<T, P> operator+(tvec1<T, P> const & s, tvec3<T, P> const & v)
+	GLM_FUNC_QUALIFIER tvec3<T, P> operator+(tvec1<T, P> const & scalar, tvec3<T, P> const & v)
 	{
 		return tvec3<T, P>(
-			s.x + v.x,
-			s.x + v.y,
-			s.x + v.z);
+			scalar.x + v.x,
+			scalar.x + v.y,
+			scalar.x + v.z);
 	}
 
 	template <typename T, precision P>
@@ -604,39 +604,39 @@ namespace glm
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tvec3<T, P> operator-(tvec3<T, P> const & v, T const & s)
+	GLM_FUNC_QUALIFIER tvec3<T, P> operator-(tvec3<T, P> const & v, T const & scalar)
 	{
 		return tvec3<T, P>(
-			v.x - s,
-			v.y - s,
-			v.z - s);
+			v.x - scalar,
+			v.y - scalar,
+			v.z - scalar);
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tvec3<T, P> operator-(tvec3<T, P> const & v, tvec1<T, P> const & s)
+	GLM_FUNC_QUALIFIER tvec3<T, P> operator-(tvec3<T, P> const & v, tvec1<T, P> const & scalar)
 	{
 		return tvec3<T, P>(
-			v.x - s.x,
-			v.y - s.x,
-			v.z - s.x);
+			v.x - scalar.x,
+			v.y - scalar.x,
+			v.z - scalar.x);
 	}
 
 	template <typename T, precision P> 
-	GLM_FUNC_QUALIFIER tvec3<T, P> operator-(T const & s, tvec3<T, P> const & v)
+	GLM_FUNC_QUALIFIER tvec3<T, P> operator-(T const & scalar, tvec3<T, P> const & v)
 	{
 		return tvec3<T, P>(
-			s - v.x,
-			s - v.y,
-			s - v.z);
+			scalar - v.x,
+			scalar - v.y,
+			scalar - v.z);
 	}
 
 	template <typename T, precision P> 
-	GLM_FUNC_QUALIFIER tvec3<T, P> operator-(tvec1<T, P> const & s, tvec3<T, P> const & v)
+	GLM_FUNC_QUALIFIER tvec3<T, P> operator-(tvec1<T, P> const & scalar, tvec3<T, P> const & v)
 	{
 		return tvec3<T, P>(
-			s.x - v.x,
-			s.x - v.y,
-			s.x - v.z);
+			scalar.x - v.x,
+			scalar.x - v.y,
+			scalar.x - v.z);
 	}
 
 	template <typename T, precision P>
@@ -649,39 +649,39 @@ namespace glm
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tvec3<T, P> operator*(tvec3<T, P> const & v, T const & s)
+	GLM_FUNC_QUALIFIER tvec3<T, P> operator*(tvec3<T, P> const & v, T const & scalar)
 	{
 		return tvec3<T, P>(
-			v.x * s,
-			v.y * s,
-			v.z * s);
+			v.x * scalar,
+			v.y * scalar,
+			v.z * scalar);
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tvec3<T, P> operator*(tvec3<T, P> const & v, tvec1<T, P> const & s)
+	GLM_FUNC_QUALIFIER tvec3<T, P> operator*(tvec3<T, P> const & v, tvec1<T, P> const & scalar)
 	{
 		return tvec3<T, P>(
-			v.x * s.x,
-			v.y * s.x,
-			v.z * s.x);
+			v.x * scalar.x,
+			v.y * scalar.x,
+			v.z * scalar.x);
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tvec3<T, P> operator*(T const & s, tvec3<T, P> const & v)
+	GLM_FUNC_QUALIFIER tvec3<T, P> operator*(T const & scalar, tvec3<T, P> const & v)
 	{
 		return tvec3<T, P>(
-			s * v.x,
-			s * v.y,
-			s * v.z);
+			scalar * v.x,
+			scalar * v.y,
+			scalar * v.z);
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tvec3<T, P> operator*(tvec1<T, P> const & s, tvec3<T, P> const & v)
+	GLM_FUNC_QUALIFIER tvec3<T, P> operator*(tvec1<T, P> const & scalar, tvec3<T, P> const & v)
 	{
 		return tvec3<T, P>(
-			s.x * v.x,
-			s.x * v.y,
-			s.x * v.z);
+			scalar.x * v.x,
+			scalar.x * v.y,
+			scalar.x * v.z);
 	}
 
 	template <typename T, precision P>
@@ -694,39 +694,39 @@ namespace glm
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tvec3<T, P> operator/(tvec3<T, P> const & v, T const & s)
+	GLM_FUNC_QUALIFIER tvec3<T, P> operator/(tvec3<T, P> const & v, T const & scalar)
 	{
 		return tvec3<T, P>(
-			v.x / s,
-			v.y / s,
-			v.z / s);
+			v.x / scalar,
+			v.y / scalar,
+			v.z / scalar);
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tvec3<T, P> operator/(tvec3<T, P> const & v, tvec1<T, P> const & s)
+	GLM_FUNC_QUALIFIER tvec3<T, P> operator/(tvec3<T, P> const & v, tvec1<T, P> const & scalar)
 	{
 		return tvec3<T, P>(
-			v.x / s.x,
-			v.y / s.x,
-			v.z / s.x);
+			v.x / scalar.x,
+			v.y / scalar.x,
+			v.z / scalar.x);
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tvec3<T, P> operator/(T const & s, tvec3<T, P> const & v)
+	GLM_FUNC_QUALIFIER tvec3<T, P> operator/(T const & scalar, tvec3<T, P> const & v)
 	{
 		return tvec3<T, P>(
-			s / v.x,
-			s / v.y,
-			s / v.z);
+			scalar / v.x,
+			scalar / v.y,
+			scalar / v.z);
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tvec3<T, P> operator/(tvec1<T, P> const & s, tvec3<T, P> const & v)
+	GLM_FUNC_QUALIFIER tvec3<T, P> operator/(tvec1<T, P> const & scalar, tvec3<T, P> const & v)
 	{
 		return tvec3<T, P>(
-			s.x / v.x,
-			s.x / v.y,
-			s.x / v.z);
+			scalar.x / v.x,
+			scalar.x / v.y,
+			scalar.x / v.z);
 	}
 
 	template <typename T, precision P>
@@ -741,39 +741,39 @@ namespace glm
 	// -- Binary bit operators --
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tvec3<T, P> operator%(tvec3<T, P> const & v, T const & s)
+	GLM_FUNC_QUALIFIER tvec3<T, P> operator%(tvec3<T, P> const & v, T const & scalar)
 	{
 		return tvec3<T, P>(
-			v.x % s,
-			v.y % s,
-			v.z % s);
+			v.x % scalar,
+			v.y % scalar,
+			v.z % scalar);
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tvec3<T, P> operator%(tvec3<T, P> const & v, tvec1<T, P> const & s)
+	GLM_FUNC_QUALIFIER tvec3<T, P> operator%(tvec3<T, P> const & v, tvec1<T, P> const & scalar)
 	{
 		return tvec3<T, P>(
-			v.x % s.x,
-			v.y % s.x,
-			v.z % s.x);
+			v.x % scalar.x,
+			v.y % scalar.x,
+			v.z % scalar.x);
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tvec3<T, P> operator%(T const & s, tvec3<T, P> const & v)
+	GLM_FUNC_QUALIFIER tvec3<T, P> operator%(T const & scalar, tvec3<T, P> const & v)
 	{
 		return tvec3<T, P>(
-			s % v.x,
-			s % v.y,
-			s % v.z);
+			scalar % v.x,
+			scalar % v.y,
+			scalar % v.z);
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tvec3<T, P> operator%(tvec1<T, P> const & s, tvec3<T, P> const & v)
+	GLM_FUNC_QUALIFIER tvec3<T, P> operator%(tvec1<T, P> const & scalar, tvec3<T, P> const & v)
 	{
 		return tvec3<T, P>(
-			s.x % v.x,
-			s.x % v.y,
-			s.x % v.z);
+			scalar.x % v.x,
+			scalar.x % v.y,
+			scalar.x % v.z);
 	}
 
 	template <typename T, precision P>
@@ -786,39 +786,39 @@ namespace glm
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tvec3<T, P> operator&(tvec3<T, P> const & v, T const & s)
+	GLM_FUNC_QUALIFIER tvec3<T, P> operator&(tvec3<T, P> const & v, T const & scalar)
 	{
 		return tvec3<T, P>(
-			v.x & s,
-			v.y & s,
-			v.z & s);
+			v.x & scalar,
+			v.y & scalar,
+			v.z & scalar);
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tvec3<T, P> operator&(tvec3<T, P> const & v, tvec1<T, P> const & s)
+	GLM_FUNC_QUALIFIER tvec3<T, P> operator&(tvec3<T, P> const & v, tvec1<T, P> const & scalar)
 	{
 		return tvec3<T, P>(
-			v.x & s.x,
-			v.y & s.x,
-			v.z & s.x);
+			v.x & scalar.x,
+			v.y & scalar.x,
+			v.z & scalar.x);
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tvec3<T, P> operator&(T const & s, tvec3<T, P> const & v)
+	GLM_FUNC_QUALIFIER tvec3<T, P> operator&(T const & scalar, tvec3<T, P> const & v)
 	{
 		return tvec3<T, P>(
-			s & v.x,
-			s & v.y,
-			s & v.z);
+			scalar & v.x,
+			scalar & v.y,
+			scalar & v.z);
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tvec3<T, P> operator&(tvec1<T, P> const & s, tvec3<T, P> const & v)
+	GLM_FUNC_QUALIFIER tvec3<T, P> operator&(tvec1<T, P> const & scalar, tvec3<T, P> const & v)
 	{
 		return tvec3<T, P>(
-			s.x & v.x,
-			s.x & v.y,
-			s.x & v.z);
+			scalar.x & v.x,
+			scalar.x & v.y,
+			scalar.x & v.z);
 	}
 
 	template <typename T, precision P>
@@ -831,39 +831,39 @@ namespace glm
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tvec3<T, P> operator|(tvec3<T, P> const & v, T const & s)
+	GLM_FUNC_QUALIFIER tvec3<T, P> operator|(tvec3<T, P> const & v, T const & scalar)
 	{
 		return tvec3<T, P>(
-			v.x | s,
-			v.y | s,
-			v.z | s);
+			v.x | scalar,
+			v.y | scalar,
+			v.z | scalar);
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tvec3<T, P> operator|(tvec3<T, P> const & v, tvec1<T, P> const & s)
+	GLM_FUNC_QUALIFIER tvec3<T, P> operator|(tvec3<T, P> const & v, tvec1<T, P> const & scalar)
 	{
 		return tvec3<T, P>(
-			v.x | s.x,
-			v.y | s.x,
-			v.z | s.x);
+			v.x | scalar.x,
+			v.y | scalar.x,
+			v.z | scalar.x);
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tvec3<T, P> operator|(T const & s, tvec3<T, P> const & v)
+	GLM_FUNC_QUALIFIER tvec3<T, P> operator|(T const & scalar, tvec3<T, P> const & v)
 	{
 		return tvec3<T, P>(
-			s | v.x,
-			s | v.y,
-			s | v.z);
+			scalar | v.x,
+			scalar | v.y,
+			scalar | v.z);
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tvec3<T, P> operator|(tvec1<T, P> const & s, tvec3<T, P> const & v)
+	GLM_FUNC_QUALIFIER tvec3<T, P> operator|(tvec1<T, P> const & scalar, tvec3<T, P> const & v)
 	{
 		return tvec3<T, P>(
-			s.x | v.x,
-			s.x | v.y,
-			s.x | v.z);
+			scalar.x | v.x,
+			scalar.x | v.y,
+			scalar.x | v.z);
 	}
 
 	template <typename T, precision P>
@@ -876,39 +876,39 @@ namespace glm
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tvec3<T, P> operator^(tvec3<T, P> const & v, T const & s)
+	GLM_FUNC_QUALIFIER tvec3<T, P> operator^(tvec3<T, P> const & v, T const & scalar)
 	{
 		return tvec3<T, P>(
-			v.x ^ s,
-			v.y ^ s,
-			v.z ^ s);
+			v.x ^ scalar,
+			v.y ^ scalar,
+			v.z ^ scalar);
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tvec3<T, P> operator^(tvec3<T, P> const & v, tvec1<T, P> const & s)
+	GLM_FUNC_QUALIFIER tvec3<T, P> operator^(tvec3<T, P> const & v, tvec1<T, P> const & scalar)
 	{
 		return tvec3<T, P>(
-			v.x ^ s.x,
-			v.y ^ s.x,
-			v.z ^ s.x);
+			v.x ^ scalar.x,
+			v.y ^ scalar.x,
+			v.z ^ scalar.x);
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tvec3<T, P> operator^(T const & s, tvec3<T, P> const & v)
+	GLM_FUNC_QUALIFIER tvec3<T, P> operator^(T const & scalar, tvec3<T, P> const & v)
 	{
 		return tvec3<T, P>(
-			s ^ v.x,
-			s ^ v.y,
-			s ^ v.z);
+			scalar ^ v.x,
+			scalar ^ v.y,
+			scalar ^ v.z);
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tvec3<T, P> operator^(tvec1<T, P> const & s, tvec3<T, P> const & v)
+	GLM_FUNC_QUALIFIER tvec3<T, P> operator^(tvec1<T, P> const & scalar, tvec3<T, P> const & v)
 	{
 		return tvec3<T, P>(
-			s.x ^ v.x,
-			s.x ^ v.y,
-			s.x ^ v.z);
+			scalar.x ^ v.x,
+			scalar.x ^ v.y,
+			scalar.x ^ v.z);
 	}
 
 	template <typename T, precision P>
@@ -921,39 +921,39 @@ namespace glm
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tvec3<T, P> operator<<(tvec3<T, P> const & v, T const & s)
+	GLM_FUNC_QUALIFIER tvec3<T, P> operator<<(tvec3<T, P> const & v, T const & scalar)
 	{
 		return tvec3<T, P>(
-			v.x << s,
-			v.y << s,
-			v.z << s);
+			v.x << scalar,
+			v.y << scalar,
+			v.z << scalar);
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tvec3<T, P> operator<<(tvec3<T, P> const & v, tvec1<T, P> const & s)
+	GLM_FUNC_QUALIFIER tvec3<T, P> operator<<(tvec3<T, P> const & v, tvec1<T, P> const & scalar)
 	{
 		return tvec3<T, P>(
-			v.x << s.x,
-			v.y << s.x,
-			v.z << s.x);
+			v.x << scalar.x,
+			v.y << scalar.x,
+			v.z << scalar.x);
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tvec3<T, P> operator<<(T const & s, tvec3<T, P> const & v)
+	GLM_FUNC_QUALIFIER tvec3<T, P> operator<<(T const & scalar, tvec3<T, P> const & v)
 	{
 		return tvec3<T, P>(
-			s << v.x,
-			s << v.y,
-			s << v.z);
+			scalar << v.x,
+			scalar << v.y,
+			scalar << v.z);
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tvec3<T, P> operator<<(tvec1<T, P> const & s, tvec3<T, P> const & v)
+	GLM_FUNC_QUALIFIER tvec3<T, P> operator<<(tvec1<T, P> const & scalar, tvec3<T, P> const & v)
 	{
 		return tvec3<T, P>(
-			s.x << v.x,
-			s.x << v.y,
-			s.x << v.z);
+			scalar.x << v.x,
+			scalar.x << v.y,
+			scalar.x << v.z);
 	}
 
 	template <typename T, precision P>
@@ -966,39 +966,39 @@ namespace glm
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tvec3<T, P> operator>>(tvec3<T, P> const & v, T const & s)
+	GLM_FUNC_QUALIFIER tvec3<T, P> operator>>(tvec3<T, P> const & v, T const & scalar)
 	{
 		return tvec3<T, P>(
-			v.x >> s,
-			v.y >> s,
-			v.z >> s);
+			v.x >> scalar,
+			v.y >> scalar,
+			v.z >> scalar);
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tvec3<T, P> operator>>(tvec3<T, P> const & v, tvec1<T, P> const & s)
+	GLM_FUNC_QUALIFIER tvec3<T, P> operator>>(tvec3<T, P> const & v, tvec1<T, P> const & scalar)
 	{
 		return tvec3<T, P>(
-			v.x >> s.x,
-			v.y >> s.x,
-			v.z >> s.x);
+			v.x >> scalar.x,
+			v.y >> scalar.x,
+			v.z >> scalar.x);
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tvec3<T, P> operator>>(T const & s, tvec3<T, P> const & v)
+	GLM_FUNC_QUALIFIER tvec3<T, P> operator>>(T const & scalar, tvec3<T, P> const & v)
 	{
 		return tvec3<T, P>(
-			s >> v.x,
-			s >> v.y,
-			s >> v.z);
+			scalar >> v.x,
+			scalar >> v.y,
+			scalar >> v.z);
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tvec3<T, P> operator>>(tvec1<T, P> const & s, tvec3<T, P> const & v)
+	GLM_FUNC_QUALIFIER tvec3<T, P> operator>>(tvec1<T, P> const & scalar, tvec3<T, P> const & v)
 	{
 		return tvec3<T, P>(
-			s.x >> v.x,
-			s.x >> v.y,
-			s.x >> v.z);
+			scalar.x >> v.x,
+			scalar.x >> v.y,
+			scalar.x >> v.z);
 	}
 
 	template <typename T, precision P>

--- a/glm/detail/type_vec4.hpp
+++ b/glm/detail/type_vec4.hpp
@@ -174,7 +174,7 @@ namespace detail
 		// -- Explicit basic constructors --
 
 		GLM_FUNC_DECL explicit tvec4(ctor);
-		GLM_FUNC_DECL explicit tvec4(T s);
+		GLM_FUNC_DECL explicit tvec4(T scalar);
 		GLM_FUNC_DECL tvec4(T a, T b, T c, T d);
 
 		// -- Conversion scalar constructors --
@@ -360,13 +360,13 @@ namespace detail
 	GLM_FUNC_DECL tvec4<T, P> operator+(tvec4<T, P> const & v, T scalar);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec4<T, P> operator+(tvec4<T, P> const & v, tvec1<T, P> const & s);
+	GLM_FUNC_DECL tvec4<T, P> operator+(tvec4<T, P> const & v, tvec1<T, P> const & scalar);
 
 	template <typename T, precision P>
 	GLM_FUNC_DECL tvec4<T, P> operator+(T scalar, tvec4<T, P> const & v);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec4<T, P> operator+(tvec1<T, P> const & s, tvec4<T, P> const & v);
+	GLM_FUNC_DECL tvec4<T, P> operator+(tvec1<T, P> const & scalar, tvec4<T, P> const & v);
 
 	template <typename T, precision P>
 	GLM_FUNC_DECL tvec4<T, P> operator+(tvec4<T, P> const & v1, tvec4<T, P> const & v2);
@@ -375,13 +375,13 @@ namespace detail
 	GLM_FUNC_DECL tvec4<T, P> operator-(tvec4<T, P> const & v, T scalar);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec4<T, P> operator-(tvec4<T, P> const & v, tvec1<T, P> const & s);
+	GLM_FUNC_DECL tvec4<T, P> operator-(tvec4<T, P> const & v, tvec1<T, P> const & scalar);
 
 	template <typename T, precision P>
 	GLM_FUNC_DECL tvec4<T, P> operator-(T scalar, tvec4<T, P> const & v);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec4<T, P> operator-(tvec1<T, P> const & s, tvec4<T, P> const & v);
+	GLM_FUNC_DECL tvec4<T, P> operator-(tvec1<T, P> const & scalar, tvec4<T, P> const & v);
 
 	template <typename T, precision P>
 	GLM_FUNC_DECL tvec4<T, P> operator-(tvec4<T, P> const & v1, tvec4<T, P> const & v2);
@@ -390,13 +390,13 @@ namespace detail
 	GLM_FUNC_DECL tvec4<T, P> operator*(tvec4<T, P> const & v, T scalar);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec4<T, P> operator*(tvec4<T, P> const & v, tvec1<T, P> const & s);
+	GLM_FUNC_DECL tvec4<T, P> operator*(tvec4<T, P> const & v, tvec1<T, P> const & scalar);
 
 	template <typename T, precision P>
 	GLM_FUNC_DECL tvec4<T, P> operator*(T scalar, tvec4<T, P> const & v);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec4<T, P> operator*(tvec1<T, P> const & s, tvec4<T, P> const & v);
+	GLM_FUNC_DECL tvec4<T, P> operator*(tvec1<T, P> const & scalar, tvec4<T, P> const & v);
 
 	template <typename T, precision P>
 	GLM_FUNC_DECL tvec4<T, P> operator*(tvec4<T, P> const & v1, tvec4<T, P> const & v2);
@@ -405,13 +405,13 @@ namespace detail
 	GLM_FUNC_DECL tvec4<T, P> operator/(tvec4<T, P> const & v, T scalar);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec4<T, P> operator/(tvec4<T, P> const & v, tvec1<T, P> const & s);
+	GLM_FUNC_DECL tvec4<T, P> operator/(tvec4<T, P> const & v, tvec1<T, P> const & scalar);
 
 	template <typename T, precision P>
 	GLM_FUNC_DECL tvec4<T, P> operator/(T scalar, tvec4<T, P> const & v);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec4<T, P> operator/(tvec1<T, P> const & s, tvec4<T, P> const & v);
+	GLM_FUNC_DECL tvec4<T, P> operator/(tvec1<T, P> const & scalar, tvec4<T, P> const & v);
 
 	template <typename T, precision P>
 	GLM_FUNC_DECL tvec4<T, P> operator/(tvec4<T, P> const & v1, tvec4<T, P> const & v2);
@@ -426,13 +426,13 @@ namespace detail
 	GLM_FUNC_DECL tvec4<T, P> operator%(tvec4<T, P> const & v, T scalar);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec4<T, P> operator%(tvec4<T, P> const & v, tvec1<T, P> const & s);
+	GLM_FUNC_DECL tvec4<T, P> operator%(tvec4<T, P> const & v, tvec1<T, P> const & scalar);
 
 	template <typename T, precision P>
 	GLM_FUNC_DECL tvec4<T, P> operator%(T scalar, tvec4<T, P> const & v);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec4<T, P> operator%(tvec1<T, P> const & s, tvec4<T, P> const & v);
+	GLM_FUNC_DECL tvec4<T, P> operator%(tvec1<T, P> const & scalar, tvec4<T, P> const & v);
 
 	template <typename T, precision P>
 	GLM_FUNC_DECL tvec4<T, P> operator%(tvec4<T, P> const & v1, tvec4<T, P> const & v2);
@@ -441,13 +441,13 @@ namespace detail
 	GLM_FUNC_DECL tvec4<T, P> operator&(tvec4<T, P> const & v, T scalar);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec4<T, P> operator&(tvec4<T, P> const & v, tvec1<T, P> const & s);
+	GLM_FUNC_DECL tvec4<T, P> operator&(tvec4<T, P> const & v, tvec1<T, P> const & scalar);
 
 	template <typename T, precision P>
 	GLM_FUNC_DECL tvec4<T, P> operator&(T scalar, tvec4<T, P> const & v);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec4<T, P> operator&(tvec1<T, P> const & s, tvec4<T, P> const & v);
+	GLM_FUNC_DECL tvec4<T, P> operator&(tvec1<T, P> const & scalar, tvec4<T, P> const & v);
 
 	template <typename T, precision P>
 	GLM_FUNC_DECL tvec4<T, P> operator&(tvec4<T, P> const & v1, tvec4<T, P> const & v2);
@@ -456,13 +456,13 @@ namespace detail
 	GLM_FUNC_DECL tvec4<T, P> operator|(tvec4<T, P> const & v, T scalar);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec4<T, P> operator|(tvec4<T, P> const & v, tvec1<T, P> const & s);
+	GLM_FUNC_DECL tvec4<T, P> operator|(tvec4<T, P> const & v, tvec1<T, P> const & scalar);
 
 	template <typename T, precision P>
 	GLM_FUNC_DECL tvec4<T, P> operator|(T scalar, tvec4<T, P> const & v);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec4<T, P> operator|(tvec1<T, P> const & s, tvec4<T, P> const & v);
+	GLM_FUNC_DECL tvec4<T, P> operator|(tvec1<T, P> const & scalar, tvec4<T, P> const & v);
 
 	template <typename T, precision P>
 	GLM_FUNC_DECL tvec4<T, P> operator|(tvec4<T, P> const & v1, tvec4<T, P> const & v2);
@@ -471,13 +471,13 @@ namespace detail
 	GLM_FUNC_DECL tvec4<T, P> operator^(tvec4<T, P> const & v, T scalar);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec4<T, P> operator^(tvec4<T, P> const & v, tvec1<T, P> const & s);
+	GLM_FUNC_DECL tvec4<T, P> operator^(tvec4<T, P> const & v, tvec1<T, P> const & scalar);
 
 	template <typename T, precision P>
 	GLM_FUNC_DECL tvec4<T, P> operator^(T scalar, tvec4<T, P> const & v);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec4<T, P> operator^(tvec1<T, P> const & s, tvec4<T, P> const & v);
+	GLM_FUNC_DECL tvec4<T, P> operator^(tvec1<T, P> const & scalar, tvec4<T, P> const & v);
 
 	template <typename T, precision P>
 	GLM_FUNC_DECL tvec4<T, P> operator^(tvec4<T, P> const & v1, tvec4<T, P> const & v2);
@@ -486,13 +486,13 @@ namespace detail
 	GLM_FUNC_DECL tvec4<T, P> operator<<(tvec4<T, P> const & v, T scalar);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec4<T, P> operator<<(tvec4<T, P> const & v, tvec1<T, P> const & s);
+	GLM_FUNC_DECL tvec4<T, P> operator<<(tvec4<T, P> const & v, tvec1<T, P> const & scalar);
 
 	template <typename T, precision P>
 	GLM_FUNC_DECL tvec4<T, P> operator<<(T scalar, tvec4<T, P> const & v);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec4<T, P> operator<<(tvec1<T, P> const & s, tvec4<T, P> const & v);
+	GLM_FUNC_DECL tvec4<T, P> operator<<(tvec1<T, P> const & scalar, tvec4<T, P> const & v);
 
 	template <typename T, precision P>
 	GLM_FUNC_DECL tvec4<T, P> operator<<(tvec4<T, P> const & v1, tvec4<T, P> const & v2);
@@ -501,13 +501,13 @@ namespace detail
 	GLM_FUNC_DECL tvec4<T, P> operator>>(tvec4<T, P> const & v, T scalar);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec4<T, P> operator>>(tvec4<T, P> const & v, tvec1<T, P> const & s);
+	GLM_FUNC_DECL tvec4<T, P> operator>>(tvec4<T, P> const & v, tvec1<T, P> const & scalar);
 
 	template <typename T, precision P>
 	GLM_FUNC_DECL tvec4<T, P> operator>>(T scalar, tvec4<T, P> const & v);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec4<T, P> operator>>(tvec1<T, P> const & s, tvec4<T, P> const & v);
+	GLM_FUNC_DECL tvec4<T, P> operator>>(tvec1<T, P> const & scalar, tvec4<T, P> const & v);
 
 	template <typename T, precision P>
 	GLM_FUNC_DECL tvec4<T, P> operator>>(tvec4<T, P> const & v1, tvec4<T, P> const & v2);

--- a/glm/detail/type_vec4.inl
+++ b/glm/detail/type_vec4.inl
@@ -63,8 +63,8 @@ namespace glm
 	{}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tvec4<T, P>::tvec4(T s)
-		: x(s), y(s), z(s), w(s)
+	GLM_FUNC_QUALIFIER tvec4<T, P>::tvec4(T scalar)
+		: x(scalar), y(scalar), z(scalar), w(scalar)
 	{}
 
 	template <typename T, precision P>
@@ -780,43 +780,43 @@ namespace glm
 	// -- Binary bit operators --
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tvec4<T, P> operator%(tvec4<T, P> const & v, T s)
+	GLM_FUNC_QUALIFIER tvec4<T, P> operator%(tvec4<T, P> const & v, T scalar)
 	{
 		return tvec4<T, P>(
-			v.x % s,
-			v.y % s,
-			v.z % s,
-			v.w % s);
+			v.x % scalar,
+			v.y % scalar,
+			v.z % scalar,
+			v.w % scalar);
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tvec4<T, P> operator%(tvec4<T, P> const & v, tvec1<T, P> const & s)
+	GLM_FUNC_QUALIFIER tvec4<T, P> operator%(tvec4<T, P> const & v, tvec1<T, P> const & scalar)
 	{
 		return tvec4<T, P>(
-			v.x % s.x,
-			v.y % s.x,
-			v.z % s.x,
-			v.w % s.x);
+			v.x % scalar.x,
+			v.y % scalar.x,
+			v.z % scalar.x,
+			v.w % scalar.x);
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tvec4<T, P> operator%(T s, tvec4<T, P> const & v)
+	GLM_FUNC_QUALIFIER tvec4<T, P> operator%(T scalar, tvec4<T, P> const & v)
 	{
 		return tvec4<T, P>(
-			s % v.x,
-			s % v.y,
-			s % v.z,
-			s % v.w);
+			scalar % v.x,
+			scalar % v.y,
+			scalar % v.z,
+			scalar % v.w);
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tvec4<T, P> operator%(tvec1<T, P> const & s, tvec4<T, P> const & v)
+	GLM_FUNC_QUALIFIER tvec4<T, P> operator%(tvec1<T, P> const & scalar, tvec4<T, P> const & v)
 	{
 		return tvec4<T, P>(
-			s.x % v.x,
-			s.x % v.y,
-			s.x % v.z,
-			s.x % v.w);
+			scalar.x % v.x,
+			scalar.x % v.y,
+			scalar.x % v.z,
+			scalar.x % v.w);
 	}
 
 	template <typename T, precision P>
@@ -830,43 +830,43 @@ namespace glm
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tvec4<T, P> operator&(tvec4<T, P> const & v, T s)
+	GLM_FUNC_QUALIFIER tvec4<T, P> operator&(tvec4<T, P> const & v, T scalar)
 	{
 		return tvec4<T, P>(
-			v.x & s,
-			v.y & s,
-			v.z & s,
-			v.w & s);
+			v.x & scalar,
+			v.y & scalar,
+			v.z & scalar,
+			v.w & scalar);
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tvec4<T, P> operator&(tvec4<T, P> const & v, tvec1<T, P> const & s)
+	GLM_FUNC_QUALIFIER tvec4<T, P> operator&(tvec4<T, P> const & v, tvec1<T, P> const & scalar)
 	{
 		return tvec4<T, P>(
-			v.x & s.x,
-			v.y & s.x,
-			v.z & s.x,
-			v.w & s.x);
+			v.x & scalar.x,
+			v.y & scalar.x,
+			v.z & scalar.x,
+			v.w & scalar.x);
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tvec4<T, P> operator&(T s, tvec4<T, P> const & v)
+	GLM_FUNC_QUALIFIER tvec4<T, P> operator&(T scalar, tvec4<T, P> const & v)
 	{
 		return tvec4<T, P>(
-			s & v.x,
-			s & v.y,
-			s & v.z,
-			s & v.w);
+			scalar & v.x,
+			scalar & v.y,
+			scalar & v.z,
+			scalar & v.w);
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tvec4<T, P> operator&(tvec1<T, P> const & s, tvec4<T, P> const & v)
+	GLM_FUNC_QUALIFIER tvec4<T, P> operator&(tvec1<T, P> const & scalar, tvec4<T, P> const & v)
 	{
 		return tvec4<T, P>(
-			s.x & v.x,
-			s.x & v.y,
-			s.x & v.z,
-			s.x & v.w);
+			scalar.x & v.x,
+			scalar.x & v.y,
+			scalar.x & v.z,
+			scalar.x & v.w);
 	}
 
 	template <typename T, precision P>
@@ -880,43 +880,43 @@ namespace glm
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tvec4<T, P> operator|(tvec4<T, P> const & v, T s)
+	GLM_FUNC_QUALIFIER tvec4<T, P> operator|(tvec4<T, P> const & v, T scalar)
 	{
 		return tvec4<T, P>(
-			v.x | s,
-			v.y | s,
-			v.z | s,
-			v.w | s);
+			v.x | scalar,
+			v.y | scalar,
+			v.z | scalar,
+			v.w | scalar);
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tvec4<T, P> operator|(tvec4<T, P> const & v, tvec1<T, P> const & s)
+	GLM_FUNC_QUALIFIER tvec4<T, P> operator|(tvec4<T, P> const & v, tvec1<T, P> const & scalar)
 	{
 		return tvec4<T, P>(
-			v.x | s.x,
-			v.y | s.x,
-			v.z | s.x,
-			v.w | s.x);
+			v.x | scalar.x,
+			v.y | scalar.x,
+			v.z | scalar.x,
+			v.w | scalar.x);
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tvec4<T, P> operator|(T s, tvec4<T, P> const & v)
+	GLM_FUNC_QUALIFIER tvec4<T, P> operator|(T scalar, tvec4<T, P> const & v)
 	{
 		return tvec4<T, P>(
-			s | v.x,
-			s | v.y,
-			s | v.z,
-			s | v.w);
+			scalar | v.x,
+			scalar | v.y,
+			scalar | v.z,
+			scalar | v.w);
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tvec4<T, P> operator|(tvec1<T, P> const & s, tvec4<T, P> const & v)
+	GLM_FUNC_QUALIFIER tvec4<T, P> operator|(tvec1<T, P> const & scalar, tvec4<T, P> const & v)
 	{
 		return tvec4<T, P>(
-			s.x | v.x,
-			s.x | v.y,
-			s.x | v.z,
-			s.x | v.w);
+			scalar.x | v.x,
+			scalar.x | v.y,
+			scalar.x | v.z,
+			scalar.x | v.w);
 	}
 
 	template <typename T, precision P>
@@ -930,23 +930,23 @@ namespace glm
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tvec4<T, P> operator^(tvec4<T, P> const & v, T s)
+	GLM_FUNC_QUALIFIER tvec4<T, P> operator^(tvec4<T, P> const & v, T scalar)
 	{
 		return tvec4<T, P>(
-			v.x ^ s,
-			v.y ^ s,
-			v.z ^ s,
-			v.w ^ s);
+			v.x ^ scalar,
+			v.y ^ scalar,
+			v.z ^ scalar,
+			v.w ^ scalar);
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tvec4<T, P> operator^(tvec4<T, P> const & v, tvec1<T, P> const & s)
+	GLM_FUNC_QUALIFIER tvec4<T, P> operator^(tvec4<T, P> const & v, tvec1<T, P> const & scalar)
 	{
 		return tvec4<T, P>(
-			v.x ^ s.x,
-			v.y ^ s.x,
-			v.z ^ s.x,
-			v.w ^ s.x);
+			v.x ^ scalar.x,
+			v.y ^ scalar.x,
+			v.z ^ scalar.x,
+			v.w ^ scalar.x);
 	}
 
 	template <typename T, precision P>
@@ -960,13 +960,13 @@ namespace glm
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tvec4<T, P> operator^(tvec1<T, P> const & s, tvec4<T, P> const & v)
+	GLM_FUNC_QUALIFIER tvec4<T, P> operator^(tvec1<T, P> const & scalar, tvec4<T, P> const & v)
 	{
 		return tvec4<T, P>(
-			s.x ^ v.x,
-			s.x ^ v.y,
-			s.x ^ v.z,
-			s.x ^ v.w);
+			scalar.x ^ v.x,
+			scalar.x ^ v.y,
+			scalar.x ^ v.z,
+			scalar.x ^ v.w);
 	}
 
 	template <typename T, precision P>
@@ -990,13 +990,13 @@ namespace glm
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tvec4<T, P> operator<<(tvec4<T, P> const & v, tvec1<T, P> const & s)
+	GLM_FUNC_QUALIFIER tvec4<T, P> operator<<(tvec4<T, P> const & v, tvec1<T, P> const & scalar)
 	{
 		return tvec4<T, P>(
-			v.x << s.x,
-			v.y << s.x,
-			v.z << s.x,
-			v.w << s.x);
+			v.x << scalar.x,
+			v.y << scalar.x,
+			v.z << scalar.x,
+			v.w << scalar.x);
 	}
 
 	template <typename T, precision P>
@@ -1010,13 +1010,13 @@ namespace glm
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tvec4<T, P> operator<<(tvec1<T, P> const & s, tvec4<T, P> const & v)
+	GLM_FUNC_QUALIFIER tvec4<T, P> operator<<(tvec1<T, P> const & scalar, tvec4<T, P> const & v)
 	{
 		return tvec4<T, P>(
-			s.x << v.x,
-			s.x << v.y,
-			s.x << v.z,
-			s.x << v.w);
+			scalar.x << v.x,
+			scalar.x << v.y,
+			scalar.x << v.z,
+			scalar.x << v.w);
 	}
 
 	template <typename T, precision P>
@@ -1040,13 +1040,13 @@ namespace glm
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tvec4<T, P> operator>>(tvec4<T, P> const & v, tvec1<T, P> const & s)
+	GLM_FUNC_QUALIFIER tvec4<T, P> operator>>(tvec4<T, P> const & v, tvec1<T, P> const & scalar)
 	{
 		return tvec4<T, P>(
-			v.x >> s.x,
-			v.y >> s.x,
-			v.z >> s.x,
-			v.w >> s.x);
+			v.x >> scalar.x,
+			v.y >> scalar.x,
+			v.z >> scalar.x,
+			v.w >> scalar.x);
 	}
 
 	template <typename T, precision P>
@@ -1060,13 +1060,13 @@ namespace glm
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tvec4<T, P> operator>>(tvec1<T, P> const & s, tvec4<T, P> const & v)
+	GLM_FUNC_QUALIFIER tvec4<T, P> operator>>(tvec1<T, P> const & scalar, tvec4<T, P> const & v)
 	{
 		return tvec4<T, P>(
-			s.x >> v.x,
-			s.x >> v.y,
-			s.x >> v.z,
-			s.x >> v.w);
+			scalar.x >> v.x,
+			scalar.x >> v.y,
+			scalar.x >> v.z,
+			scalar.x >> v.w);
 	}
 
 	template <typename T, precision P>


### PR DESCRIPTION
With msvc2015 the (new) warning C4458 occurs on all vector operators using scalars as parameters since they overlap with the union member s:

Example:
```\glm-0.9.7.0\glm\detail\type_vec3.inl(302): warning C4458: declaration of 's' hides class member```

For projects that use highest warning levels for compilation (and some even with warnings as errors) this prohibits compilation.