### PR TITLE
Add constructors to aid in meta-programming

### DIFF
--- a/glm/detail/type_vec1.hpp
+++ b/glm/detail/type_vec1.hpp
@@ -134,6 +134,12 @@ namespace glm
 		template <typename U, precision Q>
 		GLM_FUNC_DECL GLM_EXPLICIT tvec1(tvec1<U, Q> const & v);
 
+		/// Extra helper constructors for metaprogramming
+#		ifdef GLM_META_PROG_HELPERS
+		template <typename X, typename Y, typename Z = Y, typename W = Z>
+		GLM_FUNC_DECL tvec1(X const& x, Y const&, Z const& = Z(0), W const& = W(0));
+#		endif
+
 		// -- Swizzle constructors --
 
 #		if(GLM_HAS_ANONYMOUS_UNION && defined(GLM_SWIZZLE))

--- a/glm/detail/type_vec1.inl
+++ b/glm/detail/type_vec1.inl
@@ -93,6 +93,15 @@ namespace glm
 		: x(static_cast<T>(v.x))
 	{}
 
+	// -- Metaprogramming helper constructors --
+#	ifdef GLM_META_PROG_HELPERS
+	template <typename T, precision P>
+	template <typename X, typename Y, typename Z, typename W>
+	GLM_FUNC_QUALIFIER tvec1<T, P>::tvec1(X const& x, Y const&, Z const&, W const&)
+		: x(static_cast<T>(x))
+	{}
+#	endif
+
 	// -- Component accesses --
 
 #	ifdef GLM_FORCE_SIZE_FUNC

--- a/glm/detail/type_vec2.hpp
+++ b/glm/detail/type_vec2.hpp
@@ -140,6 +140,12 @@ namespace glm
 		template <typename U, precision Q>
 		GLM_FUNC_DECL GLM_EXPLICIT tvec2(tvec2<U, Q> const & v);
 
+		/// Extra helper constructors for metaprogramming
+#		ifdef GLM_META_PROG_HELPERS
+		template <typename X, typename Y, typename Z, typename W = Z>
+		GLM_FUNC_DECL tvec2(X const& x, Y const& y, Z const& z, W const& w = W(0));
+#		endif
+
 		// -- Swizzle constructors --
 
 #		if GLM_HAS_ANONYMOUS_UNION && defined(GLM_SWIZZLE)

--- a/glm/detail/type_vec2.inl
+++ b/glm/detail/type_vec2.inl
@@ -107,6 +107,15 @@ namespace glm
 		, y(static_cast<T>(v.y))
 	{}
 
+	// -- Metaprogramming helper constructors --
+#	ifdef GLM_META_PROG_HELPERS
+	template <typename T, precision P>
+	template <typename X, typename Y, typename Z, typename W>
+	GLM_FUNC_QUALIFIER tvec2<T, P>::tvec2(X const& x, Y const& y, Z const&, W const&)
+		: x(static_cast<T>(x)), y(static_cast<T>(y))
+	{}
+#	endif
+
 	// -- Component accesses --
 
 #	ifdef GLM_FORCE_SIZE_FUNC

--- a/glm/detail/type_vec3.hpp
+++ b/glm/detail/type_vec3.hpp
@@ -150,6 +150,15 @@ namespace glm
 		template <typename U, precision Q>
 		GLM_FUNC_DECL GLM_EXPLICIT tvec3(tvec3<U, Q> const & v);
 
+		/// Extra helper constructors for metaprogramming
+#		ifdef GLM_META_PROG_HELPERS
+		template <typename X, typename Y, typename Z, typename W>
+		GLM_FUNC_DECL tvec3(X const& x, Y const& y, Z const& z, W const&);
+
+		template <typename X, typename Y>
+		GLM_FUNC_DECL tvec3(X const& x, Y const& y);
+#		endif
+
 		// -- Swizzle constructors --
 
 #		if GLM_HAS_ANONYMOUS_UNION && defined(GLM_SWIZZLE)

--- a/glm/detail/type_vec3.inl
+++ b/glm/detail/type_vec3.inl
@@ -140,6 +140,21 @@ namespace glm
 		z(static_cast<T>(v.z))
 	{}
 
+	// -- Metaprogramming helper constructors --
+#	ifdef GLM_META_PROG_HELPERS
+	template <typename T, precision P>
+	template <typename X, typename Y, typename Z, typename W>
+	GLM_FUNC_QUALIFIER tvec3<T, P>::tvec3(X const& x, Y const& y, Z const& z, W const&)
+		: x(static_cast<T>(x)), y(static_cast<T>(y)), z(static_cast<T>(z))
+	{}
+
+	template <typename T, precision P>
+	template <typename X, typename Y>
+	GLM_FUNC_QUALIFIER tvec3<T, P>::tvec3(X const& x, Y const& y)
+		: x(static_cast<T>(x)), y(static_cast<T>(y)), z(static_cast<T>(0))
+	{}
+#	endif
+
 	// -- Component accesses --
 
 #	ifdef GLM_FORCE_SIZE_FUNC

--- a/glm/detail/type_vec4.hpp
+++ b/glm/detail/type_vec4.hpp
@@ -225,6 +225,11 @@ namespace detail
 		template <typename U, precision Q>
 		GLM_FUNC_DECL GLM_EXPLICIT tvec4(tvec4<U, Q> const & v);
 
+#		ifdef GLM_META_PROG_HELPERS
+		template <typename X, typename Y, typename Z = Y>
+		GLM_FUNC_DECL tvec4(X const& x, Y const& y, Z const& z = Z(0));
+#		endif
+
 		// -- Swizzle constructors --
 
 #		if GLM_HAS_ANONYMOUS_UNION && defined(GLM_SWIZZLE)

--- a/glm/detail/type_vec4.inl
+++ b/glm/detail/type_vec4.inl
@@ -202,6 +202,14 @@ namespace glm
 		w(static_cast<T>(v.w))
 	{}
 
+#	ifdef GLM_META_PROG_HELPERS
+	template <typename T, precision P>
+	template <typename X, typename Y, typename Z>
+	GLM_FUNC_QUALIFIER tvec4<T, P>::tvec4(X const& x, Y const& y, Z const& z)
+		: x(static_cast<T>(x)), y(static_cast<T>(y)), z(static_cast<T>(z)), w(static_cast<T>(0))
+	{}
+#	endif
+
 	// -- Component accesses --
 
 #	ifdef GLM_FORCE_SIZE_FUNC

--- a/glm/gtc/quaternion.hpp
+++ b/glm/gtc/quaternion.hpp
@@ -107,6 +107,11 @@ namespace glm
 		GLM_FUNC_DECL explicit tquat(T const & s, tvec3<T, P> const & v);
 		GLM_FUNC_DECL tquat(T const & w, T const & x, T const & y, T const & z);
 
+#		ifdef GLM_META_PROG_HELPERS
+		template <typename W, typename X, typename Y = X>
+		GLM_FUNC_DECL tquat(W const& w, X const& x, Y const& y = Y());
+#		endif
+
 		// -- Conversion constructors --
 
 		template <typename U, precision Q>

--- a/glm/gtc/quaternion.inl
+++ b/glm/gtc/quaternion.inl
@@ -196,6 +196,14 @@ namespace detail
 		*this = quat_cast(m);
 	}
 
+#	ifdef GLM_META_PROG_HELPERS
+	template <typename T, precision P>
+	template <typename W, typename X, typename Y>
+	GLM_FUNC_QUALIFIER tquat<T, P>::tquat(W const& w, X const& x, Y const& y)
+		: x(static_cast<T>(x)), y(static_cast<T>(y)), z(static_cast<T>(0)), w(static_cast<T>(w))
+	{}
+#	endif
+
 #	if GLM_HAS_EXPLICIT_CONVERSION_OPERATORS
 	template <typename T, precision P>
 	GLM_FUNC_QUALIFIER tquat<T, P>::operator tmat3x3<T, P>()

--- a/glm/gtx/simd_quat.hpp
+++ b/glm/gtx/simd_quat.hpp
@@ -113,6 +113,10 @@ namespace detail
 		explicit fquatSIMD(
 			vec3 const & eulerAngles);
 
+#		ifdef GLM_META_PROG_HELPERS
+		template <typename W, typename X, typename Y = X>
+		GLM_FUNC_DECL fquatSIMD(W const& w, X const& x, Y const& y = Y());
+#		endif
 
 		//////////////////////////////////////
 		// Unary arithmetic operators

--- a/glm/gtx/simd_quat.inl
+++ b/glm/gtx/simd_quat.inl
@@ -96,6 +96,13 @@ GLM_FUNC_QUALIFIER fquatSIMD::fquatSIMD(vec3 const & eulerAngles)
 		(s.x * c.y * c.z) - (c.x * s.y * s.z));
 }
 
+#	ifdef GLM_META_PROG_HELPERS
+	template <typename W, typename X, typename Y>
+	GLM_FUNC_QUALIFIER fquatSIMD::fquatSIMD(W const& w, X const& x, Y const& y)
+		: fquatSIMD(static_cast<float>(w), static_cast<float>(x), static_cast<float>(y), 0.0f)
+	{}
+#	endif
+
 
 //////////////////////////////////////
 // Unary arithmetic operators

--- a/glm/gtx/simd_vec4.hpp
+++ b/glm/gtx/simd_vec4.hpp
@@ -136,6 +136,11 @@ namespace detail
 		explicit fvec4SIMD(
 			vec4 const & v);
 
+#		ifdef GLM_META_PROG_HELPERS
+		template <typename X, typename Y, typename Z = Y>
+		GLM_FUNC_DECL fvec4SIMD(X const& x, Y const& y, Z const& z = Z(0));
+#		endif
+
 		////////////////////////////////////////
 		//// Conversion vector constructors
 

--- a/glm/gtx/simd_vec4.inl
+++ b/glm/gtx/simd_vec4.inl
@@ -89,6 +89,12 @@ GLM_FUNC_QUALIFIER fvec4SIMD::fvec4SIMD(vec2 const & v1, vec2 const & v2) :
 	Data(_mm_set_ps(v2.y, v2.x, v1.y, v1.x))
 {}
 
+#	ifdef GLM_META_PROG_HELPERS
+	template <typename X, typename Y, typename Z>
+	GLM_FUNC_QUALIFIER fvec4SIMD::fvec4SIMD(X const& x, Y const& y, Z const& z)
+		: fvec4SIMD(static_cast<float>(x), static_cast<float>(y), static_cast<float>(z), 0.0f)
+	{}
+#	endif
 //GLM_FUNC_QUALIFIER fvec4SIMD::fvec4SIMD(ivec4SIMD const & v) :
 //	Data(_mm_cvtepi32_ps(v.Data))
 //{}

--- a/test/core/core_type_vec1.cpp
+++ b/test/core/core_type_vec1.cpp
@@ -80,6 +80,17 @@ int test_vec1_ctor()
 		Error += std::is_copy_constructible<glm::vec1>::value ? 0 : 1;
 #	endif
 
+#	ifdef GLM_META_PROG_HELPERS
+	{
+		glm::vec1 a(1), b(1, 2), c(1, 2, 3), d(1, 2, 3, 4);
+
+		Error += (a == b) ? 0 : 1;
+		Error += (b == c) ? 0 : 1;
+		Error += (c == d) ? 0 : 1;
+		Error += (d == a) ? 0 : 1;
+	}
+#	endif
+
 /*
 #if GLM_HAS_INITIALIZER_LISTS
 	{

--- a/test/core/core_type_vec2.cpp
+++ b/test/core/core_type_vec2.cpp
@@ -235,6 +235,16 @@ int test_vec2_ctor()
 		Error += A == B ? 0 : 1;
 	}
 
+#	ifdef GLM_META_PROG_HELPERS
+	{
+		glm::vec2 a(1, 2), b(1, 2, 3), c(1, 2, 3, 4);
+
+		Error += (a == b) ? 0 : 1;
+		Error += (b == c) ? 0 : 1;
+		Error += (c == a) ? 0 : 1;
+	}
+#	endif
+
 #	if GLM_HAS_TRIVIAL_QUERIES
 	//	Error += std::is_trivially_default_constructible<glm::vec2>::value ? 0 : 1;
 	//	Error += std::is_trivially_copy_assignable<glm::vec2>::value ? 0 : 1;

--- a/test/core/core_type_vec3.cpp
+++ b/test/core/core_type_vec3.cpp
@@ -45,6 +45,16 @@ int test_vec3_ctor()
 {
 	int Error = 0;
 
+#	ifdef GLM_META_PROG_HELPERS
+	{
+		glm::vec3 a(1, 2, 0), b(1, 2, 0, 4), c(1, 2);
+
+		Error += (a == b) ? 0 : 1;
+		Error += (b == c) ? 0 : 1;
+		Error += (a == c) ? 0 : 1;
+	}
+#	endif
+
 #	if GLM_HAS_TRIVIAL_QUERIES
 	//	Error += std::is_trivially_default_constructible<glm::vec3>::value ? 0 : 1;
 	//	Error += std::is_trivially_copy_assignable<glm::vec3>::value ? 0 : 1;

--- a/test/core/core_type_vec4.cpp
+++ b/test/core/core_type_vec4.cpp
@@ -73,6 +73,16 @@ int test_vec4_ctor()
 		Error += glm::all(glm::equal(A, B)) ? 0 : 1;
 	}
 
+#	ifdef GLM_META_PROG_HELPERS
+	{
+		glm::vec4 a(1, 2, 0, 0), b(1, 2), c(1, 2, 0);
+
+		Error += (a == b) ? 0 : 1;
+		Error += (b == c) ? 0 : 1;
+		Error += (a == c) ? 0 : 1;
+	}
+#	endif
+
 #	if GLM_HAS_TRIVIAL_QUERIES
 	//	Error += std::is_trivially_default_constructible<glm::vec4>::value ? 0 : 1;
 	//	Error += std::is_trivially_copy_assignable<glm::vec4>::value ? 0 : 1;

--- a/test/gtc/gtc_quaternion.cpp
+++ b/test/gtc/gtc_quaternion.cpp
@@ -177,39 +177,39 @@ int test_quat_slerp()
 	Error += glm::all(glm::epsilonEqual(id, id2, Epsilon)) ? 0 : 1;
 
 	// Testing a == 1
-	// Must be 90° rotation on Y : 0 0.7 0 0.7
+	// Must be 90deg rotation on Y : 0 0.7 0 0.7
 	glm::quat Y90rot2 = glm::slerp(id, Y90rot, 1.0f);
 	Error += glm::all(glm::epsilonEqual(Y90rot, Y90rot2, Epsilon)) ? 0 : 1;
 
 	// Testing standard, easy case
-	// Must be 45° rotation on Y : 0 0.38 0 0.92
+	// Must be 45deg rotation on Y : 0 0.38 0 0.92
 	glm::quat Y45rot1 = glm::slerp(id, Y90rot, 0.5f);
 
 	// Testing reverse case
-	// Must be 45° rotation on Y : 0 0.38 0 0.92
+	// Must be 45deg rotation on Y : 0 0.38 0 0.92
 	glm::quat Ym45rot2 = glm::slerp(Y90rot, id, 0.5f);
 
 	// Testing against full circle around the sphere instead of shortest path
-	// Must be 45° rotation on Y
-	// certainly not a 135° rotation
+	// Must be 45deg rotation on Y
+	// certainly not a 135deg rotation
 	glm::quat Y45rot3 = glm::slerp(id , -Y90rot, 0.5f);
 	float Y45angle3 = glm::angle(Y45rot3);
 	Error += glm::epsilonEqual(Y45angle3, glm::pi<float>() * 0.25f, Epsilon) ? 0 : 1;
 	Error += glm::all(glm::epsilonEqual(Ym45rot2, Y45rot3, Epsilon)) ? 0 : 1;
 
 	// Same, but inverted
-	// Must also be 45° rotation on Y :  0 0.38 0 0.92
+	// Must also be 45deg rotation on Y :  0 0.38 0 0.92
 	// -0 -0.38 -0 -0.92 is ok too
 	glm::quat Y45rot4 = glm::slerp(-Y90rot, id, 0.5f);
 	Error += glm::all(glm::epsilonEqual(Ym45rot2, -Y45rot4, Epsilon)) ? 0 : 1;
 
 	// Testing q1 = q2
-	// Must be 90° rotation on Y : 0 0.7 0 0.7
+	// Must be 90deg rotation on Y : 0 0.7 0 0.7
 	glm::quat Y90rot3 = glm::slerp(Y90rot, Y90rot, 0.5f);
 	Error += glm::all(glm::epsilonEqual(Y90rot, Y90rot3, Epsilon)) ? 0 : 1;
 
-	// Testing 180° rotation
-	// Must be 90° rotation on almost any axis that is on the XZ plane
+	// Testing 180deg rotation
+	// Must be 90deg rotation on almost any axis that is on the XZ plane
 	glm::quat XZ90rot = glm::slerp(id, -Y90rot, 0.5f);
 	float XZ90angle = glm::angle(XZ90rot); // Must be PI/4 = 0.78;
 	Error += glm::epsilonEqual(XZ90angle, glm::pi<float>() * 0.25f, Epsilon) ? 0 : 1;
@@ -297,6 +297,16 @@ int test_quat_mul_vec()
 int test_quat_ctr()
 {
 	int Error(0);
+
+#	ifdef GLM_META_PROG_HELPERS
+	{
+		glm::quat a(0, 1, 0, 0), b(0, 1, 0), c(0, 1);
+
+		Error += (a == b) ? 0 : 1;
+		Error += (b == c) ? 0 : 1;
+		Error += (a == c) ? 0 : 1;
+	}
+#	endif
 
 #	if GLM_HAS_TRIVIAL_QUERIES
 	//	Error += std::is_trivially_default_constructible<glm::quat>::value ? 0 : 1;

--- a/test/gtx/gtx_simd_vec4.cpp
+++ b/test/gtx/gtx_simd_vec4.cpp
@@ -29,22 +29,32 @@
 /// @author Christophe Riccio
 ///////////////////////////////////////////////////////////////////////////////////
 
+#define GLM_META_PROG_HELPERS
 #include <glm/glm.hpp>
 #include <glm/gtx/simd_vec4.hpp>
 #include <cstdio>
+
 
 #if(GLM_ARCH != GLM_ARCH_PURE)
 
 int main()
 {
+	int Error = 0;
 
 #ifdef GLM_META_PROG_HELPERS
 		assert(glm::simdVec4::components == glm::simdVec4::pure_type::components);
+	{
+		glm::simdVec4 a(1, 2, 0, 0), b(1, 2), c(1, 2, 0);
+
+		Error += (glm::vec4_cast(a) == glm::vec4_cast(b)) ? 0 : 1;
+		Error += (glm::vec4_cast(b) == glm::vec4_cast(c)) ? 0 : 1;
+		Error += (glm::vec4_cast(c) == glm::vec4_cast(a)) ? 0 : 1;
+	}
 #endif
 
 	glm::simdVec4 A1(0.0f, 0.1f, 0.2f, 0.3f);
 	glm::simdVec4 B1(0.4f, 0.5f, 0.6f, 0.7f);
-	glm::simdVec4 C1 = A1 + B1;
+	//glm::simdVec4 C1 = A1 + B1;
 	glm::simdVec4 D1 = A1.swizzle<glm::X, glm::Z, glm::Y, glm::W>();
 	glm::simdVec4 E1(glm::vec4(1.0f));
 	glm::vec4 F1 = glm::vec4_cast(E1);
@@ -61,7 +71,7 @@ int main()
 
 	glm::simdVec4 GNI(add0);
 
-	return 0;
+	return Error;
 }
 
 #else


### PR DESCRIPTION
In a project of mine, I need to be able to have functions that convert between all the different vector types at will (and matrices, and quaternions).  I do *not* feel like writing 225 different functions (`vec2`, `vec3`, and `vec4`, times the 5 instantiations I care about) to do this.  I managed to make it work with templates, but [it's not pretty](https://github.com/JesseTG/BALLS/blob/master/BALLS/BALLS/util/MetaTypeConverters.cpp).  If I could just use one constructor interface for each vector type, it would make things much easier on me.  So I did.