### PR TITLE
Add const qualifier in extractEulerAngleXYZ()

### DIFF
--- a/glm/gtx/euler_angles.hpp
+++ b/glm/gtx/euler_angles.hpp
@@ -161,7 +161,7 @@ namespace glm
     /// Extracts the (X * Y * Z) Euler angles from the rotation matrix M
     /// @see gtx_euler_angles
     template <typename T>
-    GLM_FUNC_DECL void extractEulerAngleXYZ(tmat4x4<T, defaultp> & M,
+    GLM_FUNC_DECL void extractEulerAngleXYZ(tmat4x4<T, defaultp> const & M,
                                             T & t1,
                                             T & t2,
                                             T & t3);

--- a/glm/gtx/euler_angles.inl
+++ b/glm/gtx/euler_angles.inl
@@ -323,7 +323,7 @@ namespace glm
 	}
     
     template <typename T>
-    GLM_FUNC_DECL void extractEulerAngleXYZ(tmat4x4<T, defaultp> & M,
+    GLM_FUNC_DECL void extractEulerAngleXYZ(tmat4x4<T, defaultp> const & M,
                                             T & t1,
                                             T & t2,
                                             T & t3)


### PR DESCRIPTION
The source rotation matrix is not affected by the function and can be made `const`.