### PR TITLE
Fix unintentional backface culling in triangle intersect

### DIFF
--- a/glm/gtx/intersect.inl
+++ b/glm/gtx/intersect.inl
@@ -73,43 +73,6 @@ namespace glm
 		return baryPosition.z >= typename genType::value_type(0.0f);
 	}
 
-	//template <typename genType>
-	//GLM_FUNC_QUALIFIER bool intersectRayTriangle
-	//(
-	//	genType const & orig, genType const & dir,
-	//	genType const & vert0, genType const & vert1, genType const & vert2,
-	//	genType & position
-	//)
-	//{
-	//	typename genType::value_type Epsilon = std::numeric_limits<typename genType::value_type>::epsilon();
-	//
-	//	genType edge1 = vert1 - vert0;
-	//	genType edge2 = vert2 - vert0;
-	//
-	//	genType pvec = cross(dir, edge2);
-	//
-	//	float det = dot(edge1, pvec);
-	//	if(det < Epsilon)
-	//		return false;
-	//
-	//	genType tvec = orig - vert0;
-	//
-	//	position.y = dot(tvec, pvec);
-	//	if (position.y < typename genType::value_type(0) || position.y > det)
-	//		return typename genType::value_type(0);
-	//
-	//	genType qvec = cross(tvec, edge1);
-	//
-	//	position.z = dot(dir, qvec);
-	//	if (position.z < typename genType::value_type(0) || position.y + position.z > det)
-	//		return typename genType::value_type(0);
-	//
-	//	position.x = dot(edge2, qvec);
-	//	position *= typename genType::value_type(1) / det;
-	//
-	//	return typename genType::value_type(1);
-	//}
-
 	template <typename genType>
 	GLM_FUNC_QUALIFIER bool intersectLineTriangle
 	(

--- a/glm/gtx/intersect.inl
+++ b/glm/gtx/intersect.inl
@@ -49,7 +49,7 @@ namespace glm
 		typename genType::value_type a = glm::dot(e1, p);
 
 		typename genType::value_type Epsilon = std::numeric_limits<typename genType::value_type>::epsilon();
-		if(a < Epsilon)
+		if(a < Epsilon && a > -Epsilon)
 			return false;
 
 		typename genType::value_type f = typename genType::value_type(1.0f) / a;

--- a/readme.md
+++ b/readme.md
@@ -68,6 +68,7 @@ glm::mat4 camera(float Translate, glm::vec2 const & Rotate)
 
 ##### Fixes:
 - Fixed GTX_extended_min_max filename typo #386
+- Fixed intersectRayTriangle to not do any unintentional backface culling
 
 #### [GLM 0.9.7.2](https://github.com/g-truc/glm/tree/0.9.7) - 2015-XX-XX
 ##### Fixes:


### PR DESCRIPTION
This also fixes #194. The backface culling is unintentional because it is not documented anywhere and we can't give the triangle a normal so just assume the general case.