### PR TITLE
test: Don't use 'Error:' or 'error:' in test output

### DIFF
--- a/test/gtx/gtx_integer.cpp
+++ b/test/gtx/gtx_integer.cpp
@@ -63,10 +63,10 @@ int test_log2()
 		Error += glm::abs(double(A) - B) <= 24 ? 0 : 1;
 		assert(!Error);
 
-		printf("Log2(%d) Error: %d, %d\n", 1 << i, A, B);
+		printf("Log2(%d) error A=%d, B=%d\n", 1 << i, A, B);
 	}
 
-	printf("log2 error: %d\n", Error);
+	printf("log2 error=%d\n", Error);
 
 	return Error;
 }


### PR DESCRIPTION
This is parsed by msbuild when using cmake-generated Visual Studio project files, and will automatically fail the build if encountered.  This is a bug (or badly designed intentional behaviour) in
msbuild.  It's not a bug in glm.  See http://blogs.msdn.com/b/dsvc/archive/2012/02/29/output-from-exec-task-resulting-in-build-failure.aspx for further details.

Note that this won't be apparent when running the tests directly from the glm build tree with `ctest`.  You will see it when running the glm tests as part of a larger project build which contains glm as a component.  For example:

- http://pastebin.ca/3211683 is the build failing without this change
- http://pastebin.ca/3211759 is the build succeeding with this change

Note I will look at getting cmake changed to run msbuild configured to ignore these errors (if it's possible), but it would be nice to have it fixed in glm as well for people using older and current cmake versions, and for people using msbuild or other tools directly where it's not easy to fix, especially since the workaround in glm is trivial.


Thanks for your consideration,
Roger