### PR TITLE
Fixed build by adding missing scope

### DIFF
--- a/glm/detail/func_trigonometric.inl
+++ b/glm/detail/func_trigonometric.inl
@@ -123,7 +123,7 @@ namespace glm
 	template <typename T, precision P, template <typename, precision> class vecType>
 	GLM_FUNC_QUALIFIER vecType<T, P> atan(vecType<T, P> const & a, vecType<T, P> const & b)
 	{
-		return detail::functor2<T, P, vecType>::call(atan2, a, b);
+		return detail::functor2<T, P, vecType>::call(::std::atan2, a, b);
 	}
 
 	using std::atan;


### PR DESCRIPTION
Hi,

I've been getting a build error in glm compiling with QNX QCC (basically a wrapper for GCC 4.2.2 as far as I can tell). Anyhow it looks like there was a scope missing from an atan2 call so I've fixed that and it's building fine for me now.

Not sure if this is something you'd like to merge in, but I figured I'd offer it up just in case. Oh and this is my first attempt at a pull request, so forgive me if I've got anything wrong here!

Thanks,

Laurie