### PR TITLE
Fixed: outerProduct defintions and operator signatures for mat2x4 and vec4

### DIFF
--- a/glm/detail/func_matrix.hpp
+++ b/glm/detail/func_matrix.hpp
@@ -72,19 +72,19 @@ namespace detail
 	template <typename T, precision P>
 	struct outerProduct_trait<T, P, tvec2, tvec3>
 	{
-		typedef tmat2x3<T, P> type;
+		typedef tmat3x2<T, P> type;
 	};
 
 	template <typename T, precision P>
 	struct outerProduct_trait<T, P, tvec2, tvec4>
 	{
-		typedef tmat2x4<T, P> type;
+		typedef tmat4x2<T, P> type;
 	};
 
 	template <typename T, precision P>
 	struct outerProduct_trait<T, P, tvec3, tvec2>
 	{
-		typedef tmat3x2<T, P> type;
+		typedef tmat2x3<T, P> type;
 	};
 
 	template <typename T, precision P>
@@ -96,19 +96,19 @@ namespace detail
 	template <typename T, precision P>
 	struct outerProduct_trait<T, P, tvec3, tvec4>
 	{
-		typedef tmat3x4<T, P> type;
+		typedef tmat4x3<T, P> type;
 	};
 
 	template <typename T, precision P>
 	struct outerProduct_trait<T, P, tvec4, tvec2>
 	{
-		typedef tmat4x2<T, P> type;
+		typedef tmat2x4<T, P> type;
 	};
 
 	template <typename T, precision P>
 	struct outerProduct_trait<T, P, tvec4, tvec3>
 	{
-		typedef tmat4x3<T, P> type;
+		typedef tmat3x4<T, P> type;
 	};
 
 	template <typename T, precision P>

--- a/glm/detail/type_mat2x4.hpp
+++ b/glm/detail/type_mat2x4.hpp
@@ -197,7 +197,7 @@ namespace glm
 	GLM_FUNC_DECL tmat3x4<T, P> operator*(tmat2x4<T, P> const & m1, tmat3x2<T, P> const & m2);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tmat2x4<T, P> operator/(tmat2x4<T, P> const & m, T s);
+	GLM_FUNC_DECL tmat2x4<T, P> operator/(tmat2x4<T, P> const & m, const T& s);
 
 	template <typename T, precision P>
 	GLM_FUNC_DECL tmat2x4<T, P> operator/(T s, tmat2x4<T, P> const & m);

--- a/glm/detail/type_mat2x4.inl
+++ b/glm/detail/type_mat2x4.inl
@@ -500,7 +500,7 @@ namespace glm
 	}
 
 	template <typename T, precision P> 
-	GLM_FUNC_QUALIFIER tmat2x4<T, P> operator/(tmat2x4<T, P> const & m, T s)
+	GLM_FUNC_QUALIFIER tmat2x4<T, P> operator/(tmat2x4<T, P> const & m, const T& s)
 	{
 		return tmat2x4<T, P>(
 			m[0] / s,

--- a/glm/detail/type_vec4.hpp
+++ b/glm/detail/type_vec4.hpp
@@ -379,7 +379,7 @@ namespace detail
 	// -- Binary operators --
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec4<T, P> operator+(tvec4<T, P> const & v, T scalar);
+	GLM_FUNC_DECL tvec4<T, P> operator+(tvec4<T, P> const & v, const T& scalar);
 
 	template <typename T, precision P>
 	GLM_FUNC_DECL tvec4<T, P> operator+(tvec4<T, P> const & v, tvec1<T, P> const & scalar);
@@ -394,7 +394,7 @@ namespace detail
 	GLM_FUNC_DECL tvec4<T, P> operator+(tvec4<T, P> const & v1, tvec4<T, P> const & v2);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec4<T, P> operator-(tvec4<T, P> const & v, T scalar);
+	GLM_FUNC_DECL tvec4<T, P> operator-(tvec4<T, P> const & v, const T& scalar);
 
 	template <typename T, precision P>
 	GLM_FUNC_DECL tvec4<T, P> operator-(tvec4<T, P> const & v, tvec1<T, P> const & scalar);
@@ -409,7 +409,7 @@ namespace detail
 	GLM_FUNC_DECL tvec4<T, P> operator-(tvec4<T, P> const & v1, tvec4<T, P> const & v2);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec4<T, P> operator*(tvec4<T, P> const & v, T scalar);
+	GLM_FUNC_DECL tvec4<T, P> operator*(tvec4<T, P> const & v, const T& scalar);
 
 	template <typename T, precision P>
 	GLM_FUNC_DECL tvec4<T, P> operator*(tvec4<T, P> const & v, tvec1<T, P> const & scalar);
@@ -424,7 +424,7 @@ namespace detail
 	GLM_FUNC_DECL tvec4<T, P> operator*(tvec4<T, P> const & v1, tvec4<T, P> const & v2);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec4<T, P> operator/(tvec4<T, P> const & v, T scalar);
+	GLM_FUNC_DECL tvec4<T, P> operator/(tvec4<T, P> const & v, const T& scalar);
 
 	template <typename T, precision P>
 	GLM_FUNC_DECL tvec4<T, P> operator/(tvec4<T, P> const & v, tvec1<T, P> const & scalar);

--- a/glm/detail/type_vec4.inl
+++ b/glm/detail/type_vec4.inl
@@ -730,7 +730,7 @@ namespace glm
 	// -- Binary arithmetic operators --
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tvec4<T, P> operator+(tvec4<T, P> const & v, T scalar)
+	GLM_FUNC_QUALIFIER tvec4<T, P> operator+(tvec4<T, P> const & v, const T& scalar)
 	{
 		return tvec4<T, P>(
 			v.x + scalar,
@@ -760,7 +760,7 @@ namespace glm
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tvec4<T, P> operator-(tvec4<T, P> const & v, T scalar)
+	GLM_FUNC_QUALIFIER tvec4<T, P> operator-(tvec4<T, P> const & v, const T& scalar)
 	{
 		return tvec4<T, P>(
 			v.x - scalar,
@@ -790,7 +790,7 @@ namespace glm
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tvec4<T, P> operator*(tvec4<T, P> const & v, T scalar)
+	GLM_FUNC_QUALIFIER tvec4<T, P> operator*(tvec4<T, P> const & v, const T& scalar)
 	{
 		return tvec4<T, P>(
 			v.x * scalar,
@@ -820,7 +820,7 @@ namespace glm
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tvec4<T, P> operator/(tvec4<T, P> const & v, T scalar)
+	GLM_FUNC_QUALIFIER tvec4<T, P> operator/(tvec4<T, P> const & v, const T& scalar)
 	{
 		return tvec4<T, P>(
 			v.x / scalar,

--- a/test/core/core_func_matrix.cpp
+++ b/test/core/core_func_matrix.cpp
@@ -101,7 +101,18 @@ int test_matrixCompMult()
 
 int test_outerProduct()
 {
-	glm::mat4 m = glm::outerProduct(glm::vec4(1.0f), glm::vec4(1.0f));
+	{ glm::mat2 m = glm::outerProduct(glm::vec2(1.0f), glm::vec2(1.0f)); }
+	{ glm::mat3 m = glm::outerProduct(glm::vec3(1.0f), glm::vec3(1.0f)); }
+	{ glm::mat4 m = glm::outerProduct(glm::vec4(1.0f), glm::vec4(1.0f)); }
+
+  { glm::mat2x3 m = glm::outerProduct(glm::vec3(1.0f), glm::vec2(1.0f)); }
+  { glm::mat2x4 m = glm::outerProduct(glm::vec4(1.0f), glm::vec2(1.0f)); }
+
+  { glm::mat3x2 m = glm::outerProduct(glm::vec2(1.0f), glm::vec3(1.0f)); }
+  { glm::mat3x4 m = glm::outerProduct(glm::vec4(1.0f), glm::vec3(1.0f)); }
+  
+  { glm::mat4x2 m = glm::outerProduct(glm::vec2(1.0f), glm::vec4(1.0f)); }
+  { glm::mat4x3 m = glm::outerProduct(glm::vec3(1.0f), glm::vec4(1.0f)); }
 
 	return 0;
 }


### PR DESCRIPTION
This sometimes causes problems when trying to refer to overloaded operators with signatures while using C++ meta programming.

I used the other classes mat4x3, mat4, ... (and vec2/vec3) as references, so these are probably the ones which do not use the intended signatures.