### PR TITLE
Introduce the ability to allow most explicit conversions to be implicit

### DIFF
--- a/glm/detail/setup.hpp
+++ b/glm/detail/setup.hpp
@@ -942,6 +942,12 @@
 #	define GLM_RELAXED_CONSTEXPR const
 #endif
 
+#ifdef GLM_IMPLICIT_CONVERSION_CTOR
+#	define GLM_EXPLICIT_CONV
+#else
+#	define GLM_EXPLICIT_CONV explicit
+#endif
+
 #ifdef GLM_FORCE_EXPLICIT_CTOR
 #	define GLM_EXPLICIT explicit
 #else

--- a/glm/detail/type_mat2x2.hpp
+++ b/glm/detail/type_mat2x2.hpp
@@ -102,14 +102,14 @@ namespace glm
 		template <typename U, precision Q>
 		GLM_FUNC_DECL GLM_EXPLICIT tmat2x2(tmat2x2<U, Q> const & m);
 
-		GLM_FUNC_DECL explicit tmat2x2(tmat3x3<T, P> const & x);
-		GLM_FUNC_DECL explicit tmat2x2(tmat4x4<T, P> const & x);
-		GLM_FUNC_DECL explicit tmat2x2(tmat2x3<T, P> const & x);
-		GLM_FUNC_DECL explicit tmat2x2(tmat3x2<T, P> const & x);
-		GLM_FUNC_DECL explicit tmat2x2(tmat2x4<T, P> const & x);
-		GLM_FUNC_DECL explicit tmat2x2(tmat4x2<T, P> const & x);
-		GLM_FUNC_DECL explicit tmat2x2(tmat3x4<T, P> const & x);
-		GLM_FUNC_DECL explicit tmat2x2(tmat4x3<T, P> const & x);
+		GLM_FUNC_DECL GLM_EXPLICIT_CONV tmat2x2(tmat3x3<T, P> const & x);
+		GLM_FUNC_DECL GLM_EXPLICIT_CONV tmat2x2(tmat4x4<T, P> const & x);
+		GLM_FUNC_DECL GLM_EXPLICIT_CONV tmat2x2(tmat2x3<T, P> const & x);
+		GLM_FUNC_DECL GLM_EXPLICIT_CONV tmat2x2(tmat3x2<T, P> const & x);
+		GLM_FUNC_DECL GLM_EXPLICIT_CONV tmat2x2(tmat2x4<T, P> const & x);
+		GLM_FUNC_DECL GLM_EXPLICIT_CONV tmat2x2(tmat4x2<T, P> const & x);
+		GLM_FUNC_DECL GLM_EXPLICIT_CONV tmat2x2(tmat3x4<T, P> const & x);
+		GLM_FUNC_DECL GLM_EXPLICIT_CONV tmat2x2(tmat4x3<T, P> const & x);
 
 		// -- Accesses --
 

--- a/glm/detail/type_mat2x3.hpp
+++ b/glm/detail/type_mat2x3.hpp
@@ -99,14 +99,14 @@ namespace glm
 		template <typename U, precision Q>
 		GLM_FUNC_DECL GLM_EXPLICIT tmat2x3(tmat2x3<U, Q> const & m);
 
-		GLM_FUNC_DECL explicit tmat2x3(tmat2x2<T, P> const & x);
-		GLM_FUNC_DECL explicit tmat2x3(tmat3x3<T, P> const & x);
-		GLM_FUNC_DECL explicit tmat2x3(tmat4x4<T, P> const & x);
-		GLM_FUNC_DECL explicit tmat2x3(tmat2x4<T, P> const & x);
-		GLM_FUNC_DECL explicit tmat2x3(tmat3x2<T, P> const & x);
-		GLM_FUNC_DECL explicit tmat2x3(tmat3x4<T, P> const & x);
-		GLM_FUNC_DECL explicit tmat2x3(tmat4x2<T, P> const & x);
-		GLM_FUNC_DECL explicit tmat2x3(tmat4x3<T, P> const & x);
+		GLM_FUNC_DECL GLM_EXPLICIT_CONV tmat2x3(tmat2x2<T, P> const & x);
+		GLM_FUNC_DECL GLM_EXPLICIT_CONV tmat2x3(tmat3x3<T, P> const & x);
+		GLM_FUNC_DECL GLM_EXPLICIT_CONV tmat2x3(tmat4x4<T, P> const & x);
+		GLM_FUNC_DECL GLM_EXPLICIT_CONV tmat2x3(tmat2x4<T, P> const & x);
+		GLM_FUNC_DECL GLM_EXPLICIT_CONV tmat2x3(tmat3x2<T, P> const & x);
+		GLM_FUNC_DECL GLM_EXPLICIT_CONV tmat2x3(tmat3x4<T, P> const & x);
+		GLM_FUNC_DECL GLM_EXPLICIT_CONV tmat2x3(tmat4x2<T, P> const & x);
+		GLM_FUNC_DECL GLM_EXPLICIT_CONV tmat2x3(tmat4x3<T, P> const & x);
 
 		// -- Accesses --
 

--- a/glm/detail/type_mat2x4.hpp
+++ b/glm/detail/type_mat2x4.hpp
@@ -101,14 +101,14 @@ namespace glm
 		template <typename U, precision Q>
 		GLM_FUNC_DECL GLM_EXPLICIT tmat2x4(tmat2x4<U, Q> const & m);
 
-		GLM_FUNC_DECL explicit tmat2x4(tmat2x2<T, P> const & x);
-		GLM_FUNC_DECL explicit tmat2x4(tmat3x3<T, P> const & x);
-		GLM_FUNC_DECL explicit tmat2x4(tmat4x4<T, P> const & x);
-		GLM_FUNC_DECL explicit tmat2x4(tmat2x3<T, P> const & x);
-		GLM_FUNC_DECL explicit tmat2x4(tmat3x2<T, P> const & x);
-		GLM_FUNC_DECL explicit tmat2x4(tmat3x4<T, P> const & x);
-		GLM_FUNC_DECL explicit tmat2x4(tmat4x2<T, P> const & x);
-		GLM_FUNC_DECL explicit tmat2x4(tmat4x3<T, P> const & x);
+		GLM_FUNC_DECL GLM_EXPLICIT_CONV tmat2x4(tmat2x2<T, P> const & x);
+		GLM_FUNC_DECL GLM_EXPLICIT_CONV tmat2x4(tmat3x3<T, P> const & x);
+		GLM_FUNC_DECL GLM_EXPLICIT_CONV tmat2x4(tmat4x4<T, P> const & x);
+		GLM_FUNC_DECL GLM_EXPLICIT_CONV tmat2x4(tmat2x3<T, P> const & x);
+		GLM_FUNC_DECL GLM_EXPLICIT_CONV tmat2x4(tmat3x2<T, P> const & x);
+		GLM_FUNC_DECL GLM_EXPLICIT_CONV tmat2x4(tmat3x4<T, P> const & x);
+		GLM_FUNC_DECL GLM_EXPLICIT_CONV tmat2x4(tmat4x2<T, P> const & x);
+		GLM_FUNC_DECL GLM_EXPLICIT_CONV tmat2x4(tmat4x3<T, P> const & x);
 
 		// -- Accesses --
 

--- a/glm/detail/type_mat3x2.hpp
+++ b/glm/detail/type_mat3x2.hpp
@@ -106,14 +106,14 @@ namespace glm
 		template <typename U, precision Q>
 		GLM_FUNC_DECL GLM_EXPLICIT tmat3x2(tmat3x2<U, Q> const & m);
 
-		GLM_FUNC_DECL explicit tmat3x2(tmat2x2<T, P> const & x);
-		GLM_FUNC_DECL explicit tmat3x2(tmat3x3<T, P> const & x);
-		GLM_FUNC_DECL explicit tmat3x2(tmat4x4<T, P> const & x);
-		GLM_FUNC_DECL explicit tmat3x2(tmat2x3<T, P> const & x);
-		GLM_FUNC_DECL explicit tmat3x2(tmat2x4<T, P> const & x);
-		GLM_FUNC_DECL explicit tmat3x2(tmat3x4<T, P> const & x);
-		GLM_FUNC_DECL explicit tmat3x2(tmat4x2<T, P> const & x);
-		GLM_FUNC_DECL explicit tmat3x2(tmat4x3<T, P> const & x);
+		GLM_FUNC_DECL GLM_EXPLICIT_CONV tmat3x2(tmat2x2<T, P> const & x);
+		GLM_FUNC_DECL GLM_EXPLICIT_CONV tmat3x2(tmat3x3<T, P> const & x);
+		GLM_FUNC_DECL GLM_EXPLICIT_CONV tmat3x2(tmat4x4<T, P> const & x);
+		GLM_FUNC_DECL GLM_EXPLICIT_CONV tmat3x2(tmat2x3<T, P> const & x);
+		GLM_FUNC_DECL GLM_EXPLICIT_CONV tmat3x2(tmat2x4<T, P> const & x);
+		GLM_FUNC_DECL GLM_EXPLICIT_CONV tmat3x2(tmat3x4<T, P> const & x);
+		GLM_FUNC_DECL GLM_EXPLICIT_CONV tmat3x2(tmat4x2<T, P> const & x);
+		GLM_FUNC_DECL GLM_EXPLICIT_CONV tmat3x2(tmat4x3<T, P> const & x);
 
 		// -- Accesses --
 

--- a/glm/detail/type_mat3x3.hpp
+++ b/glm/detail/type_mat3x3.hpp
@@ -110,14 +110,14 @@ namespace glm
 		template <typename U, precision Q>
 		GLM_FUNC_DECL GLM_EXPLICIT tmat3x3(tmat3x3<U, Q> const & m);
 
-		GLM_FUNC_DECL explicit tmat3x3(tmat2x2<T, P> const & x);
-		GLM_FUNC_DECL explicit tmat3x3(tmat4x4<T, P> const & x);
-		GLM_FUNC_DECL explicit tmat3x3(tmat2x3<T, P> const & x);
-		GLM_FUNC_DECL explicit tmat3x3(tmat3x2<T, P> const & x);
-		GLM_FUNC_DECL explicit tmat3x3(tmat2x4<T, P> const & x);
-		GLM_FUNC_DECL explicit tmat3x3(tmat4x2<T, P> const & x);
-		GLM_FUNC_DECL explicit tmat3x3(tmat3x4<T, P> const & x);
-		GLM_FUNC_DECL explicit tmat3x3(tmat4x3<T, P> const & x);
+		GLM_FUNC_DECL GLM_EXPLICIT_CONV tmat3x3(tmat2x2<T, P> const & x);
+		GLM_FUNC_DECL GLM_EXPLICIT_CONV tmat3x3(tmat4x4<T, P> const & x);
+		GLM_FUNC_DECL GLM_EXPLICIT_CONV tmat3x3(tmat2x3<T, P> const & x);
+		GLM_FUNC_DECL GLM_EXPLICIT_CONV tmat3x3(tmat3x2<T, P> const & x);
+		GLM_FUNC_DECL GLM_EXPLICIT_CONV tmat3x3(tmat2x4<T, P> const & x);
+		GLM_FUNC_DECL GLM_EXPLICIT_CONV tmat3x3(tmat4x2<T, P> const & x);
+		GLM_FUNC_DECL GLM_EXPLICIT_CONV tmat3x3(tmat3x4<T, P> const & x);
+		GLM_FUNC_DECL GLM_EXPLICIT_CONV tmat3x3(tmat4x3<T, P> const & x);
 
 		// -- Accesses --
 

--- a/glm/detail/type_mat3x4.hpp
+++ b/glm/detail/type_mat3x4.hpp
@@ -106,14 +106,14 @@ namespace glm
 		template <typename U, precision Q>
 		GLM_FUNC_DECL GLM_EXPLICIT tmat3x4(tmat3x4<U, Q> const & m);
 
-		GLM_FUNC_DECL explicit tmat3x4(tmat2x2<T, P> const & x);
-		GLM_FUNC_DECL explicit tmat3x4(tmat3x3<T, P> const & x);
-		GLM_FUNC_DECL explicit tmat3x4(tmat4x4<T, P> const & x);
-		GLM_FUNC_DECL explicit tmat3x4(tmat2x3<T, P> const & x);
-		GLM_FUNC_DECL explicit tmat3x4(tmat3x2<T, P> const & x);
-		GLM_FUNC_DECL explicit tmat3x4(tmat2x4<T, P> const & x);
-		GLM_FUNC_DECL explicit tmat3x4(tmat4x2<T, P> const & x);
-		GLM_FUNC_DECL explicit tmat3x4(tmat4x3<T, P> const & x);
+		GLM_FUNC_DECL GLM_EXPLICIT_CONV tmat3x4(tmat2x2<T, P> const & x);
+		GLM_FUNC_DECL GLM_EXPLICIT_CONV tmat3x4(tmat3x3<T, P> const & x);
+		GLM_FUNC_DECL GLM_EXPLICIT_CONV tmat3x4(tmat4x4<T, P> const & x);
+		GLM_FUNC_DECL GLM_EXPLICIT_CONV tmat3x4(tmat2x3<T, P> const & x);
+		GLM_FUNC_DECL GLM_EXPLICIT_CONV tmat3x4(tmat3x2<T, P> const & x);
+		GLM_FUNC_DECL GLM_EXPLICIT_CONV tmat3x4(tmat2x4<T, P> const & x);
+		GLM_FUNC_DECL GLM_EXPLICIT_CONV tmat3x4(tmat4x2<T, P> const & x);
+		GLM_FUNC_DECL GLM_EXPLICIT_CONV tmat3x4(tmat4x3<T, P> const & x);
 
 		// -- Accesses --
 

--- a/glm/detail/type_mat4x2.hpp
+++ b/glm/detail/type_mat4x2.hpp
@@ -111,14 +111,14 @@ namespace glm
 		template <typename U, precision Q>
 		GLM_FUNC_DECL GLM_EXPLICIT tmat4x2(tmat4x2<U, Q> const & m);
 
-		GLM_FUNC_DECL explicit tmat4x2(tmat2x2<T, P> const & x);
-		GLM_FUNC_DECL explicit tmat4x2(tmat3x3<T, P> const & x);
-		GLM_FUNC_DECL explicit tmat4x2(tmat4x4<T, P> const & x);
-		GLM_FUNC_DECL explicit tmat4x2(tmat2x3<T, P> const & x);
-		GLM_FUNC_DECL explicit tmat4x2(tmat3x2<T, P> const & x);
-		GLM_FUNC_DECL explicit tmat4x2(tmat2x4<T, P> const & x);
-		GLM_FUNC_DECL explicit tmat4x2(tmat4x3<T, P> const & x);
-		GLM_FUNC_DECL explicit tmat4x2(tmat3x4<T, P> const & x);
+		GLM_FUNC_DECL GLM_EXPLICIT_CONV tmat4x2(tmat2x2<T, P> const & x);
+		GLM_FUNC_DECL GLM_EXPLICIT_CONV tmat4x2(tmat3x3<T, P> const & x);
+		GLM_FUNC_DECL GLM_EXPLICIT_CONV tmat4x2(tmat4x4<T, P> const & x);
+		GLM_FUNC_DECL GLM_EXPLICIT_CONV tmat4x2(tmat2x3<T, P> const & x);
+		GLM_FUNC_DECL GLM_EXPLICIT_CONV tmat4x2(tmat3x2<T, P> const & x);
+		GLM_FUNC_DECL GLM_EXPLICIT_CONV tmat4x2(tmat2x4<T, P> const & x);
+		GLM_FUNC_DECL GLM_EXPLICIT_CONV tmat4x2(tmat4x3<T, P> const & x);
+		GLM_FUNC_DECL GLM_EXPLICIT_CONV tmat4x2(tmat3x4<T, P> const & x);
 
 		// -- Accesses --
 

--- a/glm/detail/type_mat4x3.hpp
+++ b/glm/detail/type_mat4x3.hpp
@@ -111,14 +111,14 @@ namespace glm
 		template <typename U, precision Q>
 		GLM_FUNC_DECL GLM_EXPLICIT tmat4x3(tmat4x3<U, Q> const & m);
 
-		GLM_FUNC_DECL explicit tmat4x3(tmat2x2<T, P> const & x);
-		GLM_FUNC_DECL explicit tmat4x3(tmat3x3<T, P> const & x);
-		GLM_FUNC_DECL explicit tmat4x3(tmat4x4<T, P> const & x);
-		GLM_FUNC_DECL explicit tmat4x3(tmat2x3<T, P> const & x);
-		GLM_FUNC_DECL explicit tmat4x3(tmat3x2<T, P> const & x);
-		GLM_FUNC_DECL explicit tmat4x3(tmat2x4<T, P> const & x);
-		GLM_FUNC_DECL explicit tmat4x3(tmat4x2<T, P> const & x);
-		GLM_FUNC_DECL explicit tmat4x3(tmat3x4<T, P> const & x);
+		GLM_FUNC_DECL GLM_EXPLICIT_CONV tmat4x3(tmat2x2<T, P> const & x);
+		GLM_FUNC_DECL GLM_EXPLICIT_CONV tmat4x3(tmat3x3<T, P> const & x);
+		GLM_FUNC_DECL GLM_EXPLICIT_CONV tmat4x3(tmat4x4<T, P> const & x);
+		GLM_FUNC_DECL GLM_EXPLICIT_CONV tmat4x3(tmat2x3<T, P> const & x);
+		GLM_FUNC_DECL GLM_EXPLICIT_CONV tmat4x3(tmat3x2<T, P> const & x);
+		GLM_FUNC_DECL GLM_EXPLICIT_CONV tmat4x3(tmat2x4<T, P> const & x);
+		GLM_FUNC_DECL GLM_EXPLICIT_CONV tmat4x3(tmat4x2<T, P> const & x);
+		GLM_FUNC_DECL GLM_EXPLICIT_CONV tmat4x3(tmat3x4<T, P> const & x);
 
 		// -- Accesses --
 

--- a/glm/detail/type_mat4x4.hpp
+++ b/glm/detail/type_mat4x4.hpp
@@ -115,14 +115,14 @@ namespace glm
 		template <typename U, precision Q>
 		GLM_FUNC_DECL GLM_EXPLICIT tmat4x4(tmat4x4<U, Q> const & m);
 
-		GLM_FUNC_DECL explicit tmat4x4(tmat2x2<T, P> const & x);
-		GLM_FUNC_DECL explicit tmat4x4(tmat3x3<T, P> const & x);
-		GLM_FUNC_DECL explicit tmat4x4(tmat2x3<T, P> const & x);
-		GLM_FUNC_DECL explicit tmat4x4(tmat3x2<T, P> const & x);
-		GLM_FUNC_DECL explicit tmat4x4(tmat2x4<T, P> const & x);
-		GLM_FUNC_DECL explicit tmat4x4(tmat4x2<T, P> const & x);
-		GLM_FUNC_DECL explicit tmat4x4(tmat3x4<T, P> const & x);
-		GLM_FUNC_DECL explicit tmat4x4(tmat4x3<T, P> const & x);
+		GLM_FUNC_DECL GLM_EXPLICIT_CONV tmat4x4(tmat2x2<T, P> const & x);
+		GLM_FUNC_DECL GLM_EXPLICIT_CONV tmat4x4(tmat3x3<T, P> const & x);
+		GLM_FUNC_DECL GLM_EXPLICIT_CONV tmat4x4(tmat2x3<T, P> const & x);
+		GLM_FUNC_DECL GLM_EXPLICIT_CONV tmat4x4(tmat3x2<T, P> const & x);
+		GLM_FUNC_DECL GLM_EXPLICIT_CONV tmat4x4(tmat2x4<T, P> const & x);
+		GLM_FUNC_DECL GLM_EXPLICIT_CONV tmat4x4(tmat4x2<T, P> const & x);
+		GLM_FUNC_DECL GLM_EXPLICIT_CONV tmat4x4(tmat3x4<T, P> const & x);
+		GLM_FUNC_DECL GLM_EXPLICIT_CONV tmat4x4(tmat4x3<T, P> const & x);
 
 		// -- Accesses --
 

--- a/glm/detail/type_vec1.hpp
+++ b/glm/detail/type_vec1.hpp
@@ -126,13 +126,13 @@ namespace glm
 
 		/// Explicit conversions (From section 5.4.1 Conversion and scalar constructors of GLSL 1.30.08 specification)
 		template <typename U, precision Q>
-		GLM_FUNC_DECL explicit tvec1(tvec2<U, Q> const & v);
+		GLM_FUNC_DECL GLM_EXPLICIT_CONV tvec1(tvec2<U, Q> const & v);
 		/// Explicit conversions (From section 5.4.1 Conversion and scalar constructors of GLSL 1.30.08 specification)
 		template <typename U, precision Q>
-		GLM_FUNC_DECL explicit tvec1(tvec3<U, Q> const & v);
+		GLM_FUNC_DECL GLM_EXPLICIT_CONV tvec1(tvec3<U, Q> const & v);
 		/// Explicit conversions (From section 5.4.1 Conversion and scalar constructors of GLSL 1.30.08 specification)
 		template <typename U, precision Q>
-		GLM_FUNC_DECL explicit tvec1(tvec4<U, Q> const & v);
+		GLM_FUNC_DECL GLM_EXPLICIT_CONV tvec1(tvec4<U, Q> const & v);
 
 		/// Explicit conversions (From section 5.4.1 Conversion and scalar constructors of GLSL 1.30.08 specification)
 		template <typename U, precision Q>

--- a/glm/detail/type_vec2.hpp
+++ b/glm/detail/type_vec2.hpp
@@ -138,10 +138,10 @@ namespace glm
 
 		/// Explicit conversions (From section 5.4.1 Conversion and scalar constructors of GLSL 1.30.08 specification)
 		template <typename U, precision Q>
-		GLM_FUNC_DECL explicit tvec2(tvec3<U, Q> const & v);
+		GLM_FUNC_DECL GLM_EXPLICIT_CONV tvec2(tvec3<U, Q> const & v);
 		/// Explicit conversions (From section 5.4.1 Conversion and scalar constructors of GLSL 1.30.08 specification)
 		template <typename U, precision Q>
-		GLM_FUNC_DECL explicit tvec2(tvec4<U, Q> const & v);
+		GLM_FUNC_DECL GLM_EXPLICIT_CONV tvec2(tvec4<U, Q> const & v);
 
 		/// Explicit conversions (From section 5.4.1 Conversion and scalar constructors of GLSL 1.30.08 specification)
 		template <typename U, precision Q>

--- a/glm/detail/type_vec3.hpp
+++ b/glm/detail/type_vec3.hpp
@@ -143,19 +143,19 @@ namespace glm
 
 		/// Explicit conversions (From section 5.4.1 Conversion and scalar constructors of GLSL 1.30.08 specification)
 		template <typename A, typename B, precision Q>
-		GLM_FUNC_DECL explicit tvec3(tvec2<A, Q> const & a, B const & b);
+		GLM_FUNC_DECL GLM_EXPLICIT_CONV tvec3(tvec2<A, Q> const & a, B const & b);
 		/// Explicit conversions (From section 5.4.1 Conversion and scalar constructors of GLSL 1.30.08 specification)
 		template <typename A, typename B, precision Q>
-		GLM_FUNC_DECL explicit tvec3(tvec2<A, Q> const & a, tvec1<B, Q> const & b);
+		GLM_FUNC_DECL GLM_EXPLICIT_CONV tvec3(tvec2<A, Q> const & a, tvec1<B, Q> const & b);
 		/// Explicit conversions (From section 5.4.1 Conversion and scalar constructors of GLSL 1.30.08 specification)
 		template <typename A, typename B, precision Q>
-		GLM_FUNC_DECL explicit tvec3(A const & a, tvec2<B, Q> const & b);
+		GLM_FUNC_DECL GLM_EXPLICIT_CONV tvec3(A const & a, tvec2<B, Q> const & b);
 		/// Explicit conversions (From section 5.4.1 Conversion and scalar constructors of GLSL 1.30.08 specification)
 		template <typename A, typename B, precision Q>
-		GLM_FUNC_DECL explicit tvec3(tvec1<A, Q> const & a, tvec2<B, Q> const & b);
+		GLM_FUNC_DECL GLM_EXPLICIT_CONV tvec3(tvec1<A, Q> const & a, tvec2<B, Q> const & b);
 		/// Explicit conversions (From section 5.4.1 Conversion and scalar constructors of GLSL 1.30.08 specification)
 		template <typename U, precision Q>
-		GLM_FUNC_DECL explicit tvec3(tvec4<U, Q> const & v);
+		GLM_FUNC_DECL GLM_EXPLICIT_CONV tvec3(tvec4<U, Q> const & v);
 
 		/// Explicit conversions (From section 5.4.1 Conversion and scalar constructors of GLSL 1.30.08 specification)
 		template <typename U, precision Q>

--- a/glm/detail/type_vec4.hpp
+++ b/glm/detail/type_vec4.hpp
@@ -208,37 +208,37 @@ namespace detail
 
 		/// Explicit conversions (From section 5.4.1 Conversion and scalar constructors of GLSL 1.30.08 specification)
 		template <typename A, typename B, typename C, precision Q>
-		GLM_FUNC_DECL explicit tvec4(tvec2<A, Q> const & a, B b, C c);
+		GLM_FUNC_DECL GLM_EXPLICIT_CONV tvec4(tvec2<A, Q> const & a, B b, C c);
 		/// Explicit conversions (From section 5.4.1 Conversion and scalar constructors of GLSL 1.30.08 specification)
 		template <typename A, typename B, typename C, precision Q>
-		GLM_FUNC_DECL explicit tvec4(tvec2<A, Q> const & a, tvec1<B, Q> const & b, tvec1<C, Q> const & c);
+		GLM_FUNC_DECL GLM_EXPLICIT_CONV tvec4(tvec2<A, Q> const & a, tvec1<B, Q> const & b, tvec1<C, Q> const & c);
 		/// Explicit conversions (From section 5.4.1 Conversion and scalar constructors of GLSL 1.30.08 specification)
 		template <typename A, typename B, typename C, precision Q>
-		GLM_FUNC_DECL explicit tvec4(A a, tvec2<B, Q> const & b, C c);
+		GLM_FUNC_DECL GLM_EXPLICIT_CONV tvec4(A a, tvec2<B, Q> const & b, C c);
 		/// Explicit conversions (From section 5.4.1 Conversion and scalar constructors of GLSL 1.30.08 specification)
 		template <typename A, typename B, typename C, precision Q>
-		GLM_FUNC_DECL explicit tvec4(tvec1<A, Q> const & a, tvec2<B, Q> const & b, tvec1<C, Q> const & c);
+		GLM_FUNC_DECL GLM_EXPLICIT_CONV tvec4(tvec1<A, Q> const & a, tvec2<B, Q> const & b, tvec1<C, Q> const & c);
 		/// Explicit conversions (From section 5.4.1 Conversion and scalar constructors of GLSL 1.30.08 specification)
 		template <typename A, typename B, typename C, precision Q>
-		GLM_FUNC_DECL explicit tvec4(A a, B b, tvec2<C, Q> const & c);
+		GLM_FUNC_DECL GLM_EXPLICIT_CONV tvec4(A a, B b, tvec2<C, Q> const & c);
 		/// Explicit conversions (From section 5.4.1 Conversion and scalar constructors of GLSL 1.30.08 specification)
 		template <typename A, typename B, typename C, precision Q>
-		GLM_FUNC_DECL explicit tvec4(tvec1<A, Q> const & a, tvec1<B, Q> const & b, tvec2<C, Q> const & c);
+		GLM_FUNC_DECL GLM_EXPLICIT_CONV tvec4(tvec1<A, Q> const & a, tvec1<B, Q> const & b, tvec2<C, Q> const & c);
 		/// Explicit conversions (From section 5.4.1 Conversion and scalar constructors of GLSL 1.30.08 specification)
 		template <typename A, typename B, precision Q>
-		GLM_FUNC_DECL explicit tvec4(tvec3<A, Q> const & a, B b);
+		GLM_FUNC_DECL GLM_EXPLICIT_CONV tvec4(tvec3<A, Q> const & a, B b);
 		/// Explicit conversions (From section 5.4.1 Conversion and scalar constructors of GLSL 1.30.08 specification)
 		template <typename A, typename B, precision Q>
-		GLM_FUNC_DECL explicit tvec4(tvec3<A, Q> const & a, tvec1<B, Q> const & b);
+		GLM_FUNC_DECL GLM_EXPLICIT_CONV tvec4(tvec3<A, Q> const & a, tvec1<B, Q> const & b);
 		/// Explicit conversions (From section 5.4.1 Conversion and scalar constructors of GLSL 1.30.08 specification)
 		template <typename A, typename B, precision Q>
-		GLM_FUNC_DECL explicit tvec4(A a, tvec3<B, Q> const & b);
+		GLM_FUNC_DECL GLM_EXPLICIT_CONV tvec4(A a, tvec3<B, Q> const & b);
 		/// Explicit conversions (From section 5.4.1 Conversion and scalar constructors of GLSL 1.30.08 specification)
 		template <typename A, typename B, precision Q>
-		GLM_FUNC_DECL explicit tvec4(tvec1<A, Q> const & a, tvec3<B, Q> const & b);
+		GLM_FUNC_DECL GLM_EXPLICIT_CONV tvec4(tvec1<A, Q> const & a, tvec3<B, Q> const & b);
 		/// Explicit conversions (From section 5.4.1 Conversion and scalar constructors of GLSL 1.30.08 specification)
 		template <typename A, typename B, precision Q>
-		GLM_FUNC_DECL explicit tvec4(tvec2<A, Q> const & a, tvec2<B, Q> const & b);
+		GLM_FUNC_DECL GLM_EXPLICIT_CONV tvec4(tvec2<A, Q> const & a, tvec2<B, Q> const & b);
 
 		/// Explicit conversions (From section 5.4.1 Conversion and scalar constructors of GLSL 1.30.08 specification)
 		template <typename U, precision Q>

--- a/glm/gtc/quaternion.hpp
+++ b/glm/gtc/quaternion.hpp
@@ -144,12 +144,12 @@ namespace glm
 		/// @param v A second normalized axis
 		/// @see gtc_quaternion
 		/// @see http://lolengine.net/blog/2013/09/18/beautiful-maths-quaternion-from-vectors
-		GLM_FUNC_DECL explicit tquat(tvec3<T, P> const & u,	tvec3<T, P> const & v);
+		GLM_FUNC_DECL GLM_EXPLICIT_CONV tquat(tvec3<T, P> const & u,	tvec3<T, P> const & v);
 
 		/// Build a quaternion from euler angles (pitch, yaw, roll), in radians.
-		GLM_FUNC_DECL explicit tquat(tvec3<T, P> const & eulerAngles);
-		GLM_FUNC_DECL explicit tquat(tmat3x3<T, P> const & m);
-		GLM_FUNC_DECL explicit tquat(tmat4x4<T, P> const & m);
+		GLM_FUNC_DECL GLM_EXPLICIT_CONV tquat(tvec3<T, P> const & eulerAngles);
+		GLM_FUNC_DECL GLM_EXPLICIT_CONV tquat(tmat3x3<T, P> const & m);
+		GLM_FUNC_DECL GLM_EXPLICIT_CONV tquat(tmat4x4<T, P> const & m);
 
 		// -- Unary arithmetic operators --
 

--- a/glm/gtx/dual_quaternion.hpp
+++ b/glm/gtx/dual_quaternion.hpp
@@ -112,8 +112,8 @@ namespace glm
 		template <typename U, precision Q>
 		GLM_FUNC_DECL GLM_EXPLICIT tdualquat(tdualquat<U, Q> const & q);
 
-		GLM_FUNC_DECL explicit tdualquat(tmat2x4<T, P> const & holder_mat);
-		GLM_FUNC_DECL explicit tdualquat(tmat3x4<T, P> const & aug_mat);
+		GLM_FUNC_DECL GLM_EXPLICIT_CONV tdualquat(tmat2x4<T, P> const & holder_mat);
+		GLM_FUNC_DECL GLM_EXPLICIT_CONV tdualquat(tmat3x4<T, P> const & aug_mat);
 
 		// -- Unary arithmetic operators --
 


### PR DESCRIPTION
- Use the new GLM_IMPLICIT_CONVERSION_CTOR #define
- By default GLM_EXPLICIT_CONV is defined as "explicit"
- #define GLM_IMPLICIT_CONVERSION_CTOR defines it as empty

I feel this is a better way to solve the problem I proposed in #421 ; namely, converting between various GLM types freely in a manner suited to template metaprogramming.  Except now instead of [registering a function pointer](http://doc.qt.io/qt-5/qmetatype.html#registerConverter-3), I can just [declare the existence of an implicit conversion](http://doc.qt.io/qt-5/qmetatype.html#registerConverter), and just tell [`QVariant`](http://doc.qt.io/qt-5/qvariant.html) to use it.  This should *greatly* simplify the [original file](https://github.com/JesseTG/BALLS/blob/master/BALLS/BALLS/util/MetaTypeConverters.cpp) that I was concerned about, without introducing any more complexity to GLM.

By the way, my other PR #458 is ready to merge, pending your approval (I'd nearly forgotten about it, actually).