### PR TITLE
Fix polar coordinates function latitude.

### DIFF
--- a/glm/gtx/polar_coordinates.inl
+++ b/glm/gtx/polar_coordinates.inl
@@ -43,7 +43,7 @@ namespace glm
 		T const xz_dist(sqrt(tmp.x * tmp.x + tmp.z * tmp.z));
 
 		return tvec3<T, P>(
-			atan(xz_dist, tmp.y),	// latitude
+			asin(tmp.y),	// latitude
 			atan(tmp.x, tmp.z),		// longitude
 			xz_dist);				// xz distance
 	}


### PR DESCRIPTION
Latitude was being computed from `atan`, should be `asin`.