### PR TITLE
Templatize most (if not all) unary GLM conversions

### DIFF
--- a/glm/detail/type_mat2x2.hpp
+++ b/glm/detail/type_mat2x2.hpp
@@ -102,14 +102,29 @@ namespace glm
 		template <typename U, precision Q>
 		GLM_FUNC_DECL GLM_EXPLICIT tmat2x2(tmat2x2<U, Q> const & m);
 
-		GLM_FUNC_DECL GLM_EXPLICIT tmat2x2(tmat3x3<T, P> const & x);
-		GLM_FUNC_DECL GLM_EXPLICIT tmat2x2(tmat4x4<T, P> const & x);
-		GLM_FUNC_DECL GLM_EXPLICIT tmat2x2(tmat2x3<T, P> const & x);
-		GLM_FUNC_DECL GLM_EXPLICIT tmat2x2(tmat3x2<T, P> const & x);
-		GLM_FUNC_DECL GLM_EXPLICIT tmat2x2(tmat2x4<T, P> const & x);
-		GLM_FUNC_DECL GLM_EXPLICIT tmat2x2(tmat4x2<T, P> const & x);
-		GLM_FUNC_DECL GLM_EXPLICIT tmat2x2(tmat3x4<T, P> const & x);
-		GLM_FUNC_DECL GLM_EXPLICIT tmat2x2(tmat4x3<T, P> const & x);
+		template <typename U, precision Q>
+		GLM_FUNC_DECL GLM_EXPLICIT tmat2x2(tmat3x3<U, Q> const & x);
+
+		template <typename U, precision Q>
+		GLM_FUNC_DECL GLM_EXPLICIT tmat2x2(tmat4x4<U, Q> const & x);
+
+		template <typename U, precision Q>
+		GLM_FUNC_DECL GLM_EXPLICIT tmat2x2(tmat2x3<U, Q> const & x);
+
+		template <typename U, precision Q>
+		GLM_FUNC_DECL GLM_EXPLICIT tmat2x2(tmat3x2<U, Q> const & x);
+
+		template <typename U, precision Q>
+		GLM_FUNC_DECL GLM_EXPLICIT tmat2x2(tmat2x4<U, Q> const & x);
+
+		template <typename U, precision Q>
+		GLM_FUNC_DECL GLM_EXPLICIT tmat2x2(tmat4x2<U, Q> const & x);
+
+		template <typename U, precision Q>
+		GLM_FUNC_DECL GLM_EXPLICIT tmat2x2(tmat3x4<U, Q> const & x);
+
+		template <typename U, precision Q>
+		GLM_FUNC_DECL GLM_EXPLICIT tmat2x2(tmat4x3<U, Q> const & x);
 
 		// -- Accesses --
 

--- a/glm/detail/type_mat2x2.inl
+++ b/glm/detail/type_mat2x2.inl
@@ -149,56 +149,64 @@ namespace detail
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tmat2x2<T, P>::tmat2x2(tmat3x3<T, P> const & m)
+	template <typename U, precision Q>
+	GLM_FUNC_QUALIFIER tmat2x2<T, P>::tmat2x2(tmat3x3<U, Q> const & m)
 	{
 		this->value[0] = col_type(m[0]);
 		this->value[1] = col_type(m[1]);
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tmat2x2<T, P>::tmat2x2(tmat4x4<T, P> const & m)
+	template <typename U, precision Q>
+	GLM_FUNC_QUALIFIER tmat2x2<T, P>::tmat2x2(tmat4x4<U, Q> const & m)
 	{
 		this->value[0] = col_type(m[0]);
 		this->value[1] = col_type(m[1]);
 	}
 
 	template <typename T, precision P> 
-	GLM_FUNC_QUALIFIER tmat2x2<T, P>::tmat2x2(tmat2x3<T, P> const & m)
+	template <typename U, precision Q>
+	GLM_FUNC_QUALIFIER tmat2x2<T, P>::tmat2x2(tmat2x3<U, Q> const & m)
 	{
 		this->value[0] = col_type(m[0]);
 		this->value[1] = col_type(m[1]);
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tmat2x2<T, P>::tmat2x2(tmat3x2<T, P> const & m)
+	template <typename U, precision Q>
+	GLM_FUNC_QUALIFIER tmat2x2<T, P>::tmat2x2(tmat3x2<U, Q> const & m)
 	{
 		this->value[0] = m[0];
 		this->value[1] = m[1];
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tmat2x2<T, P>::tmat2x2(tmat2x4<T, P> const & m)
+	template <typename U, precision Q>
+	GLM_FUNC_QUALIFIER tmat2x2<T, P>::tmat2x2(tmat2x4<U, Q> const & m)
 	{
 		this->value[0] = col_type(m[0]);
 		this->value[1] = col_type(m[1]);
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tmat2x2<T, P>::tmat2x2(tmat4x2<T, P> const & m)
+	template <typename U, precision Q>
+	GLM_FUNC_QUALIFIER tmat2x2<T, P>::tmat2x2(tmat4x2<U, Q> const & m)
 	{
 		this->value[0] = m[0];
 		this->value[1] = m[1];
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tmat2x2<T, P>::tmat2x2(tmat3x4<T, P> const & m)
+	template <typename U, precision Q>
+	GLM_FUNC_QUALIFIER tmat2x2<T, P>::tmat2x2(tmat3x4<U, Q> const & m)
 	{
 		this->value[0] = col_type(m[0]);
 		this->value[1] = col_type(m[1]);
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tmat2x2<T, P>::tmat2x2(tmat4x3<T, P> const & m)
+	template <typename U, precision Q>
+	GLM_FUNC_QUALIFIER tmat2x2<T, P>::tmat2x2(tmat4x3<U, Q> const & m)
 	{
 		this->value[0] = col_type(m[0]);
 		this->value[1] = col_type(m[1]);

--- a/glm/detail/type_mat2x3.hpp
+++ b/glm/detail/type_mat2x3.hpp
@@ -99,14 +99,29 @@ namespace glm
 		template <typename U, precision Q>
 		GLM_FUNC_DECL GLM_EXPLICIT tmat2x3(tmat2x3<U, Q> const & m);
 
-		GLM_FUNC_DECL GLM_EXPLICIT tmat2x3(tmat2x2<T, P> const & x);
-		GLM_FUNC_DECL GLM_EXPLICIT tmat2x3(tmat3x3<T, P> const & x);
-		GLM_FUNC_DECL GLM_EXPLICIT tmat2x3(tmat4x4<T, P> const & x);
-		GLM_FUNC_DECL GLM_EXPLICIT tmat2x3(tmat2x4<T, P> const & x);
-		GLM_FUNC_DECL GLM_EXPLICIT tmat2x3(tmat3x2<T, P> const & x);
-		GLM_FUNC_DECL GLM_EXPLICIT tmat2x3(tmat3x4<T, P> const & x);
-		GLM_FUNC_DECL GLM_EXPLICIT tmat2x3(tmat4x2<T, P> const & x);
-		GLM_FUNC_DECL GLM_EXPLICIT tmat2x3(tmat4x3<T, P> const & x);
+		template <typename U, precision Q>
+		GLM_FUNC_DECL GLM_EXPLICIT tmat2x3(tmat2x2<U, Q> const & x);
+
+		template <typename U, precision Q>
+		GLM_FUNC_DECL GLM_EXPLICIT tmat2x3(tmat3x3<U, Q> const & x);
+
+		template <typename U, precision Q>
+		GLM_FUNC_DECL GLM_EXPLICIT tmat2x3(tmat4x4<U, Q> const & x);
+
+		template <typename U, precision Q>
+		GLM_FUNC_DECL GLM_EXPLICIT tmat2x3(tmat2x4<U, Q> const & x);
+
+		template <typename U, precision Q>
+		GLM_FUNC_DECL GLM_EXPLICIT tmat2x3(tmat3x2<U, Q> const & x);
+
+		template <typename U, precision Q>
+		GLM_FUNC_DECL GLM_EXPLICIT tmat2x3(tmat3x4<U, Q> const & x);
+
+		template <typename U, precision Q>
+		GLM_FUNC_DECL GLM_EXPLICIT tmat2x3(tmat4x2<U, Q> const & x);
+
+		template <typename U, precision Q>
+		GLM_FUNC_DECL GLM_EXPLICIT tmat2x3(tmat4x3<U, Q> const & x);
 
 		// -- Accesses --
 

--- a/glm/detail/type_mat2x3.inl
+++ b/glm/detail/type_mat2x3.inl
@@ -133,56 +133,64 @@ namespace glm
 	}
 
 	template <typename T, precision P> 
-	GLM_FUNC_QUALIFIER tmat2x3<T, P>::tmat2x3(tmat2x2<T, P> const & m)
+	template <typename U, precision Q>
+	GLM_FUNC_QUALIFIER tmat2x3<T, P>::tmat2x3(tmat2x2<U, Q> const & m)
 	{
 		this->value[0] = col_type(m[0], 0);
 		this->value[1] = col_type(m[1], 0);
 	}
 
 	template <typename T, precision P> 
-	GLM_FUNC_QUALIFIER tmat2x3<T, P>::tmat2x3(tmat3x3<T, P> const & m)
+	template <typename U, precision Q>
+	GLM_FUNC_QUALIFIER tmat2x3<T, P>::tmat2x3(tmat3x3<U, Q> const & m)
 	{
 		this->value[0] = col_type(m[0]);
 		this->value[1] = col_type(m[1]);
 	}
 
 	template <typename T, precision P> 
-	GLM_FUNC_QUALIFIER tmat2x3<T, P>::tmat2x3(tmat4x4<T, P> const & m)
+	template <typename U, precision Q>
+	GLM_FUNC_QUALIFIER tmat2x3<T, P>::tmat2x3(tmat4x4<U, Q> const & m)
 	{
 		this->value[0] = col_type(m[0]);
 		this->value[1] = col_type(m[1]);
 	}
 
 	template <typename T, precision P> 
-	GLM_FUNC_QUALIFIER tmat2x3<T, P>::tmat2x3(tmat2x4<T, P> const & m)
+	template <typename U, precision Q>
+	GLM_FUNC_QUALIFIER tmat2x3<T, P>::tmat2x3(tmat2x4<U, Q> const & m)
 	{
 		this->value[0] = col_type(m[0]);
 		this->value[1] = col_type(m[1]);
 	}
 
 	template <typename T, precision P> 
-	GLM_FUNC_QUALIFIER tmat2x3<T, P>::tmat2x3(tmat3x2<T, P> const & m)
+	template <typename U, precision Q>
+	GLM_FUNC_QUALIFIER tmat2x3<T, P>::tmat2x3(tmat3x2<U, Q> const & m)
 	{
 		this->value[0] = col_type(m[0], 0);
 		this->value[1] = col_type(m[1], 0);
 	}
 
 	template <typename T, precision P> 
-	GLM_FUNC_QUALIFIER tmat2x3<T, P>::tmat2x3(tmat3x4<T, P> const & m)
+	template <typename U, precision Q>
+	GLM_FUNC_QUALIFIER tmat2x3<T, P>::tmat2x3(tmat3x4<U, Q> const & m)
 	{
 		this->value[0] = col_type(m[0]);
 		this->value[1] = col_type(m[1]);
 	}
 
 	template <typename T, precision P> 
-	GLM_FUNC_QUALIFIER tmat2x3<T, P>::tmat2x3(tmat4x2<T, P> const & m)
+	template <typename U, precision Q>
+	GLM_FUNC_QUALIFIER tmat2x3<T, P>::tmat2x3(tmat4x2<U, Q> const & m)
 	{
 		this->value[0] = col_type(m[0], 0);
 		this->value[1] = col_type(m[1], 0);
 	}
 
 	template <typename T, precision P> 
-	GLM_FUNC_QUALIFIER tmat2x3<T, P>::tmat2x3(tmat4x3<T, P> const & m)
+	template <typename U, precision Q>
+	GLM_FUNC_QUALIFIER tmat2x3<T, P>::tmat2x3(tmat4x3<U, Q> const & m)
 	{
 		this->value[0] = m[0];
 		this->value[1] = m[1];

--- a/glm/detail/type_mat2x4.hpp
+++ b/glm/detail/type_mat2x4.hpp
@@ -101,14 +101,29 @@ namespace glm
 		template <typename U, precision Q>
 		GLM_FUNC_DECL GLM_EXPLICIT tmat2x4(tmat2x4<U, Q> const & m);
 
-		GLM_FUNC_DECL GLM_EXPLICIT tmat2x4(tmat2x2<T, P> const & x);
-		GLM_FUNC_DECL GLM_EXPLICIT tmat2x4(tmat3x3<T, P> const & x);
-		GLM_FUNC_DECL GLM_EXPLICIT tmat2x4(tmat4x4<T, P> const & x);
-		GLM_FUNC_DECL GLM_EXPLICIT tmat2x4(tmat2x3<T, P> const & x);
-		GLM_FUNC_DECL GLM_EXPLICIT tmat2x4(tmat3x2<T, P> const & x);
-		GLM_FUNC_DECL GLM_EXPLICIT tmat2x4(tmat3x4<T, P> const & x);
-		GLM_FUNC_DECL GLM_EXPLICIT tmat2x4(tmat4x2<T, P> const & x);
-		GLM_FUNC_DECL GLM_EXPLICIT tmat2x4(tmat4x3<T, P> const & x);
+		template <typename U, precision Q>
+		GLM_FUNC_DECL GLM_EXPLICIT tmat2x4(tmat2x2<U, Q> const & x);
+
+		template <typename U, precision Q>
+		GLM_FUNC_DECL GLM_EXPLICIT tmat2x4(tmat3x3<U, Q> const & x);
+
+		template <typename U, precision Q>
+		GLM_FUNC_DECL GLM_EXPLICIT tmat2x4(tmat4x4<U, Q> const & x);
+
+		template <typename U, precision Q>
+		GLM_FUNC_DECL GLM_EXPLICIT tmat2x4(tmat2x3<U, Q> const & x);
+
+		template <typename U, precision Q>
+		GLM_FUNC_DECL GLM_EXPLICIT tmat2x4(tmat3x2<U, Q> const & x);
+
+		template <typename U, precision Q>
+		GLM_FUNC_DECL GLM_EXPLICIT tmat2x4(tmat3x4<U, Q> const & x);
+
+		template <typename U, precision Q>
+		GLM_FUNC_DECL GLM_EXPLICIT tmat2x4(tmat4x2<U, Q> const & x);
+
+		template <typename U, precision Q>
+		GLM_FUNC_DECL GLM_EXPLICIT tmat2x4(tmat4x3<U, Q> const & x);
 
 		// -- Accesses --
 

--- a/glm/detail/type_mat2x4.inl
+++ b/glm/detail/type_mat2x4.inl
@@ -134,56 +134,64 @@ namespace glm
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tmat2x4<T, P>::tmat2x4(tmat2x2<T, P> const & m)
+	template <typename U, precision Q>
+	GLM_FUNC_QUALIFIER tmat2x4<T, P>::tmat2x4(tmat2x2<U, Q> const & m)
 	{
 		this->value[0] = col_type(m[0], 0, 0);
 		this->value[1] = col_type(m[1], 0, 0);
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tmat2x4<T, P>::tmat2x4(tmat3x3<T, P> const & m)
+	template <typename U, precision Q>
+	GLM_FUNC_QUALIFIER tmat2x4<T, P>::tmat2x4(tmat3x3<U, Q> const & m)
 	{
 		this->value[0] = col_type(m[0], 0);
 		this->value[1] = col_type(m[1], 0);
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tmat2x4<T, P>::tmat2x4(tmat4x4<T, P> const & m)
+	template <typename U, precision Q>
+	GLM_FUNC_QUALIFIER tmat2x4<T, P>::tmat2x4(tmat4x4<U, Q> const & m)
 	{
 		this->value[0] = col_type(m[0]);
 		this->value[1] = col_type(m[1]);
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tmat2x4<T, P>::tmat2x4(tmat2x3<T, P> const & m)
+	template <typename U, precision Q>
+	GLM_FUNC_QUALIFIER tmat2x4<T, P>::tmat2x4(tmat2x3<U, Q> const & m)
 	{
 		this->value[0] = col_type(m[0], 0);
 		this->value[1] = col_type(m[1], 0);
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tmat2x4<T, P>::tmat2x4(tmat3x2<T, P> const & m)
+	template <typename U, precision Q>
+	GLM_FUNC_QUALIFIER tmat2x4<T, P>::tmat2x4(tmat3x2<U, Q> const & m)
 	{
 		this->value[0] = col_type(m[0], 0, 0);
 		this->value[1] = col_type(m[1], 0, 0);
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tmat2x4<T, P>::tmat2x4(tmat3x4<T, P> const & m)
+	template <typename U, precision Q>
+	GLM_FUNC_QUALIFIER tmat2x4<T, P>::tmat2x4(tmat3x4<U, Q> const & m)
 	{
 		this->value[0] = m[0];
 		this->value[1] = m[1];
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tmat2x4<T, P>::tmat2x4(tmat4x2<T, P> const & m)
+	template <typename U, precision Q>
+	GLM_FUNC_QUALIFIER tmat2x4<T, P>::tmat2x4(tmat4x2<U, Q> const & m)
 	{
 		this->value[0] = col_type(m[0], 0, 0);
 		this->value[1] = col_type(m[1], 0, 0);
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tmat2x4<T, P>::tmat2x4(tmat4x3<T, P> const & m)
+	template <typename U, precision Q>
+	GLM_FUNC_QUALIFIER tmat2x4<T, P>::tmat2x4(tmat4x3<U, Q> const & m)
 	{
 		this->value[0] = col_type(m[0], 0);
 		this->value[1] = col_type(m[1], 0);

--- a/glm/detail/type_mat3x2.hpp
+++ b/glm/detail/type_mat3x2.hpp
@@ -106,14 +106,29 @@ namespace glm
 		template <typename U, precision Q>
 		GLM_FUNC_DECL GLM_EXPLICIT tmat3x2(tmat3x2<U, Q> const & m);
 
-		GLM_FUNC_DECL GLM_EXPLICIT tmat3x2(tmat2x2<T, P> const & x);
-		GLM_FUNC_DECL GLM_EXPLICIT tmat3x2(tmat3x3<T, P> const & x);
-		GLM_FUNC_DECL GLM_EXPLICIT tmat3x2(tmat4x4<T, P> const & x);
-		GLM_FUNC_DECL GLM_EXPLICIT tmat3x2(tmat2x3<T, P> const & x);
-		GLM_FUNC_DECL GLM_EXPLICIT tmat3x2(tmat2x4<T, P> const & x);
-		GLM_FUNC_DECL GLM_EXPLICIT tmat3x2(tmat3x4<T, P> const & x);
-		GLM_FUNC_DECL GLM_EXPLICIT tmat3x2(tmat4x2<T, P> const & x);
-		GLM_FUNC_DECL GLM_EXPLICIT tmat3x2(tmat4x3<T, P> const & x);
+		template <typename U, precision Q>
+		GLM_FUNC_DECL GLM_EXPLICIT tmat3x2(tmat2x2<U, Q> const & x);
+
+		template <typename U, precision Q>
+		GLM_FUNC_DECL GLM_EXPLICIT tmat3x2(tmat3x3<U, Q> const & x);
+
+		template <typename U, precision Q>
+		GLM_FUNC_DECL GLM_EXPLICIT tmat3x2(tmat4x4<U, Q> const & x);
+
+		template <typename U, precision Q>
+		GLM_FUNC_DECL GLM_EXPLICIT tmat3x2(tmat2x3<U, Q> const & x);
+
+		template <typename U, precision Q>
+		GLM_FUNC_DECL GLM_EXPLICIT tmat3x2(tmat2x4<U, Q> const & x);
+
+		template <typename U, precision Q>
+		GLM_FUNC_DECL GLM_EXPLICIT tmat3x2(tmat3x4<U, Q> const & x);
+
+		template <typename U, precision Q>
+		GLM_FUNC_DECL GLM_EXPLICIT tmat3x2(tmat4x2<U, Q> const & x);
+
+		template <typename U, precision Q>
+		GLM_FUNC_DECL GLM_EXPLICIT tmat3x2(tmat4x3<U, Q> const & x);
 
 		// -- Accesses --
 

--- a/glm/detail/type_mat3x2.inl
+++ b/glm/detail/type_mat3x2.inl
@@ -155,7 +155,8 @@ namespace glm
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tmat3x2<T, P>::tmat3x2(tmat2x2<T, P> const & m)
+	template <typename U, precision Q>
+	GLM_FUNC_QUALIFIER tmat3x2<T, P>::tmat3x2(tmat2x2<U, Q> const & m)
 	{
 		this->value[0] = m[0];
 		this->value[1] = m[1];
@@ -163,7 +164,8 @@ namespace glm
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tmat3x2<T, P>::tmat3x2(tmat3x3<T, P> const & m)
+	template <typename U, precision Q>
+	GLM_FUNC_QUALIFIER tmat3x2<T, P>::tmat3x2(tmat3x3<U, Q> const & m)
 	{
 		this->value[0] = col_type(m[0]);
 		this->value[1] = col_type(m[1]);
@@ -171,7 +173,8 @@ namespace glm
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tmat3x2<T, P>::tmat3x2(tmat4x4<T, P> const & m)
+	template <typename U, precision Q>
+	GLM_FUNC_QUALIFIER tmat3x2<T, P>::tmat3x2(tmat4x4<U, Q> const & m)
 	{
 		this->value[0] = col_type(m[0]);
 		this->value[1] = col_type(m[1]);
@@ -179,7 +182,8 @@ namespace glm
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tmat3x2<T, P>::tmat3x2(tmat2x3<T, P> const & m)
+	template <typename U, precision Q>
+	GLM_FUNC_QUALIFIER tmat3x2<T, P>::tmat3x2(tmat2x3<U, Q> const & m)
 	{
 		this->value[0] = col_type(m[0]);
 		this->value[1] = col_type(m[1]);
@@ -187,7 +191,8 @@ namespace glm
 	}
 
 	template <typename T, precision P> 
-	GLM_FUNC_QUALIFIER tmat3x2<T, P>::tmat3x2(tmat2x4<T, P> const & m)
+	template <typename U, precision Q>
+	GLM_FUNC_QUALIFIER tmat3x2<T, P>::tmat3x2(tmat2x4<U, Q> const & m)
 	{
 		this->value[0] = col_type(m[0]);
 		this->value[1] = col_type(m[1]);
@@ -195,7 +200,8 @@ namespace glm
 	}
 
 	template <typename T, precision P> 
-	GLM_FUNC_QUALIFIER tmat3x2<T, P>::tmat3x2(tmat3x4<T, P> const & m)
+	template <typename U, precision Q>
+	GLM_FUNC_QUALIFIER tmat3x2<T, P>::tmat3x2(tmat3x4<U, Q> const & m)
 	{
 		this->value[0] = col_type(m[0]);
 		this->value[1] = col_type(m[1]);
@@ -203,7 +209,8 @@ namespace glm
 	}
 
 	template <typename T, precision P> 
-	GLM_FUNC_QUALIFIER tmat3x2<T, P>::tmat3x2(tmat4x2<T, P> const & m)
+	template <typename U, precision Q>
+	GLM_FUNC_QUALIFIER tmat3x2<T, P>::tmat3x2(tmat4x2<U, Q> const & m)
 	{
 		this->value[0] = m[0];
 		this->value[1] = m[1];
@@ -211,7 +218,8 @@ namespace glm
 	}
 
 	template <typename T, precision P> 
-	GLM_FUNC_QUALIFIER tmat3x2<T, P>::tmat3x2(tmat4x3<T, P> const & m)
+	template <typename U, precision Q>
+	GLM_FUNC_QUALIFIER tmat3x2<T, P>::tmat3x2(tmat4x3<U, Q> const & m)
 	{
 		this->value[0] = col_type(m[0]);
 		this->value[1] = col_type(m[1]);

--- a/glm/detail/type_mat3x3.hpp
+++ b/glm/detail/type_mat3x3.hpp
@@ -110,14 +110,29 @@ namespace glm
 		template <typename U, precision Q>
 		GLM_FUNC_DECL GLM_EXPLICIT tmat3x3(tmat3x3<U, Q> const & m);
 
-		GLM_FUNC_DECL GLM_EXPLICIT tmat3x3(tmat2x2<T, P> const & x);
-		GLM_FUNC_DECL GLM_EXPLICIT tmat3x3(tmat4x4<T, P> const & x);
-		GLM_FUNC_DECL GLM_EXPLICIT tmat3x3(tmat2x3<T, P> const & x);
-		GLM_FUNC_DECL GLM_EXPLICIT tmat3x3(tmat3x2<T, P> const & x);
-		GLM_FUNC_DECL GLM_EXPLICIT tmat3x3(tmat2x4<T, P> const & x);
-		GLM_FUNC_DECL GLM_EXPLICIT tmat3x3(tmat4x2<T, P> const & x);
-		GLM_FUNC_DECL GLM_EXPLICIT tmat3x3(tmat3x4<T, P> const & x);
-		GLM_FUNC_DECL GLM_EXPLICIT tmat3x3(tmat4x3<T, P> const & x);
+		template <typename U, precision Q>
+		GLM_FUNC_DECL GLM_EXPLICIT tmat3x3(tmat2x2<U, Q> const & x);
+
+		template <typename U, precision Q>
+		GLM_FUNC_DECL GLM_EXPLICIT tmat3x3(tmat4x4<U, Q> const & x);
+
+		template <typename U, precision Q>
+		GLM_FUNC_DECL GLM_EXPLICIT tmat3x3(tmat2x3<U, Q> const & x);
+
+		template <typename U, precision Q>
+		GLM_FUNC_DECL GLM_EXPLICIT tmat3x3(tmat3x2<U, Q> const & x);
+
+		template <typename U, precision Q>
+		GLM_FUNC_DECL GLM_EXPLICIT tmat3x3(tmat2x4<U, Q> const & x);
+
+		template <typename U, precision Q>
+		GLM_FUNC_DECL GLM_EXPLICIT tmat3x3(tmat4x2<U, Q> const & x);
+
+		template <typename U, precision Q>
+		GLM_FUNC_DECL GLM_EXPLICIT tmat3x3(tmat3x4<U, Q> const & x);
+
+		template <typename U, precision Q>
+		GLM_FUNC_DECL GLM_EXPLICIT tmat3x3(tmat4x3<U, Q> const & x);
 
 		// -- Accesses --
 

--- a/glm/detail/type_mat3x3.inl
+++ b/glm/detail/type_mat3x3.inl
@@ -180,7 +180,8 @@ namespace detail
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tmat3x3<T, P>::tmat3x3(tmat2x2<T, P> const & m)
+	template <typename U, precision Q>
+	GLM_FUNC_QUALIFIER tmat3x3<T, P>::tmat3x3(tmat2x2<U, Q> const & m)
 	{
 		this->value[0] = col_type(m[0], 0);
 		this->value[1] = col_type(m[1], 0);
@@ -188,7 +189,8 @@ namespace detail
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tmat3x3<T, P>::tmat3x3(tmat4x4<T, P> const & m)
+	template <typename U, precision Q>
+	GLM_FUNC_QUALIFIER tmat3x3<T, P>::tmat3x3(tmat4x4<U, Q> const & m)
 	{
 		this->value[0] = col_type(m[0]);
 		this->value[1] = col_type(m[1]);
@@ -196,7 +198,8 @@ namespace detail
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tmat3x3<T, P>::tmat3x3(tmat2x3<T, P> const & m)
+	template <typename U, precision Q>
+	GLM_FUNC_QUALIFIER tmat3x3<T, P>::tmat3x3(tmat2x3<U, Q> const & m)
 	{
 		this->value[0] = m[0];
 		this->value[1] = m[1];
@@ -204,7 +207,8 @@ namespace detail
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tmat3x3<T, P>::tmat3x3(tmat3x2<T, P> const & m)
+	template <typename U, precision Q>
+	GLM_FUNC_QUALIFIER tmat3x3<T, P>::tmat3x3(tmat3x2<U, Q> const & m)
 	{
 		this->value[0] = col_type(m[0], 0);
 		this->value[1] = col_type(m[1], 0);
@@ -212,7 +216,8 @@ namespace detail
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tmat3x3<T, P>::tmat3x3(tmat2x4<T, P> const & m)
+	template <typename U, precision Q>
+	GLM_FUNC_QUALIFIER tmat3x3<T, P>::tmat3x3(tmat2x4<U, Q> const & m)
 	{
 		this->value[0] = col_type(m[0]);
 		this->value[1] = col_type(m[1]);
@@ -220,7 +225,8 @@ namespace detail
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tmat3x3<T, P>::tmat3x3(tmat4x2<T, P> const & m)
+	template <typename U, precision Q>
+	GLM_FUNC_QUALIFIER tmat3x3<T, P>::tmat3x3(tmat4x2<U, Q> const & m)
 	{
 		this->value[0] = col_type(m[0], 0);
 		this->value[1] = col_type(m[1], 0);
@@ -228,7 +234,8 @@ namespace detail
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tmat3x3<T, P>::tmat3x3(tmat3x4<T, P> const & m)
+	template <typename U, precision Q>
+	GLM_FUNC_QUALIFIER tmat3x3<T, P>::tmat3x3(tmat3x4<U, Q> const & m)
 	{
 		this->value[0] = col_type(m[0]);
 		this->value[1] = col_type(m[1]);
@@ -236,7 +243,8 @@ namespace detail
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tmat3x3<T, P>::tmat3x3(tmat4x3<T, P> const & m)
+	template <typename U, precision Q>
+	GLM_FUNC_QUALIFIER tmat3x3<T, P>::tmat3x3(tmat4x3<U, Q> const & m)
 	{
 		this->value[0] = m[0];
 		this->value[1] = m[1];

--- a/glm/detail/type_mat3x4.hpp
+++ b/glm/detail/type_mat3x4.hpp
@@ -106,14 +106,29 @@ namespace glm
 		template <typename U, precision Q>
 		GLM_FUNC_DECL GLM_EXPLICIT tmat3x4(tmat3x4<U, Q> const & m);
 
-		GLM_FUNC_DECL GLM_EXPLICIT tmat3x4(tmat2x2<T, P> const & x);
-		GLM_FUNC_DECL GLM_EXPLICIT tmat3x4(tmat3x3<T, P> const & x);
-		GLM_FUNC_DECL GLM_EXPLICIT tmat3x4(tmat4x4<T, P> const & x);
-		GLM_FUNC_DECL GLM_EXPLICIT tmat3x4(tmat2x3<T, P> const & x);
-		GLM_FUNC_DECL GLM_EXPLICIT tmat3x4(tmat3x2<T, P> const & x);
-		GLM_FUNC_DECL GLM_EXPLICIT tmat3x4(tmat2x4<T, P> const & x);
-		GLM_FUNC_DECL GLM_EXPLICIT tmat3x4(tmat4x2<T, P> const & x);
-		GLM_FUNC_DECL GLM_EXPLICIT tmat3x4(tmat4x3<T, P> const & x);
+		template <typename U, precision Q>
+		GLM_FUNC_DECL GLM_EXPLICIT tmat3x4(tmat2x2<U, Q> const & x);
+
+		template <typename U, precision Q>
+		GLM_FUNC_DECL GLM_EXPLICIT tmat3x4(tmat3x3<U, Q> const & x);
+
+		template <typename U, precision Q>
+		GLM_FUNC_DECL GLM_EXPLICIT tmat3x4(tmat4x4<U, Q> const & x);
+
+		template <typename U, precision Q>
+		GLM_FUNC_DECL GLM_EXPLICIT tmat3x4(tmat2x3<U, Q> const & x);
+
+		template <typename U, precision Q>
+		GLM_FUNC_DECL GLM_EXPLICIT tmat3x4(tmat3x2<U, Q> const & x);
+
+		template <typename U, precision Q>
+		GLM_FUNC_DECL GLM_EXPLICIT tmat3x4(tmat2x4<U, Q> const & x);
+
+		template <typename U, precision Q>
+		GLM_FUNC_DECL GLM_EXPLICIT tmat3x4(tmat4x2<U, Q> const & x);
+
+		template <typename U, precision Q>
+		GLM_FUNC_DECL GLM_EXPLICIT tmat3x4(tmat4x3<U, Q> const & x);
 
 		// -- Accesses --
 

--- a/glm/detail/type_mat3x4.inl
+++ b/glm/detail/type_mat3x4.inl
@@ -155,7 +155,8 @@ namespace glm
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tmat3x4<T, P>::tmat3x4(tmat2x2<T, P> const & m)
+	template <typename U, precision Q>
+	GLM_FUNC_QUALIFIER tmat3x4<T, P>::tmat3x4(tmat2x2<U, Q> const & m)
 	{
 		this->value[0] = col_type(m[0], 0, 0);
 		this->value[1] = col_type(m[1], 0, 0);
@@ -163,7 +164,8 @@ namespace glm
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tmat3x4<T, P>::tmat3x4(tmat3x3<T, P> const & m)
+	template <typename U, precision Q>
+	GLM_FUNC_QUALIFIER tmat3x4<T, P>::tmat3x4(tmat3x3<U, Q> const & m)
 	{
 		this->value[0] = col_type(m[0], 0);
 		this->value[1] = col_type(m[1], 0);
@@ -171,7 +173,8 @@ namespace glm
 	}
 
 	template <typename T, precision P> 
-	GLM_FUNC_QUALIFIER tmat3x4<T, P>::tmat3x4(tmat4x4<T, P> const & m)
+	template <typename U, precision Q>
+	GLM_FUNC_QUALIFIER tmat3x4<T, P>::tmat3x4(tmat4x4<U, Q> const & m)
 	{
 		this->value[0] = col_type(m[0]);
 		this->value[1] = col_type(m[1]);
@@ -179,7 +182,8 @@ namespace glm
 	}
 
 	template <typename T, precision P> 
-	GLM_FUNC_QUALIFIER tmat3x4<T, P>::tmat3x4(tmat2x3<T, P> const & m)
+	template <typename U, precision Q>
+	GLM_FUNC_QUALIFIER tmat3x4<T, P>::tmat3x4(tmat2x3<U, Q> const & m)
 	{
 		this->value[0] = col_type(m[0], 0);
 		this->value[1] = col_type(m[1], 0);
@@ -187,7 +191,8 @@ namespace glm
 	}
 
 	template <typename T, precision P> 
-	GLM_FUNC_QUALIFIER tmat3x4<T, P>::tmat3x4(tmat3x2<T, P> const & m)
+	template <typename U, precision Q>
+	GLM_FUNC_QUALIFIER tmat3x4<T, P>::tmat3x4(tmat3x2<U, Q> const & m)
 	{
 		this->value[0] = col_type(m[0], 0, 0);
 		this->value[1] = col_type(m[1], 0, 0);
@@ -195,7 +200,8 @@ namespace glm
 	}
 
 	template <typename T, precision P> 
-	GLM_FUNC_QUALIFIER tmat3x4<T, P>::tmat3x4(tmat2x4<T, P> const & m)
+	template <typename U, precision Q>
+	GLM_FUNC_QUALIFIER tmat3x4<T, P>::tmat3x4(tmat2x4<U, Q> const & m)
 	{
 		this->value[0] = col_type(m[0]);
 		this->value[1] = col_type(m[1]);
@@ -203,7 +209,8 @@ namespace glm
 	}
 
 	template <typename T, precision P> 
-	GLM_FUNC_QUALIFIER tmat3x4<T, P>::tmat3x4(tmat4x2<T, P> const & m)
+	template <typename U, precision Q>
+	GLM_FUNC_QUALIFIER tmat3x4<T, P>::tmat3x4(tmat4x2<U, Q> const & m)
 	{
 		this->value[0] = col_type(m[0], 0, 0);
 		this->value[1] = col_type(m[1], 0, 0);
@@ -211,7 +218,8 @@ namespace glm
 	}
 
 	template <typename T, precision P> 
-	GLM_FUNC_QUALIFIER tmat3x4<T, P>::tmat3x4(tmat4x3<T, P> const & m)
+	template <typename U, precision Q>
+	GLM_FUNC_QUALIFIER tmat3x4<T, P>::tmat3x4(tmat4x3<U, Q> const & m)
 	{
 		this->value[0] = col_type(m[0], 0);
 		this->value[1] = col_type(m[1], 0);

--- a/glm/detail/type_mat4x2.hpp
+++ b/glm/detail/type_mat4x2.hpp
@@ -111,14 +111,29 @@ namespace glm
 		template <typename U, precision Q>
 		GLM_FUNC_DECL GLM_EXPLICIT tmat4x2(tmat4x2<U, Q> const & m);
 
-		GLM_FUNC_DECL GLM_EXPLICIT tmat4x2(tmat2x2<T, P> const & x);
-		GLM_FUNC_DECL GLM_EXPLICIT tmat4x2(tmat3x3<T, P> const & x);
-		GLM_FUNC_DECL GLM_EXPLICIT tmat4x2(tmat4x4<T, P> const & x);
-		GLM_FUNC_DECL GLM_EXPLICIT tmat4x2(tmat2x3<T, P> const & x);
-		GLM_FUNC_DECL GLM_EXPLICIT tmat4x2(tmat3x2<T, P> const & x);
-		GLM_FUNC_DECL GLM_EXPLICIT tmat4x2(tmat2x4<T, P> const & x);
-		GLM_FUNC_DECL GLM_EXPLICIT tmat4x2(tmat4x3<T, P> const & x);
-		GLM_FUNC_DECL GLM_EXPLICIT tmat4x2(tmat3x4<T, P> const & x);
+		template <typename U, precision Q>
+		GLM_FUNC_DECL GLM_EXPLICIT tmat4x2(tmat2x2<U, Q> const & x);
+
+		template <typename U, precision Q>
+		GLM_FUNC_DECL GLM_EXPLICIT tmat4x2(tmat3x3<U, Q> const & x);
+
+		template <typename U, precision Q>
+		GLM_FUNC_DECL GLM_EXPLICIT tmat4x2(tmat4x4<U, Q> const & x);
+
+		template <typename U, precision Q>
+		GLM_FUNC_DECL GLM_EXPLICIT tmat4x2(tmat2x3<U, Q> const & x);
+
+		template <typename U, precision Q>
+		GLM_FUNC_DECL GLM_EXPLICIT tmat4x2(tmat3x2<U, Q> const & x);
+
+		template <typename U, precision Q>
+		GLM_FUNC_DECL GLM_EXPLICIT tmat4x2(tmat2x4<U, Q> const & x);
+
+		template <typename U, precision Q>
+		GLM_FUNC_DECL GLM_EXPLICIT tmat4x2(tmat4x3<U, Q> const & x);
+
+		template <typename U, precision Q>
+		GLM_FUNC_DECL GLM_EXPLICIT tmat4x2(tmat3x4<U, Q> const & x);
 
 		// -- Accesses --
 

--- a/glm/detail/type_mat4x2.inl
+++ b/glm/detail/type_mat4x2.inl
@@ -169,7 +169,8 @@ namespace glm
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tmat4x2<T, P>::tmat4x2(tmat2x2<T, P> const & m)
+	template <typename U, precision Q>
+	GLM_FUNC_QUALIFIER tmat4x2<T, P>::tmat4x2(tmat2x2<U, Q> const & m)
 	{
 		this->value[0] = col_type(m[0]);
 		this->value[1] = col_type(m[1]);
@@ -178,7 +179,8 @@ namespace glm
 	}
 
 	template <typename T, precision P> 
-	GLM_FUNC_QUALIFIER tmat4x2<T, P>::tmat4x2(tmat3x3<T, P> const & m)
+	template <typename U, precision Q>
+	GLM_FUNC_QUALIFIER tmat4x2<T, P>::tmat4x2(tmat3x3<U, Q> const & m)
 	{
 		this->value[0] = col_type(m[0]);
 		this->value[1] = col_type(m[1]);
@@ -187,7 +189,8 @@ namespace glm
 	}
 
 	template <typename T, precision P> 
-	GLM_FUNC_QUALIFIER tmat4x2<T, P>::tmat4x2(tmat4x4<T, P> const & m)
+	template <typename U, precision Q>
+	GLM_FUNC_QUALIFIER tmat4x2<T, P>::tmat4x2(tmat4x4<U, Q> const & m)
 	{
 		this->value[0] = col_type(m[0]);
 		this->value[1] = col_type(m[1]);
@@ -196,7 +199,8 @@ namespace glm
 	}
 
 	template <typename T, precision P> 
-	GLM_FUNC_QUALIFIER tmat4x2<T, P>::tmat4x2(tmat2x3<T, P> const & m)
+	template <typename U, precision Q>
+	GLM_FUNC_QUALIFIER tmat4x2<T, P>::tmat4x2(tmat2x3<U, Q> const & m)
 	{
 		this->value[0] = col_type(m[0]);
 		this->value[1] = col_type(m[1]);
@@ -205,7 +209,8 @@ namespace glm
 	}
 
 	template <typename T, precision P> 
-	GLM_FUNC_QUALIFIER tmat4x2<T, P>::tmat4x2(tmat3x2<T, P> const & m)
+	template <typename U, precision Q>
+	GLM_FUNC_QUALIFIER tmat4x2<T, P>::tmat4x2(tmat3x2<U, Q> const & m)
 	{
 		this->value[0] = col_type(m[0]);
 		this->value[1] = col_type(m[1]);
@@ -214,7 +219,8 @@ namespace glm
 	}
 
 	template <typename T, precision P> 
-	GLM_FUNC_QUALIFIER tmat4x2<T, P>::tmat4x2(tmat2x4<T, P> const & m)
+	template <typename U, precision Q>
+	GLM_FUNC_QUALIFIER tmat4x2<T, P>::tmat4x2(tmat2x4<U, Q> const & m)
 	{
 		this->value[0] = col_type(m[0]);
 		this->value[1] = col_type(m[1]);
@@ -223,7 +229,8 @@ namespace glm
 	}
 
 	template <typename T, precision P> 
-	GLM_FUNC_QUALIFIER tmat4x2<T, P>::tmat4x2(tmat4x3<T, P> const & m)
+	template <typename U, precision Q>
+	GLM_FUNC_QUALIFIER tmat4x2<T, P>::tmat4x2(tmat4x3<U, Q> const & m)
 	{
 		this->value[0] = col_type(m[0]);
 		this->value[1] = col_type(m[1]);
@@ -232,7 +239,8 @@ namespace glm
 	}
 
 	template <typename T, precision P> 
-	GLM_FUNC_QUALIFIER tmat4x2<T, P>::tmat4x2(tmat3x4<T, P> const & m)
+	template <typename U, precision Q>
+	GLM_FUNC_QUALIFIER tmat4x2<T, P>::tmat4x2(tmat3x4<U, Q> const & m)
 	{
 		this->value[0] = col_type(m[0]);
 		this->value[1] = col_type(m[1]);

--- a/glm/detail/type_mat4x3.hpp
+++ b/glm/detail/type_mat4x3.hpp
@@ -111,14 +111,29 @@ namespace glm
 		template <typename U, precision Q>
 		GLM_FUNC_DECL GLM_EXPLICIT tmat4x3(tmat4x3<U, Q> const & m);
 
-		GLM_FUNC_DECL GLM_EXPLICIT tmat4x3(tmat2x2<T, P> const & x);
-		GLM_FUNC_DECL GLM_EXPLICIT tmat4x3(tmat3x3<T, P> const & x);
-		GLM_FUNC_DECL GLM_EXPLICIT tmat4x3(tmat4x4<T, P> const & x);
-		GLM_FUNC_DECL GLM_EXPLICIT tmat4x3(tmat2x3<T, P> const & x);
-		GLM_FUNC_DECL GLM_EXPLICIT tmat4x3(tmat3x2<T, P> const & x);
-		GLM_FUNC_DECL GLM_EXPLICIT tmat4x3(tmat2x4<T, P> const & x);
-		GLM_FUNC_DECL GLM_EXPLICIT tmat4x3(tmat4x2<T, P> const & x);
-		GLM_FUNC_DECL GLM_EXPLICIT tmat4x3(tmat3x4<T, P> const & x);
+		template <typename U, precision Q>
+		GLM_FUNC_DECL GLM_EXPLICIT tmat4x3(tmat2x2<U, Q> const & x);
+
+		template <typename U, precision Q>
+		GLM_FUNC_DECL GLM_EXPLICIT tmat4x3(tmat3x3<U, Q> const & x);
+
+		template <typename U, precision Q>
+		GLM_FUNC_DECL GLM_EXPLICIT tmat4x3(tmat4x4<U, Q> const & x);
+
+		template <typename U, precision Q>
+		GLM_FUNC_DECL GLM_EXPLICIT tmat4x3(tmat2x3<U, Q> const & x);
+
+		template <typename U, precision Q>
+		GLM_FUNC_DECL GLM_EXPLICIT tmat4x3(tmat3x2<U, Q> const & x);
+
+		template <typename U, precision Q>
+		GLM_FUNC_DECL GLM_EXPLICIT tmat4x3(tmat2x4<U, Q> const & x);
+
+		template <typename U, precision Q>
+		GLM_FUNC_DECL GLM_EXPLICIT tmat4x3(tmat4x2<U, Q> const & x);
+
+		template <typename U, precision Q>
+		GLM_FUNC_DECL GLM_EXPLICIT tmat4x3(tmat3x4<U, Q> const & x);
 
 		// -- Accesses --
 

--- a/glm/detail/type_mat4x3.inl
+++ b/glm/detail/type_mat4x3.inl
@@ -169,7 +169,8 @@ namespace glm
 	}
 
 	template <typename T, precision P> 
-	GLM_FUNC_QUALIFIER tmat4x3<T, P>::tmat4x3(tmat2x2<T, P> const & m)
+	template <typename U, precision Q>
+	GLM_FUNC_QUALIFIER tmat4x3<T, P>::tmat4x3(tmat2x2<U, Q> const & m)
 	{
 		this->value[0] = col_type(m[0], 0);
 		this->value[1] = col_type(m[1], 0);
@@ -178,7 +179,8 @@ namespace glm
 	}
 
 	template <typename T, precision P> 
-	GLM_FUNC_QUALIFIER tmat4x3<T, P>::tmat4x3(tmat3x3<T, P> const & m)
+	template <typename U, precision Q>
+	GLM_FUNC_QUALIFIER tmat4x3<T, P>::tmat4x3(tmat3x3<U, Q> const & m)
 	{
 		this->value[0] = col_type(m[0]);
 		this->value[1] = col_type(m[1]);
@@ -187,7 +189,8 @@ namespace glm
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tmat4x3<T, P>::tmat4x3(tmat4x4<T, P> const & m)
+	template <typename U, precision Q>
+	GLM_FUNC_QUALIFIER tmat4x3<T, P>::tmat4x3(tmat4x4<U, Q> const & m)
 	{
 		this->value[0] = col_type(m[0]);
 		this->value[1] = col_type(m[1]);
@@ -196,7 +199,8 @@ namespace glm
 	}
 
 	template <typename T, precision P> 
-	GLM_FUNC_QUALIFIER tmat4x3<T, P>::tmat4x3(tmat2x3<T, P> const & m)
+	template <typename U, precision Q>
+	GLM_FUNC_QUALIFIER tmat4x3<T, P>::tmat4x3(tmat2x3<U, Q> const & m)
 	{
 		this->value[0] = col_type(m[0]);
 		this->value[1] = col_type(m[1]);
@@ -205,7 +209,8 @@ namespace glm
 	}
 
 	template <typename T, precision P> 
-	GLM_FUNC_QUALIFIER tmat4x3<T, P>::tmat4x3(tmat3x2<T, P> const & m)
+	template <typename U, precision Q>
+	GLM_FUNC_QUALIFIER tmat4x3<T, P>::tmat4x3(tmat3x2<U, Q> const & m)
 	{
 		this->value[0] = col_type(m[0], 0);
 		this->value[1] = col_type(m[1], 0);
@@ -214,7 +219,8 @@ namespace glm
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tmat4x3<T, P>::tmat4x3(tmat2x4<T, P> const & m)
+	template <typename U, precision Q>
+	GLM_FUNC_QUALIFIER tmat4x3<T, P>::tmat4x3(tmat2x4<U, Q> const & m)
 	{
 		this->value[0] = col_type(m[0]);
 		this->value[1] = col_type(m[1]);
@@ -223,7 +229,8 @@ namespace glm
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tmat4x3<T, P>::tmat4x3(tmat4x2<T, P> const & m)
+	template <typename U, precision Q>
+	GLM_FUNC_QUALIFIER tmat4x3<T, P>::tmat4x3(tmat4x2<U, Q> const & m)
 	{
 		this->value[0] = col_type(m[0], 0);
 		this->value[1] = col_type(m[1], 0);
@@ -232,7 +239,8 @@ namespace glm
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tmat4x3<T, P>::tmat4x3(tmat3x4<T, P> const & m)
+	template <typename U, precision Q>
+	GLM_FUNC_QUALIFIER tmat4x3<T, P>::tmat4x3(tmat3x4<U, Q> const & m)
 	{
 		this->value[0] = col_type(m[0]);
 		this->value[1] = col_type(m[1]);

--- a/glm/detail/type_mat4x4.hpp
+++ b/glm/detail/type_mat4x4.hpp
@@ -115,14 +115,29 @@ namespace glm
 		template <typename U, precision Q>
 		GLM_FUNC_DECL GLM_EXPLICIT tmat4x4(tmat4x4<U, Q> const & m);
 
-		GLM_FUNC_DECL GLM_EXPLICIT tmat4x4(tmat2x2<T, P> const & x);
-		GLM_FUNC_DECL GLM_EXPLICIT tmat4x4(tmat3x3<T, P> const & x);
-		GLM_FUNC_DECL GLM_EXPLICIT tmat4x4(tmat2x3<T, P> const & x);
-		GLM_FUNC_DECL GLM_EXPLICIT tmat4x4(tmat3x2<T, P> const & x);
-		GLM_FUNC_DECL GLM_EXPLICIT tmat4x4(tmat2x4<T, P> const & x);
-		GLM_FUNC_DECL GLM_EXPLICIT tmat4x4(tmat4x2<T, P> const & x);
-		GLM_FUNC_DECL GLM_EXPLICIT tmat4x4(tmat3x4<T, P> const & x);
-		GLM_FUNC_DECL GLM_EXPLICIT tmat4x4(tmat4x3<T, P> const & x);
+		template <typename U, precision Q>
+		GLM_FUNC_DECL GLM_EXPLICIT tmat4x4(tmat2x2<U, Q> const & x);
+
+		template <typename U, precision Q>
+		GLM_FUNC_DECL GLM_EXPLICIT tmat4x4(tmat3x3<U, Q> const & x);
+
+		template <typename U, precision Q>
+		GLM_FUNC_DECL GLM_EXPLICIT tmat4x4(tmat2x3<U, Q> const & x);
+
+		template <typename U, precision Q>
+		GLM_FUNC_DECL GLM_EXPLICIT tmat4x4(tmat3x2<U, Q> const & x);
+
+		template <typename U, precision Q>
+		GLM_FUNC_DECL GLM_EXPLICIT tmat4x4(tmat2x4<U, Q> const & x);
+
+		template <typename U, precision Q>
+		GLM_FUNC_DECL GLM_EXPLICIT tmat4x4(tmat4x2<U, Q> const & x);
+
+		template <typename U, precision Q>
+		GLM_FUNC_DECL GLM_EXPLICIT tmat4x4(tmat3x4<U, Q> const & x);
+
+		template <typename U, precision Q>
+		GLM_FUNC_DECL GLM_EXPLICIT tmat4x4(tmat4x3<U, Q> const & x);
 
 		// -- Accesses --
 

--- a/glm/detail/type_mat4x4.inl
+++ b/glm/detail/type_mat4x4.inl
@@ -257,7 +257,8 @@ namespace detail
 	// -- Matrix conversions --
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tmat4x4<T, P>::tmat4x4(tmat2x2<T, P> const & m)
+	template <typename U, precision Q>
+	GLM_FUNC_QUALIFIER tmat4x4<T, P>::tmat4x4(tmat2x2<U, Q> const & m)
 	{
 		this->value[0] = col_type(m[0], 0, 0);
 		this->value[1] = col_type(m[1], 0, 0);
@@ -266,7 +267,8 @@ namespace detail
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tmat4x4<T, P>::tmat4x4(tmat3x3<T, P> const & m)
+	template <typename U, precision Q>
+	GLM_FUNC_QUALIFIER tmat4x4<T, P>::tmat4x4(tmat3x3<U, Q> const & m)
 	{
 		this->value[0] = col_type(m[0], 0);
 		this->value[1] = col_type(m[1], 0);
@@ -275,7 +277,8 @@ namespace detail
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tmat4x4<T, P>::tmat4x4(tmat2x3<T, P> const & m)
+	template <typename U, precision Q>
+	GLM_FUNC_QUALIFIER tmat4x4<T, P>::tmat4x4(tmat2x3<U, Q> const & m)
 	{
 		this->value[0] = col_type(m[0], 0);
 		this->value[1] = col_type(m[1], 0);
@@ -284,7 +287,8 @@ namespace detail
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tmat4x4<T, P>::tmat4x4(tmat3x2<T, P> const & m)
+	template <typename U, precision Q>
+	GLM_FUNC_QUALIFIER tmat4x4<T, P>::tmat4x4(tmat3x2<U, Q> const & m)
 	{
 		this->value[0] = col_type(m[0], 0, 0);
 		this->value[1] = col_type(m[1], 0, 0);
@@ -293,7 +297,8 @@ namespace detail
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tmat4x4<T, P>::tmat4x4(tmat2x4<T, P> const & m)
+	template <typename U, precision Q>
+	GLM_FUNC_QUALIFIER tmat4x4<T, P>::tmat4x4(tmat2x4<U, Q> const & m)
 	{
 		this->value[0] = m[0];
 		this->value[1] = m[1];
@@ -302,7 +307,8 @@ namespace detail
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tmat4x4<T, P>::tmat4x4(tmat4x2<T, P> const & m)
+	template <typename U, precision Q>
+	GLM_FUNC_QUALIFIER tmat4x4<T, P>::tmat4x4(tmat4x2<U, Q> const & m)
 	{
 		this->value[0] = col_type(m[0], 0, 0);
 		this->value[1] = col_type(m[1], 0, 0);
@@ -311,7 +317,8 @@ namespace detail
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tmat4x4<T, P>::tmat4x4(tmat3x4<T, P> const & m)
+	template <typename U, precision Q>
+	GLM_FUNC_QUALIFIER tmat4x4<T, P>::tmat4x4(tmat3x4<U, Q> const & m)
 	{
 		this->value[0] = m[0];
 		this->value[1] = m[1];
@@ -320,7 +327,8 @@ namespace detail
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tmat4x4<T, P>::tmat4x4(tmat4x3<T, P> const & m)
+	template <typename U, precision Q>
+	GLM_FUNC_QUALIFIER tmat4x4<T, P>::tmat4x4(tmat4x3<U, Q> const & m)
 	{
 		this->value[0] = col_type(m[0], 0);
 		this->value[1] = col_type(m[1], 0);

--- a/glm/detail/type_vec3.hpp
+++ b/glm/detail/type_vec3.hpp
@@ -161,6 +161,10 @@ namespace glm
 		template <typename U, precision Q>
 		GLM_FUNC_DECL GLM_EXPLICIT tvec3(tvec3<U, Q> const & v);
 
+		/// Other explicit conversions
+		template <typename U, precision Q>
+		GLM_FUNC_DECL GLM_EXPLICIT tvec3(tvec2<U, Q> const & v);
+
 		// -- Swizzle constructors --
 
 #		if GLM_HAS_ANONYMOUS_UNION && defined(GLM_SWIZZLE)

--- a/glm/detail/type_vec3.inl
+++ b/glm/detail/type_vec3.inl
@@ -166,6 +166,14 @@ namespace glm
 		z(static_cast<T>(v.z))
 	{}
 
+	template <typename T, precision P>
+	template <typename U, precision Q>
+	GLM_FUNC_QUALIFIER tvec3<T, P>::tvec3(tvec2<U, Q> const & v) :
+		x(static_cast<T>(v.x)),
+		y(static_cast<T>(v.y)),
+		z(static_cast<T>(0))
+	{}
+
 	// -- Component accesses --
 
 #	ifdef GLM_FORCE_SIZE_FUNC

--- a/glm/detail/type_vec4.hpp
+++ b/glm/detail/type_vec4.hpp
@@ -244,6 +244,13 @@ namespace detail
 		template <typename U, precision Q>
 		GLM_FUNC_DECL GLM_EXPLICIT tvec4(tvec4<U, Q> const & v);
 
+		/// Other explicit conversions
+		template <typename U, precision Q>
+		GLM_FUNC_DECL GLM_EXPLICIT tvec4(tvec2<U, Q> const & v);
+
+		template <typename U, precision Q>
+		GLM_FUNC_DECL GLM_EXPLICIT tvec4(tvec3<U, Q> const & v);
+
 		// -- Swizzle constructors --
 
 #		if GLM_HAS_ANONYMOUS_UNION && defined(GLM_SWIZZLE)

--- a/glm/detail/type_vec4.inl
+++ b/glm/detail/type_vec4.inl
@@ -268,6 +268,24 @@ namespace glm
 		w(static_cast<T>(v.w))
 	{}
 
+	template <typename T, precision P>
+	template <typename U, precision Q>
+	GLM_FUNC_QUALIFIER tvec4<T, P>::tvec4(tvec2<U, Q> const & v) :
+		x(static_cast<T>(v.x)),
+		y(static_cast<T>(v.y)),
+		z(static_cast<T>(0)),
+		w(static_cast<T>(0))
+	{}
+
+	template <typename T, precision P>
+	template <typename U, precision Q>
+	GLM_FUNC_QUALIFIER tvec4<T, P>::tvec4(tvec3<U, Q> const & v) :
+		x(static_cast<T>(v.x)),
+		y(static_cast<T>(v.y)),
+		z(static_cast<T>(v.z)),
+		w(static_cast<T>(0))
+	{}
+
 	// -- Component accesses --
 
 #	ifdef GLM_FORCE_SIZE_FUNC

--- a/glm/gtc/quaternion.hpp
+++ b/glm/gtc/quaternion.hpp
@@ -147,9 +147,14 @@ namespace glm
 		GLM_FUNC_DECL tquat(tvec3<T, P> const & u, tvec3<T, P> const & v);
 
 		/// Build a quaternion from euler angles (pitch, yaw, roll), in radians.
-		GLM_FUNC_DECL GLM_EXPLICIT tquat(tvec3<T, P> const & eulerAngles);
-		GLM_FUNC_DECL GLM_EXPLICIT tquat(tmat3x3<T, P> const & m);
-		GLM_FUNC_DECL GLM_EXPLICIT tquat(tmat4x4<T, P> const & m);
+		template <typename U, precision Q>
+		GLM_FUNC_DECL GLM_EXPLICIT tquat(tvec3<U, Q> const & eulerAngles);
+
+		template <typename U, precision Q>
+		GLM_FUNC_DECL GLM_EXPLICIT tquat(tmat3x3<U, Q> const & m);
+
+		template <typename U, precision Q>
+		GLM_FUNC_DECL GLM_EXPLICIT tquat(tmat4x4<U, Q> const & m);
 
 		// -- Unary arithmetic operators --
 

--- a/glm/gtc/quaternion.inl
+++ b/glm/gtc/quaternion.inl
@@ -240,7 +240,8 @@ namespace detail
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tquat<T, P>::tquat(tvec3<T, P> const & eulerAngle)
+	template <typename U, precision Q>
+	GLM_FUNC_QUALIFIER tquat<T, P>::tquat(tvec3<U, Q> const & eulerAngle)
 	{
 		tvec3<T, P> c = glm::cos(eulerAngle * T(0.5));
 		tvec3<T, P> s = glm::sin(eulerAngle * T(0.5));
@@ -252,13 +253,15 @@ namespace detail
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tquat<T, P>::tquat(tmat3x3<T, P> const & m)
+	template <typename U, precision Q>
+	GLM_FUNC_QUALIFIER tquat<T, P>::tquat(tmat3x3<U, Q> const & m)
 	{
 		*this = quat_cast(m);
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tquat<T, P>::tquat(tmat4x4<T, P> const & m)
+	template <typename U, precision Q>
+	GLM_FUNC_QUALIFIER tquat<T, P>::tquat(tmat4x4<U, Q> const & m)
 	{
 		*this = quat_cast(m);
 	}

--- a/glm/gtx/dual_quaternion.hpp
+++ b/glm/gtx/dual_quaternion.hpp
@@ -112,8 +112,11 @@ namespace glm
 		template <typename U, precision Q>
 		GLM_FUNC_DECL GLM_EXPLICIT tdualquat(tdualquat<U, Q> const & q);
 
-		GLM_FUNC_DECL GLM_EXPLICIT tdualquat(tmat2x4<T, P> const & holder_mat);
-		GLM_FUNC_DECL GLM_EXPLICIT tdualquat(tmat3x4<T, P> const & aug_mat);
+		template <typename U, precision Q>
+		GLM_FUNC_DECL GLM_EXPLICIT tdualquat(tmat2x4<U, Q> const & holder_mat);
+
+		template <typename U, precision Q>
+		GLM_FUNC_DECL GLM_EXPLICIT tdualquat(tmat3x4<U, Q> const & aug_mat);
 
 		// -- Unary arithmetic operators --
 

--- a/glm/gtx/dual_quaternion.inl
+++ b/glm/gtx/dual_quaternion.inl
@@ -141,13 +141,15 @@ namespace glm
 	{}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tdualquat<T, P>::tdualquat(tmat2x4<T, P> const & m)
+	template <typename U, precision Q>
+	GLM_FUNC_QUALIFIER tdualquat<T, P>::tdualquat(tmat2x4<U, Q> const & m)
 	{
 		*this = dualquat_cast(m);
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tdualquat<T, P>::tdualquat(tmat3x4<T, P> const & m)
+	template <typename U, precision Q>
+	GLM_FUNC_QUALIFIER tdualquat<T, P>::tdualquat(tmat3x4<U, Q> const & m)
 	{
 		*this = dualquat_cast(m);
 	}

--- a/readme.md
+++ b/readme.md
@@ -66,6 +66,7 @@ glm::mat4 camera(float Translate, glm::vec2 const & Rotate)
 - Improved GTC_random linearRand documentation
 - Improved GTC_reciprocal documentation
 - Improved GLM_FORCE_EXPLICIT_CTOR coverage #481
+- Template most unary conversion constructors
 
 ##### Fixes:
 - Fixed GTX_extended_min_max filename typo #386

--- a/test/core/core_type_ctor.cpp
+++ b/test/core/core_type_ctor.cpp
@@ -100,6 +100,11 @@ int test_vec3_ctor()
 	}
 #	endif//GLM_HAS_DEFAULTED_FUNCTIONS
 
+	Error += (glm::ivec3(glm::vec2(4.0f, 5.0f)) == glm::ivec3(4, 5, 0)) ? 0 : 1;
+	Error += (glm::ivec3(glm::vec2(5, 6)) == glm::ivec3(5, 6, 0)) ? 0 : 1;
+	Error += (glm::bvec3(glm::vec2(4.0f, 5.0f)) == glm::bvec3(true, true, false)) ? 0 : 1;
+	Error += (glm::ivec3(glm::dvec3(1.0, 1.0, 1.0)) == glm::ivec3(1, 1, 1)) ? 0 : 1;
+
 	return Error;
 }
 
@@ -130,6 +135,10 @@ int test_vec4_ctor()
 		Error += glm::all(glm::equal(B.i, glm::ivec4(1065353216))) ? 0 : 1;
 	}
 #	endif//GLM_HAS_DEFAULTED_FUNCTIONS
+
+	Error += (glm::ivec4(glm::vec2(4.0f, 5.0f)) == glm::ivec4(4, 5, 0, 0)) ? 0 : 1;
+	Error += (glm::vec4(glm::vec3(4.0f, 5.0f, 7.0f)) == glm::vec4(4.0f, 5.0f, 7.0f, 0)) ? 0 : 1;
+	Error += (glm::uvec4(glm::bvec4(true, true, false, true)) == glm::uvec4(1, 1, 0, 1)) ? 0 : 1;
 
 	return Error;
 }

--- a/test/core/core_type_mat2x2.cpp
+++ b/test/core/core_type_mat2x2.cpp
@@ -169,6 +169,16 @@ namespace cast
 		Error += entry<glm::mat4x3>();
 		Error += entry<glm::mat4x4>();
 
+		Error += entry<glm::dmat2x2>();
+		Error += entry<glm::dmat2x3>();
+		Error += entry<glm::dmat2x4>();
+		Error += entry<glm::dmat3x2>();
+		Error += entry<glm::dmat3x3>();
+		Error += entry<glm::dmat3x4>();
+		Error += entry<glm::dmat4x2>();
+		Error += entry<glm::dmat4x3>();
+		Error += entry<glm::dmat4x4>();
+
 		return Error;
 	}
 }//namespace cast

--- a/test/core/core_type_mat2x3.cpp
+++ b/test/core/core_type_mat2x3.cpp
@@ -144,6 +144,16 @@ namespace cast
 		Error += entry<glm::mat4x3>();
 		Error += entry<glm::mat4x4>();
 
+		Error += entry<glm::dmat2x2>();
+		Error += entry<glm::dmat2x3>();
+		Error += entry<glm::dmat2x4>();
+		Error += entry<glm::dmat3x2>();
+		Error += entry<glm::dmat3x3>();
+		Error += entry<glm::dmat3x4>();
+		Error += entry<glm::dmat4x2>();
+		Error += entry<glm::dmat4x3>();
+		Error += entry<glm::dmat4x4>();
+
 		return Error;
 	}
 }//namespace cast

--- a/test/core/core_type_mat2x4.cpp
+++ b/test/core/core_type_mat2x4.cpp
@@ -143,6 +143,16 @@ namespace cast
 		Error += entry<glm::mat4x3>();
 		Error += entry<glm::mat4x4>();
 
+		Error += entry<glm::dmat2x2>();
+		Error += entry<glm::dmat2x3>();
+		Error += entry<glm::dmat2x4>();
+		Error += entry<glm::dmat3x2>();
+		Error += entry<glm::dmat3x3>();
+		Error += entry<glm::dmat3x4>();
+		Error += entry<glm::dmat4x2>();
+		Error += entry<glm::dmat4x3>();
+		Error += entry<glm::dmat4x4>();
+
 		return Error;
 	}
 }//namespace cast

--- a/test/core/core_type_mat3x2.cpp
+++ b/test/core/core_type_mat3x2.cpp
@@ -148,6 +148,16 @@ namespace cast
 		Error += entry<glm::mat4x3>();
 		Error += entry<glm::mat4x4>();
 
+		Error += entry<glm::dmat2x2>();
+		Error += entry<glm::dmat2x3>();
+		Error += entry<glm::dmat2x4>();
+		Error += entry<glm::dmat3x2>();
+		Error += entry<glm::dmat3x3>();
+		Error += entry<glm::dmat3x4>();
+		Error += entry<glm::dmat4x2>();
+		Error += entry<glm::dmat4x3>();
+		Error += entry<glm::dmat4x4>();
+
 		return Error;
 	}
 }//namespace cast

--- a/test/core/core_type_mat3x3.cpp
+++ b/test/core/core_type_mat3x3.cpp
@@ -206,6 +206,16 @@ namespace cast
 		Error += entry<glm::mat4x3>();
 		Error += entry<glm::mat4x4>();
 
+		Error += entry<glm::dmat2x2>();
+		Error += entry<glm::dmat2x3>();
+		Error += entry<glm::dmat2x4>();
+		Error += entry<glm::dmat3x2>();
+		Error += entry<glm::dmat3x3>();
+		Error += entry<glm::dmat3x4>();
+		Error += entry<glm::dmat4x2>();
+		Error += entry<glm::dmat4x3>();
+		Error += entry<glm::dmat4x4>();
+
 		return Error;
 	}
 }//namespace cast

--- a/test/core/core_type_mat3x4.cpp
+++ b/test/core/core_type_mat3x4.cpp
@@ -147,6 +147,16 @@ namespace cast
 		Error += entry<glm::mat4x3>();
 		Error += entry<glm::mat4x4>();
 
+		Error += entry<glm::dmat2x2>();
+		Error += entry<glm::dmat2x3>();
+		Error += entry<glm::dmat2x4>();
+		Error += entry<glm::dmat3x2>();
+		Error += entry<glm::dmat3x3>();
+		Error += entry<glm::dmat3x4>();
+		Error += entry<glm::dmat4x2>();
+		Error += entry<glm::dmat4x3>();
+		Error += entry<glm::dmat4x4>();
+
 		return Error;
 	}
 }//namespace cast

--- a/test/core/core_type_mat4x2.cpp
+++ b/test/core/core_type_mat4x2.cpp
@@ -150,6 +150,16 @@ namespace cast
 		Error += entry<glm::mat4x2>();
 		Error += entry<glm::mat4x3>();
 		Error += entry<glm::mat4x4>();
+		
+		Error += entry<glm::dmat2x2>();
+		Error += entry<glm::dmat2x3>();
+		Error += entry<glm::dmat2x4>();
+		Error += entry<glm::dmat3x2>();
+		Error += entry<glm::dmat3x3>();
+		Error += entry<glm::dmat3x4>();
+		Error += entry<glm::dmat4x2>();
+		Error += entry<glm::dmat4x3>();
+		Error += entry<glm::dmat4x4>();
 
 		return Error;
 	}

--- a/test/core/core_type_mat4x3.cpp
+++ b/test/core/core_type_mat4x3.cpp
@@ -151,6 +151,16 @@ namespace cast
 		Error += entry<glm::mat4x3>();
 		Error += entry<glm::mat4x4>();
 
+		Error += entry<glm::dmat2x2>();
+		Error += entry<glm::dmat2x3>();
+		Error += entry<glm::dmat2x4>();
+		Error += entry<glm::dmat3x2>();
+		Error += entry<glm::dmat3x3>();
+		Error += entry<glm::dmat3x4>();
+		Error += entry<glm::dmat4x2>();
+		Error += entry<glm::dmat4x3>();
+		Error += entry<glm::dmat4x4>();
+
 		return Error;
 	}
 }//namespace cast

--- a/test/core/core_type_mat4x4.cpp
+++ b/test/core/core_type_mat4x4.cpp
@@ -324,6 +324,16 @@ namespace cast
 		Error += entry<glm::mat4x3>();
 		Error += entry<glm::mat4x4>();
 
+		Error += entry<glm::dmat2x2>();
+		Error += entry<glm::dmat2x3>();
+		Error += entry<glm::dmat2x4>();
+		Error += entry<glm::dmat3x2>();
+		Error += entry<glm::dmat3x3>();
+		Error += entry<glm::dmat3x4>();
+		Error += entry<glm::dmat4x2>();
+		Error += entry<glm::dmat4x3>();
+		Error += entry<glm::dmat4x4>();
+
 		return Error;
 	}
 }//namespace cast

--- a/test/gtc/gtc_quaternion.cpp
+++ b/test/gtc/gtc_quaternion.cpp
@@ -277,6 +277,8 @@ int test_quat_type()
 	glm::quat A;
 	glm::dquat B;
 
+	glm::dquat C(A);
+
 	return 0;
 }
 


### PR DESCRIPTION
Now you can seamlessly convert between a `bvec3` and a `uvec4`.  Also added constructors for converting smaller vector types to larger ones (the extra components are set to zero).