### PR TITLE
Undefined reference errors

### DIFF
--- a/glm/detail/type_mat4x2.hpp
+++ b/glm/detail/type_mat4x2.hpp
@@ -198,13 +198,13 @@ namespace glm
 	GLM_FUNC_DECL typename tmat4x2<T, P>::row_type operator*(typename tmat4x2<T, P>::col_type const & v, tmat4x2<T, P> const & m);
 
 	template <typename T, precision P>
+	GLM_FUNC_DECL tmat2x2<T, P> operator*(tmat4x2<T, P> const & m1, tmat2x4<T, P> const & m2);
+
+	template <typename T, precision P>
 	GLM_FUNC_DECL tmat3x2<T, P> operator*(tmat4x2<T, P> const & m1, tmat3x4<T, P> const & m2);
 
 	template <typename T, precision P>
 	GLM_FUNC_DECL tmat4x2<T, P> operator*(tmat4x2<T, P> const & m1, tmat4x4<T, P> const & m2);
-
-	template <typename T, precision P>
-	GLM_FUNC_DECL tmat2x3<T, P> operator*(tmat4x3<T, P> const & m1, tmat2x4<T, P> const & m2);
 
 	template <typename T, precision P>
 	GLM_FUNC_DECL tmat4x2<T, P> operator/(tmat4x2<T, P> const & m, T const & s);

--- a/glm/detail/type_vec2.hpp
+++ b/glm/detail/type_vec2.hpp
@@ -306,9 +306,6 @@ namespace glm
 	GLM_FUNC_DECL tvec2<T, P> operator/(tvec2<T, P> const & v1, tvec2<T, P> const & v2);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec2<T, P> operator-(tvec2<T, P> const & v);
-
-	template <typename T, precision P>
 	GLM_FUNC_DECL tvec2<T, P> operator%(tvec2<T, P> const & v, T const & scalar);
 
 	template <typename T, precision P>

--- a/glm/detail/type_vec4.hpp
+++ b/glm/detail/type_vec4.hpp
@@ -439,12 +439,6 @@ namespace detail
 	GLM_FUNC_DECL tvec4<T, P> operator/(tvec4<T, P> const & v1, tvec4<T, P> const & v2);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL bool operator==(tvec4<T, P> const & v1, tvec4<T, P> const & v2);
-
-	template <typename T, precision P>
-	GLM_FUNC_DECL bool operator!=(tvec4<T, P> const & v1, tvec4<T, P> const & v2);
-
-	template <typename T, precision P>
 	GLM_FUNC_DECL tvec4<T, P> operator%(tvec4<T, P> const & v, T scalar);
 
 	template <typename T, precision P>

--- a/glm/detail/type_vec4.hpp
+++ b/glm/detail/type_vec4.hpp
@@ -382,13 +382,13 @@ namespace detail
 	GLM_FUNC_DECL tvec4<T, P> operator+(tvec4<T, P> const & v, const T& scalar);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec4<T, P> operator+(tvec4<T, P> const & v, tvec1<T, P> const & scalar);
+	GLM_FUNC_DECL tvec4<T, P> operator+(tvec4<T, P> const & v1, tvec1<T, P> const & v2);
 
 	template <typename T, precision P>
 	GLM_FUNC_DECL tvec4<T, P> operator+(T scalar, tvec4<T, P> const & v);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec4<T, P> operator+(tvec1<T, P> const & scalar, tvec4<T, P> const & v);
+	GLM_FUNC_DECL tvec4<T, P> operator+(tvec1<T, P> const & v1, tvec4<T, P> const & v2);
 
 	template <typename T, precision P>
 	GLM_FUNC_DECL tvec4<T, P> operator+(tvec4<T, P> const & v1, tvec4<T, P> const & v2);
@@ -397,13 +397,13 @@ namespace detail
 	GLM_FUNC_DECL tvec4<T, P> operator-(tvec4<T, P> const & v, const T& scalar);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec4<T, P> operator-(tvec4<T, P> const & v, tvec1<T, P> const & scalar);
+	GLM_FUNC_DECL tvec4<T, P> operator-(tvec4<T, P> const & v1, tvec1<T, P> const & v2);
 
 	template <typename T, precision P>
 	GLM_FUNC_DECL tvec4<T, P> operator-(T scalar, tvec4<T, P> const & v);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec4<T, P> operator-(tvec1<T, P> const & scalar, tvec4<T, P> const & v);
+	GLM_FUNC_DECL tvec4<T, P> operator-(tvec1<T, P> const & v1, tvec4<T, P> const & v2);
 
 	template <typename T, precision P>
 	GLM_FUNC_DECL tvec4<T, P> operator-(tvec4<T, P> const & v1, tvec4<T, P> const & v2);
@@ -412,13 +412,13 @@ namespace detail
 	GLM_FUNC_DECL tvec4<T, P> operator*(tvec4<T, P> const & v, const T& scalar);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec4<T, P> operator*(tvec4<T, P> const & v, tvec1<T, P> const & scalar);
+	GLM_FUNC_DECL tvec4<T, P> operator*(tvec4<T, P> const & v1, tvec1<T, P> const & v2);
 
 	template <typename T, precision P>
 	GLM_FUNC_DECL tvec4<T, P> operator*(T scalar, tvec4<T, P> const & v);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec4<T, P> operator*(tvec1<T, P> const & scalar, tvec4<T, P> const & v);
+	GLM_FUNC_DECL tvec4<T, P> operator*(tvec1<T, P> const & v1, tvec4<T, P> const & v2);
 
 	template <typename T, precision P>
 	GLM_FUNC_DECL tvec4<T, P> operator*(tvec4<T, P> const & v1, tvec4<T, P> const & v2);

--- a/glm/detail/type_vec4.inl
+++ b/glm/detail/type_vec4.inl
@@ -740,6 +740,16 @@ namespace glm
 	}
 
 	template <typename T, precision P>
+	GLM_FUNC_QUALIFIER tvec4<T, P> operator+(tvec4<T, P> const & v1, tvec1<T, P> const & v2)
+	{
+		return tvec4<T, P>(
+			v1.x + v2.x,
+			v1.y + v2.x,
+			v1.z + v2.x,
+			v1.w + v2.x);
+	}
+
+	template <typename T, precision P>
 	GLM_FUNC_QUALIFIER tvec4<T, P> operator+(T scalar, tvec4<T, P> const & v)
 	{
 		return tvec4<T, P>(
@@ -747,6 +757,16 @@ namespace glm
 			scalar + v.y,
 			scalar + v.z,
 			scalar + v.w);
+	}
+
+	template <typename T, precision P>
+	GLM_FUNC_QUALIFIER tvec4<T, P> operator+(tvec1<T, P> const & v1, tvec4<T, P> const & v2)
+	{
+		return tvec4<T, P>(
+			v1.x + v2.x,
+			v1.x + v2.y,
+			v1.x + v2.z,
+			v1.x + v2.w);
 	}
 
 	template <typename T, precision P>
@@ -770,6 +790,16 @@ namespace glm
 	}
 
 	template <typename T, precision P>
+	GLM_FUNC_QUALIFIER tvec4<T, P> operator-(tvec4<T, P> const & v1, tvec1<T, P> const & v2)
+	{
+		return tvec4<T, P>(
+			v1.x - v2.x,
+			v1.y - v2.x,
+			v1.z - v2.x,
+			v1.w - v2.x);
+	}
+
+	template <typename T, precision P>
 	GLM_FUNC_QUALIFIER tvec4<T, P> operator-(T scalar, tvec4<T, P> const & v)
 	{
 		return tvec4<T, P>(
@@ -777,6 +807,16 @@ namespace glm
 			scalar - v.y,
 			scalar - v.z,
 			scalar - v.w);
+	}
+
+	template <typename T, precision P>
+	GLM_FUNC_DECL tvec4<T, P> operator-(tvec1<T, P> const & v1, tvec4<T, P> const & v2)
+	{
+		return tvec4<T, P>(
+			v1.x - v2.x,
+			v1.x - v2.y,
+			v1.x - v2.z,
+			v1.x - v2.w);
 	}
 
 	template <typename T, precision P>
@@ -800,6 +840,16 @@ namespace glm
 	}
 
 	template <typename T, precision P>
+	GLM_FUNC_QUALIFIER tvec4<T, P> operator*(tvec4<T, P> const & v1, tvec1<T, P> const & v2)
+	{
+		return tvec4<T, P>(
+			v1.x * v2.x,
+			v1.y * v2.x,
+			v1.z * v2.x,
+			v1.w * v2.x);
+	}
+
+	template <typename T, precision P>
 	GLM_FUNC_QUALIFIER tvec4<T, P> operator*(T scalar, tvec4<T, P> const & v)
 	{
 		return tvec4<T, P>(
@@ -807,6 +857,16 @@ namespace glm
 			scalar * v.y,
 			scalar * v.z,
 			scalar * v.w);
+	}
+
+	template <typename T, precision P>
+	GLM_FUNC_DECL tvec4<T, P> operator*(tvec1<T, P> const & v1, tvec4<T, P> const & v2)
+	{
+		return tvec4<T, P>(
+			v1.x * v2.x,
+			v1.x * v2.y,
+			v1.x * v2.z,
+			v1.x * v2.w);
 	}
 
 	template <typename T, precision P>


### PR DESCRIPTION
Closes https://github.com/g-truc/glm/issues/488.

There were a few issues with different operator functions, which caused `undefined reference` errors:
- some  had duplicate declarations (removed)
- others had missing definitions (added to `glm/detail/type_vec4.inl`; I also changed the parameter names to match similar functions in other vector classes)
- one declaration didn't match the definition (fixed in `glm/detail/type_mat4x2.hpp`).

I guess you only get these errors if the template function is instantiated (i.e. you actually use the function). Weirdly enough, I don't get errors for all of the duplicate declarations I've fixed here (only some of them), but everything else produces an `undefined reference` error without these changes.