### PR TITLE
More undefined reference errors

### DIFF
--- a/glm/detail/type_mat2x2.hpp
+++ b/glm/detail/type_mat2x2.hpp
@@ -49,11 +49,6 @@ namespace glm
 		typedef tmat2x2<T, P> transpose_type;
 		typedef T value_type;
 
-		template <typename U, precision Q>
-		friend tvec2<U, Q> operator/(tmat2x2<U, Q> const & m, tvec2<U, Q> const & v);
-		template <typename U, precision Q>
-		friend tvec2<U, Q> operator/(tvec2<U, Q> const & v, tmat2x2<U, Q> const & m);
-
 	private:
 		col_type value[2];
 

--- a/glm/detail/type_mat2x4.hpp
+++ b/glm/detail/type_mat2x4.hpp
@@ -177,10 +177,10 @@ namespace glm
 	GLM_FUNC_DECL tmat3x4<T, P> operator*(tmat2x4<T, P> const & m1, tmat3x2<T, P> const & m2);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tmat2x4<T, P> operator/(tmat2x4<T, P> const & m, const T& s);
+	GLM_FUNC_DECL tmat2x4<T, P> operator/(tmat2x4<T, P> const & m, T const & s);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tmat2x4<T, P> operator/(T s, tmat2x4<T, P> const & m);
+	GLM_FUNC_DECL tmat2x4<T, P> operator/(T const & s, tmat2x4<T, P> const & m);
 
 	// -- Boolean operators --
 

--- a/glm/detail/type_mat2x4.inl
+++ b/glm/detail/type_mat2x4.inl
@@ -493,7 +493,7 @@ namespace glm
 	}
 
 	template <typename T, precision P> 
-	GLM_FUNC_QUALIFIER tmat2x4<T, P> operator/(tmat2x4<T, P> const & m, const T& s)
+	GLM_FUNC_QUALIFIER tmat2x4<T, P> operator/(tmat2x4<T, P> const & m, T const & s)
 	{
 		return tmat2x4<T, P>(
 			m[0] / s,
@@ -501,7 +501,7 @@ namespace glm
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tmat2x4<T, P> operator/(T s, tmat2x4<T, P> const & m)
+	GLM_FUNC_QUALIFIER tmat2x4<T, P> operator/(T const & s, tmat2x4<T, P> const & m)
 	{
 		return tmat2x4<T, P>(
 			s / m[0],

--- a/glm/detail/type_mat3x3.hpp
+++ b/glm/detail/type_mat3x3.hpp
@@ -49,11 +49,6 @@ namespace glm
 		typedef tmat3x3<T, P> transpose_type;
 		typedef T value_type;
 
-		template <typename U, precision Q>
-		friend tvec3<U, Q> operator/(tmat3x3<U, Q> const & m, tvec3<U, Q> const & v);
-		template <typename U, precision Q>
-		friend tvec3<U, Q> operator/(tvec3<U, Q> const & v, tmat3x3<U, Q> const & m);
-
 	private:
 		col_type value[3];
 

--- a/glm/detail/type_mat4x4.hpp
+++ b/glm/detail/type_mat4x4.hpp
@@ -210,7 +210,7 @@ namespace glm
 	GLM_FUNC_DECL typename tmat4x4<T, P>::col_type operator/(tmat4x4<T, P> const & m, typename tmat4x4<T, P>::row_type const & v);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL typename tmat4x4<T, P>::row_type operator/(typename tmat4x4<T, P>::col_type & v, tmat4x4<T, P> const & m);
+	GLM_FUNC_DECL typename tmat4x4<T, P>::row_type operator/(typename tmat4x4<T, P>::col_type const & v, tmat4x4<T, P> const & m);
 
 	template <typename T, precision P>
 	GLM_FUNC_DECL tmat4x4<T, P> operator/(tmat4x4<T, P> const & m1,	tmat4x4<T, P> const & m2);

--- a/glm/detail/type_mat4x4.hpp
+++ b/glm/detail/type_mat4x4.hpp
@@ -49,11 +49,6 @@ namespace glm
 		typedef tmat4x4<T, P> transpose_type;
 		typedef T value_type;
 
-		template <typename U, precision Q>
-		friend tvec4<U, Q> operator/(tmat4x4<U, Q> const & m, tvec4<U, Q> const & v);
-		template <typename U, precision Q>
-		friend tvec4<U, Q> operator/(tvec4<U, Q> const & v, tmat4x4<U, Q> const & m);
-
 	private:
 		col_type value[4];
 

--- a/glm/detail/type_vec4.hpp
+++ b/glm/detail/type_vec4.hpp
@@ -394,13 +394,13 @@ namespace detail
 	GLM_FUNC_DECL tvec4<T, P> operator/(tvec4<T, P> const & v, T scalar);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec4<T, P> operator/(tvec4<T, P> const & v, tvec1<T, P> const & scalar);
+	GLM_FUNC_DECL tvec4<T, P> operator/(tvec4<T, P> const & v1, tvec1<T, P> const & v2);
 
 	template <typename T, precision P>
 	GLM_FUNC_DECL tvec4<T, P> operator/(T scalar, tvec4<T, P> const & v);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec4<T, P> operator/(tvec1<T, P> const & scalar, tvec4<T, P> const & v);
+	GLM_FUNC_DECL tvec4<T, P> operator/(tvec1<T, P> const & v1, tvec4<T, P> const & v2);
 
 	template <typename T, precision P>
 	GLM_FUNC_DECL tvec4<T, P> operator/(tvec4<T, P> const & v1, tvec4<T, P> const & v2);

--- a/glm/detail/type_vec4.hpp
+++ b/glm/detail/type_vec4.hpp
@@ -346,7 +346,7 @@ namespace detail
 	// -- Binary operators --
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec4<T, P> operator+(tvec4<T, P> const & v, const T& scalar);
+	GLM_FUNC_DECL tvec4<T, P> operator+(tvec4<T, P> const & v, T scalar);
 
 	template <typename T, precision P>
 	GLM_FUNC_DECL tvec4<T, P> operator+(tvec4<T, P> const & v1, tvec1<T, P> const & v2);
@@ -361,7 +361,7 @@ namespace detail
 	GLM_FUNC_DECL tvec4<T, P> operator+(tvec4<T, P> const & v1, tvec4<T, P> const & v2);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec4<T, P> operator-(tvec4<T, P> const & v, const T& scalar);
+	GLM_FUNC_DECL tvec4<T, P> operator-(tvec4<T, P> const & v, T scalar);
 
 	template <typename T, precision P>
 	GLM_FUNC_DECL tvec4<T, P> operator-(tvec4<T, P> const & v1, tvec1<T, P> const & v2);
@@ -376,7 +376,7 @@ namespace detail
 	GLM_FUNC_DECL tvec4<T, P> operator-(tvec4<T, P> const & v1, tvec4<T, P> const & v2);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec4<T, P> operator*(tvec4<T, P> const & v, const T& scalar);
+	GLM_FUNC_DECL tvec4<T, P> operator*(tvec4<T, P> const & v, T scalar);
 
 	template <typename T, precision P>
 	GLM_FUNC_DECL tvec4<T, P> operator*(tvec4<T, P> const & v1, tvec1<T, P> const & v2);
@@ -391,7 +391,7 @@ namespace detail
 	GLM_FUNC_DECL tvec4<T, P> operator*(tvec4<T, P> const & v1, tvec4<T, P> const & v2);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec4<T, P> operator/(tvec4<T, P> const & v, const T& scalar);
+	GLM_FUNC_DECL tvec4<T, P> operator/(tvec4<T, P> const & v, T scalar);
 
 	template <typename T, precision P>
 	GLM_FUNC_DECL tvec4<T, P> operator/(tvec4<T, P> const & v, tvec1<T, P> const & scalar);

--- a/glm/detail/type_vec4.inl
+++ b/glm/detail/type_vec4.inl
@@ -802,7 +802,7 @@ namespace glm
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tvec4<T, P> operator/(tvec4<T, P> const & v, tvec1<T, P> const & scalar)
+	GLM_FUNC_QUALIFIER tvec4<T, P> operator/(tvec4<T, P> const & v1, tvec1<T, P> const & v2)
 	{
 		return tvec4<T, P>(
 			v1.x / v2.x,
@@ -822,7 +822,7 @@ namespace glm
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec4<T, P> operator/(tvec1<T, P> const & scalar, tvec4<T, P> const & v)
+	GLM_FUNC_DECL tvec4<T, P> operator/(tvec1<T, P> const & v1, tvec4<T, P> const & v2)
 	{
 		return tvec4<T, P>(
 			v1.x / v2.x,

--- a/glm/detail/type_vec4.inl
+++ b/glm/detail/type_vec4.inl
@@ -802,6 +802,16 @@ namespace glm
 	}
 
 	template <typename T, precision P>
+	GLM_FUNC_QUALIFIER tvec4<T, P> operator/(tvec4<T, P> const & v, tvec1<T, P> const & scalar)
+	{
+		return tvec4<T, P>(
+			v1.x / v2.x,
+			v1.y / v2.x,
+			v1.z / v2.x,
+			v1.w / v2.x);
+	}
+
+	template <typename T, precision P>
 	GLM_FUNC_QUALIFIER tvec4<T, P> operator/(T scalar, tvec4<T, P> const & v)
 	{
 		return tvec4<T, P>(
@@ -809,6 +819,16 @@ namespace glm
 			scalar / v.y,
 			scalar / v.z,
 			scalar / v.w);
+	}
+
+	template <typename T, precision P>
+	GLM_FUNC_DECL tvec4<T, P> operator/(tvec1<T, P> const & scalar, tvec4<T, P> const & v)
+	{
+		return tvec4<T, P>(
+			v1.x / v2.x,
+			v1.x / v2.y,
+			v1.x / v2.z,
+			v1.x / v2.w);
 	}
 
 	template <typename T, precision P>

--- a/glm/detail/type_vec4.inl
+++ b/glm/detail/type_vec4.inl
@@ -642,7 +642,7 @@ namespace glm
 	// -- Binary arithmetic operators --
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tvec4<T, P> operator+(tvec4<T, P> const & v, const T& scalar)
+	GLM_FUNC_QUALIFIER tvec4<T, P> operator+(tvec4<T, P> const & v, T scalar)
 	{
 		return tvec4<T, P>(
 			v.x + scalar,
@@ -692,7 +692,7 @@ namespace glm
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tvec4<T, P> operator-(tvec4<T, P> const & v, const T& scalar)
+	GLM_FUNC_QUALIFIER tvec4<T, P> operator-(tvec4<T, P> const & v, T scalar)
 	{
 		return tvec4<T, P>(
 			v.x - scalar,
@@ -742,7 +742,7 @@ namespace glm
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tvec4<T, P> operator*(tvec4<T, P> const & v, const T& scalar)
+	GLM_FUNC_QUALIFIER tvec4<T, P> operator*(tvec4<T, P> const & v, T scalar)
 	{
 		return tvec4<T, P>(
 			v.x * scalar,
@@ -792,7 +792,7 @@ namespace glm
 	}
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tvec4<T, P> operator/(tvec4<T, P> const & v, const T& scalar)
+	GLM_FUNC_QUALIFIER tvec4<T, P> operator/(tvec4<T, P> const & v, T scalar)
 	{
 		return tvec4<T, P>(
 			v.x / scalar,

--- a/glm/gtc/quaternion.hpp
+++ b/glm/gtc/quaternion.hpp
@@ -170,6 +170,14 @@ namespace glm
 	template <typename T, precision P>
 	GLM_FUNC_DECL tquat<T, P> operator/(tquat<T, P> const & q, T const & s);
 
+	// -- Boolean operators --
+
+	template <typename T, precision P>
+	GLM_FUNC_DECL bool operator==(tquat<T, P> const & q1, tquat<T, P> const & q2);
+
+	template <typename T, precision P>
+	GLM_FUNC_DECL bool operator!=(tquat<T, P> const & q1, tquat<T, P> const & q2);
+
 	/// Returns the length of the quaternion.
 	/// 
 	/// @see gtc_quaternion

--- a/glm/gtx/dual_quaternion.hpp
+++ b/glm/gtx/dual_quaternion.hpp
@@ -130,16 +130,16 @@ namespace glm
 	GLM_FUNC_DECL tdualquat<T, P> operator*(tdualquat<T, P> const & q, tdualquat<T, P> const & p);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec3<T, P> operator*(tquat<T, P> const & q, tvec3<T, P> const & v);
+	GLM_FUNC_DECL tvec3<T, P> operator*(tdualquat<T, P> const & q, tvec3<T, P> const & v);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec3<T, P> operator*(tvec3<T, P> const & v, tquat<T, P> const & q);
+	GLM_FUNC_DECL tvec3<T, P> operator*(tvec3<T, P> const & v, tdualquat<T, P> const & q);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec4<T, P> operator*(tquat<T, P> const & q, tvec4<T, P> const & v);
+	GLM_FUNC_DECL tvec4<T, P> operator*(tdualquat<T, P> const & q, tvec4<T, P> const & v);
 
 	template <typename T, precision P>
-	GLM_FUNC_DECL tvec4<T, P> operator*(tvec4<T, P> const & v, tquat<T, P> const & q);
+	GLM_FUNC_DECL tvec4<T, P> operator*(tvec4<T, P> const & v, tdualquat<T, P> const & q);
 
 	template <typename T, precision P>
 	GLM_FUNC_DECL tdualquat<T, P> operator*(tdualquat<T, P> const & q, T const & s);

--- a/glm/gtx/dual_quaternion.hpp
+++ b/glm/gtx/dual_quaternion.hpp
@@ -150,6 +150,14 @@ namespace glm
 	template <typename T, precision P>
 	GLM_FUNC_DECL tdualquat<T, P> operator/(tdualquat<T, P> const & q, T const & s);
 
+	// -- Boolean operators --
+
+	template <typename T, precision P>
+	GLM_FUNC_DECL bool operator==(tdualquat<T, P> const & q1, tdualquat<T, P> const & q2);
+
+	template <typename T, precision P>
+	GLM_FUNC_DECL bool operator!=(tdualquat<T, P> const & q1, tdualquat<T, P> const & q2);
+
 	/// Returns the normalized quaternion.
 	///
 	/// @see gtx_dual_quaternion

--- a/glm/gtx/dual_quaternion.inl
+++ b/glm/gtx/dual_quaternion.inl
@@ -194,9 +194,15 @@ namespace glm
 	// -- Unary bit operators --
 
 	template <typename T, precision P>
-	GLM_FUNC_QUALIFIER tdualquat<T, P> operator-(tdualquat<T, P> const & q)
+	GLM_FUNC_QUALIFIER tdualquat<T, P> operator+(tdualquat<T, P> const & q)
 	{
 		return q;
+	}
+
+	template <typename T, precision P>
+	GLM_FUNC_QUALIFIER tdualquat<T, P> operator-(tdualquat<T, P> const & q)
+	{
+		return tdualquat<T, P>(-q.real, -q.dual);
 	}
 
 	// -- Binary operators --


### PR DESCRIPTION
Continuing from https://github.com/g-truc/glm/issues/488 and https://github.com/g-truc/glm/pull/489...

I found more undefined references with different operator functions. I thought I got them all with the last PR, but noticed that I didn't have `operator/` working yet.

**This is still work-in-progress and I'd like some feedback**:
- I removed the `friend operator/` member functions from `mat2x2`, `mat3x3` and `mat4x4`.
    - I think these are left over from some older version and I can't find them in any other classes. In fact, they seem to be the only `friend`s in the entire code base.
    - They clash with similar functions in the `glm` namespace (`undefined reference` errors if you use them).
    - Are they still used, or is it OK to remove them?
- Parameter naming for `operator` functions with `tvec1` parameters.
    - In some places they're named `v1` or `v2` (because it's a vector type).
    - Other places call them `scalar` (one-dimensional vector, so it's a single number).
    - My previous PR called them `v1` and `v2`, because that's what `tvec2` called them, but I noticed this a bit inconsistent.
    - Which naming convention should I use (or does it matter)? Would you like for me to go over all operator functions and make them consistent?

I'd also like to take a closer look (probably tomorrow) to see if I can find any more of these. There are plenty of operators I'm not (yet) wrapping with SWIG, but I might as well get them all fixed in one go (if I find any more).