### PR TITLE
Fixed compile errors from reciprocal.inl

### DIFF
--- a/glm/gtc/reciprocal.inl
+++ b/glm/gtc/reciprocal.inl
@@ -8,7 +8,7 @@ namespace glm
 {
 	// sec
 	template <typename genType>
-	GLM_FUNC_QUALIFIER genType sec(genType angle)
+	GLM_FUNC_QUALIFIER genType sec(genType const & angle)
 	{
 		GLM_STATIC_ASSERT(std::numeric_limits<genType>::is_iec559, "'sec' only accept floating-point values");
 		return genType(1) / glm::cos(angle);
@@ -23,7 +23,7 @@ namespace glm
 
 	// csc
 	template <typename genType>
-	GLM_FUNC_QUALIFIER genType csc(genType angle)
+	GLM_FUNC_QUALIFIER genType csc(genType const & angle)
 	{
 		GLM_STATIC_ASSERT(std::numeric_limits<genType>::is_iec559, "'csc' only accept floating-point values");
 		return genType(1) / glm::sin(angle);
@@ -38,7 +38,7 @@ namespace glm
 
 	// cot
 	template <typename genType>
-	GLM_FUNC_QUALIFIER genType cot(genType angle)
+	GLM_FUNC_QUALIFIER genType cot(genType const & angle)
 	{
 		GLM_STATIC_ASSERT(std::numeric_limits<genType>::is_iec559, "'cot' only accept floating-point values");
 	
@@ -55,7 +55,7 @@ namespace glm
 
 	// asec
 	template <typename genType>
-	GLM_FUNC_QUALIFIER genType asec(genType x)
+	GLM_FUNC_QUALIFIER genType asec(genType const & x)
 	{
 		GLM_STATIC_ASSERT(std::numeric_limits<genType>::is_iec559, "'asec' only accept floating-point values");
 		return acos(genType(1) / x);
@@ -70,7 +70,7 @@ namespace glm
 
 	// acsc
 	template <typename genType>
-	GLM_FUNC_QUALIFIER genType acsc(genType x)
+	GLM_FUNC_QUALIFIER genType acsc(genType const & x)
 	{
 		GLM_STATIC_ASSERT(std::numeric_limits<genType>::is_iec559, "'acsc' only accept floating-point values");
 		return asin(genType(1) / x);
@@ -85,7 +85,7 @@ namespace glm
 
 	// acot
 	template <typename genType>
-	GLM_FUNC_QUALIFIER genType acot(genType x)
+	GLM_FUNC_QUALIFIER genType acot(genType const & x)
 	{
 		GLM_STATIC_ASSERT(std::numeric_limits<genType>::is_iec559, "'acot' only accept floating-point values");
 
@@ -102,7 +102,7 @@ namespace glm
 
 	// sech
 	template <typename genType>
-	GLM_FUNC_QUALIFIER genType sech(genType angle)
+	GLM_FUNC_QUALIFIER genType sech(genType const & angle)
 	{
 		GLM_STATIC_ASSERT(std::numeric_limits<genType>::is_iec559, "'sech' only accept floating-point values");
 		return genType(1) / glm::cosh(angle);
@@ -117,7 +117,7 @@ namespace glm
 
 	// csch
 	template <typename genType>
-	GLM_FUNC_QUALIFIER genType csch(genType angle)
+	GLM_FUNC_QUALIFIER genType csch(genType const & angle)
 	{
 		GLM_STATIC_ASSERT(std::numeric_limits<genType>::is_iec559, "'csch' only accept floating-point values");
 		return genType(1) / glm::sinh(angle);
@@ -132,7 +132,7 @@ namespace glm
 
 	// coth
 	template <typename genType>
-	GLM_FUNC_QUALIFIER genType coth(genType angle)
+	GLM_FUNC_QUALIFIER genType coth(genType const & angle)
 	{
 		GLM_STATIC_ASSERT(std::numeric_limits<genType>::is_iec559, "'coth' only accept floating-point values");
 		return glm::cosh(angle) / glm::sinh(angle);
@@ -147,7 +147,7 @@ namespace glm
 
 	// asech
 	template <typename genType>
-	GLM_FUNC_QUALIFIER genType asech(genType x)
+	GLM_FUNC_QUALIFIER genType asech(genType const & x)
 	{
 		GLM_STATIC_ASSERT(std::numeric_limits<genType>::is_iec559, "'asech' only accept floating-point values");
 		return acosh(genType(1) / x);
@@ -162,7 +162,7 @@ namespace glm
 
 	// acsch
 	template <typename genType>
-	GLM_FUNC_QUALIFIER genType acsch(genType x)
+	GLM_FUNC_QUALIFIER genType acsch(genType const & x)
 	{
 		GLM_STATIC_ASSERT(std::numeric_limits<genType>::is_iec559, "'acsch' only accept floating-point values");
 		return acsch(genType(1) / x);
@@ -177,7 +177,7 @@ namespace glm
 
 	// acoth
 	template <typename genType>
-	GLM_FUNC_QUALIFIER genType acoth(genType x)
+	GLM_FUNC_QUALIFIER genType acoth(genType const & x)
 	{
 		GLM_STATIC_ASSERT(std::numeric_limits<genType>::is_iec559, "'acoth' only accept floating-point values");
 		return atanh(genType(1) / x);


### PR DESCRIPTION
This fixes #348, it's the same as cd78ac6 but that commit didn't seem to end up on any branch that I can find.