### PR TITLE
Fix #ifdef (had old name)

### DIFF
--- a/glm/detail/type_vec4.hpp
+++ b/glm/detail/type_vec4.hpp
@@ -5,7 +5,7 @@
 
 #include "type_vec.hpp"
 #ifdef GLM_SWIZZLE
-#	if GLM_HAS_ANONYMOUS_UNION
+#	if GLM_HAS_UNRESTRICTED_UNIONS
 #		include "_swizzle.hpp"
 #	else
 #		include "_swizzle_func.hpp"


### PR DESCRIPTION
Without this change, the build breaks with the following file:
```cpp
// main.cpp

#define GLM_SWIZZLE
#include "glm/vec4.hpp"

int main(int, char* []) {
    return 0;
}
```

```cpp
± g++ --std=c++11 main.cpp
In file included from glm/vec4.hpp:6:0,
                 from main.cpp:4:
glm/detail/type_vec4.hpp:49:33: error: ‘P’ is not a type
      _GLM_SWIZZLE4_2_MEMBERS(T, P, glm::tvec2, x, y, z, w)
                                 ^
glm/detail/type_vec4.hpp:49:41: error: ‘glm::tvec2’ is not a type
      _GLM_SWIZZLE4_2_MEMBERS(T, P, glm::tvec2, x, y, z, w)
                                         ^
glm/detail/type_vec4.hpp:49:48: error: ‘x’ is not a type
      _GLM_SWIZZLE4_2_MEMBERS(T, P, glm::tvec2, x, y, z, w)
                                                ^
glm/detail/type_vec4.hpp:49:51: error: ‘y’ is not a type
      _GLM_SWIZZLE4_2_MEMBERS(T, P, glm::tvec2, x, y, z, w)
                                                   ^
glm/detail/type_vec4.hpp:49:54: error: ‘z’ is not a type
      _GLM_SWIZZLE4_2_MEMBERS(T, P, glm::tvec2, x, y, z, w)
                                                      ^
glm/detail/type_vec4.hpp:49:57: error: ‘w’ is not a type
      _GLM_SWIZZLE4_2_MEMBERS(T, P, glm::tvec2, x, y, z, w)
                                                         ^
glm/detail/type_vec4.hpp:49:58: error: ISO C++ forbids declaration of ‘_GLM_SWIZZLE4_2_MEMBERS’ with no type [-fpermissive]
      _GLM_SWIZZLE4_2_MEMBERS(T, P, glm::tvec2, x, y, z, w)
                                                          ^
glm/detail/type_vec4.hpp:49:58: error: expected ‘;’ at end of member declaration
glm/detail/type_vec4.hpp:50:33: error: ‘P’ is not a type
      _GLM_SWIZZLE4_2_MEMBERS(T, P, glm::tvec2, r, g, b, a)
                                 ^
glm/detail/type_vec4.hpp:50:41: error: ‘glm::tvec2’ is not a type
      _GLM_SWIZZLE4_2_MEMBERS(T, P, glm::tvec2, r, g, b, a)
                                         ^
glm/detail/type_vec4.hpp:50:48: error: ‘r’ is not a type
      _GLM_SWIZZLE4_2_MEMBERS(T, P, glm::tvec2, r, g, b, a)
                                                ^
glm/detail/type_vec4.hpp:50:51: error: ‘g’ is not a type
      _GLM_SWIZZLE4_2_MEMBERS(T, P, glm::tvec2, r, g, b, a)
                                                   ^
glm/detail/type_vec4.hpp:50:54: error: ‘b’ is not a type
      _GLM_SWIZZLE4_2_MEMBERS(T, P, glm::tvec2, r, g, b, a)
                                                      ^
glm/detail/type_vec4.hpp:50:57: error: ‘a’ is not a type
      _GLM_SWIZZLE4_2_MEMBERS(T, P, glm::tvec2, r, g, b, a)
                                                         ^
glm/detail/type_vec4.hpp:50:58: error: ISO C++ forbids declaration of ‘_GLM_SWIZZLE4_2_MEMBERS’ with no type [-fpermissive]
      _GLM_SWIZZLE4_2_MEMBERS(T, P, glm::tvec2, r, g, b, a)
                                                          ^
glm/detail/type_vec4.hpp:50:58: error: expected ‘;’ at end of member declaration
glm/detail/type_vec4.hpp:50:6: error: ‘int glm::tvec4<T, P>::<anonymous union>::_GLM_SWIZZLE4_2_MEMBERS(T, int, int, int, int, int, int)’ cannot be overloaded
      _GLM_SWIZZLE4_2_MEMBERS(T, P, glm::tvec2, r, g, b, a)
      ^
glm/detail/type_vec4.hpp:49:6: error: with ‘int glm::tvec4<T, P>::<anonymous union>::_GLM_SWIZZLE4_2_MEMBERS(T, int, int, int, int, int, int)’
      _GLM_SWIZZLE4_2_MEMBERS(T, P, glm::tvec2, x, y, z, w)
      ^
glm/detail/type_vec4.hpp:51:33: error: ‘P’ is not a type
      _GLM_SWIZZLE4_2_MEMBERS(T, P, glm::tvec2, s, t, p, q)
                                 ^
glm/detail/type_vec4.hpp:51:41: error: ‘glm::tvec2’ is not a type
      _GLM_SWIZZLE4_2_MEMBERS(T, P, glm::tvec2, s, t, p, q)
                                         ^
glm/detail/type_vec4.hpp:51:48: error: ‘s’ is not a type
      _GLM_SWIZZLE4_2_MEMBERS(T, P, glm::tvec2, s, t, p, q)
                                                ^
glm/detail/type_vec4.hpp:51:51: error: ‘t’ is not a type
      _GLM_SWIZZLE4_2_MEMBERS(T, P, glm::tvec2, s, t, p, q)
                 from main.cpp:4:
glm/detail/type_vec4_simd.inl: At global scope:
glm/detail/type_vec4_simd.inl:11:9: error: ‘_swizzle_base1’ is not a class template
  struct _swizzle_base1<4, float, P, glm::tvec4, E0,E1,E2,E3, true> : public _swizzle_base0<float, 4>
         ^
glm/detail/type_vec4_simd.inl:11:91: error: expected template-name before ‘<’ token
  struct _swizzle_base1<4, float, P, glm::tvec4, E0,E1,E2,E3, true> : public _swizzle_base0<float, 4>
                                                                                           ^
glm/detail/type_vec4_simd.inl:11:91: error: expected ‘{’ before ‘<’ token
glm/detail/type_vec4_simd.inl:11:91: error: expected unqualified-id before ‘<’ token
glm/detail/type_vec4_simd.inl:28:66: error: wrong number of template arguments (9, should be 5)
  struct _swizzle_base1<4, int32, P, glm::tvec4, E0,E1,E2,E3, true> : public _swizzle_base0<int32, 4>
                                                                  ^
glm/detail/type_vec4_simd.inl:11:66: note: provided for ‘template<glm::precision P, int E0, int E1, int E2, int E3> struct glm::detail::_swizzle_base1’
  struct _swizzle_base1<4, float, P, glm::tvec4, E0,E1,E2,E3, true> : public _swizzle_base0<float, 4>
                                                                  ^
glm/detail/type_vec4_simd.inl:28:91: error: expected template-name before ‘<’ token
  struct _swizzle_base1<4, int32, P, glm::tvec4, E0,E1,E2,E3, true> : public _swizzle_base0<int32, 4>
                                                                                           ^
glm/detail/type_vec4_simd.inl:41:67: error: wrong number of template arguments (9, should be 5)
  struct _swizzle_base1<4, uint32, P, glm::tvec4, E0,E1,E2,E3, true> : public _swizzle_base0<uint32, 4>
                                                                   ^
glm/detail/type_vec4_simd.inl:11:66: note: provided for ‘template<glm::precision P, int E0, int E1, int E2, int E3> struct glm::detail::_swizzle_base1’
  struct _swizzle_base1<4, float, P, glm::tvec4, E0,E1,E2,E3, true> : public _swizzle_base0<float, 4>
                                                                  ^
glm/detail/type_vec4_simd.inl:41:92: error: expected template-name before ‘<’ token
  struct _swizzle_base1<4, uint32, P, glm::tvec4, E0,E1,E2,E3, true> : public _swizzle_base0<uint32, 4>
                                                                                            ^
```