### PR TITLE
Change -pedantic to -Wpedantic

### DIFF
--- a/glm/detail/type_vec1.hpp
+++ b/glm/detail/type_vec1.hpp
@@ -30,7 +30,7 @@ namespace glm
 #		if GLM_HAS_ALIGNED_TYPE
 #			if GLM_COMPILER & GLM_COMPILER_GCC
 #				pragma GCC diagnostic push
-#				pragma GCC diagnostic ignored "-pedantic"
+#				pragma GCC diagnostic ignored "-Wpedantic"
 #			endif
 #			if GLM_COMPILER & GLM_COMPILER_CLANG
 #				pragma clang diagnostic push

--- a/glm/detail/type_vec2.hpp
+++ b/glm/detail/type_vec2.hpp
@@ -29,7 +29,7 @@ namespace glm
 #		if GLM_HAS_ALIGNED_TYPE
 #			if GLM_COMPILER & GLM_COMPILER_GCC
 #				pragma GCC diagnostic push
-#				pragma GCC diagnostic ignored "-pedantic"
+#				pragma GCC diagnostic ignored "-Wpedantic"
 #			endif
 #			if GLM_COMPILER & GLM_COMPILER_CLANG
 #				pragma clang diagnostic push

--- a/glm/detail/type_vec3.hpp
+++ b/glm/detail/type_vec3.hpp
@@ -29,7 +29,7 @@ namespace glm
 #		if GLM_HAS_ALIGNED_TYPE
 #			if GLM_COMPILER & GLM_COMPILER_GCC
 #				pragma GCC diagnostic push
-#				pragma GCC diagnostic ignored "-pedantic"
+#				pragma GCC diagnostic ignored "-Wpedantic"
 #			endif
 #			if GLM_COMPILER & GLM_COMPILER_CLANG
 #				pragma clang diagnostic push

--- a/glm/detail/type_vec4.hpp
+++ b/glm/detail/type_vec4.hpp
@@ -29,7 +29,7 @@ namespace glm
 #		if GLM_HAS_ALIGNED_TYPE
 #			if GLM_COMPILER & GLM_COMPILER_GCC
 #				pragma GCC diagnostic push
-#				pragma GCC diagnostic ignored "-pedantic"
+#				pragma GCC diagnostic ignored "-Wpedantic"
 #			endif
 #			if GLM_COMPILER & GLM_COMPILER_CLANG
 #				pragma clang diagnostic push

--- a/glm/gtc/quaternion.hpp
+++ b/glm/gtc/quaternion.hpp
@@ -43,7 +43,7 @@ namespace glm
 #		if GLM_HAS_ALIGNED_TYPE
 #			if GLM_COMPILER & GLM_COMPILER_GCC
 #				pragma GCC diagnostic push
-#				pragma GCC diagnostic ignored "-pedantic"
+#				pragma GCC diagnostic ignored "-Wpedantic"
 #			endif
 #			if GLM_COMPILER & GLM_COMPILER_CLANG
 #				pragma clang diagnostic push


### PR DESCRIPTION
I recently tried compiling GLM with GCC 6, and got almost 20 000 warnings with `-pedantic`.

Apparently, GCC 6 prefers `-Wpedantic` over `-pedantic`, even though they should be aliases (it's being very pedantic).

It even gives a warning for the `#pragma` which tries to ignore `-pedantic`, saying it doesn't recognize it as an option for controlling warnings:
```cpp
../thirdparty/glm/gtc/../detail/type_vec3.hpp:33:36: warning: ‘-pedantic’ is not an option that controls warnings [-Wpragmas]
 #    pragma GCC diagnostic ignored "-pedantic"
                                    ^~~~~~~~~~~
```

Changing these lines from `-pedantic` to `-Wpedantic` fixes this for GCC 6, and works the same as before with GCC 5 (and other compilers should ignore GCC pragmas).