### PR TITLE
Fix 32-bit builds with GCC

### DIFF
--- a/glm/detail/func_common.inl
+++ b/glm/detail/func_common.inl
@@ -188,20 +188,6 @@ namespace detail
 		}
 	};
 
-#	if GLM_ARCH == GLM_ARCH_X86
-	template <typename T, precision P, template <typename, precision> class vecType, bool Aligned>
-	struct compute_sign<T, P, vecType, Aligned>
-	{
-		GLM_FUNC_QUALIFIER static vecType<T, P> call(vecType<T, P> const & x)
-		{
-			T const Shift(static_cast<T>(sizeof(T) * 8 - 1));
-			vecType<T, P> const y(vecType<typename make_unsigned<T>::type, P>(-x) >> typename make_unsigned<T>::type(Shift));
-
-			return (x >> Shift) | y;
-		}
-	};
-#	endif
-
 	template <typename T, precision P, template <typename, precision> class vecType, bool Aligned>
 	struct compute_floor
 	{


### PR DESCRIPTION
Close #528.

GCC fails to compile a 32-bit build with the error:
```
../thirdparty/glm/detail/../detail/func_common.inl:193:44: error: wrong number of template arguments (4, should be 5)
  struct compute_sign<T, P, vecType, Aligned>
                                            ^
../thirdparty/glm/detail/../detail/func_common.inl:183:9: note: provided for 'template<class T, glm::precision P, template<class, glm::precision <anonymous> > class vecType, bool isFloat, bool Aligned> struct glm::detail::compute_sign'
  struct compute_sign
         ^~~~~~~~~~~~
```

I'm not sure if removing the problematic code section is the correct fix (or if doing so breaks something), **please review before merging**.