### PR TITLE
Convert integers to type T in quaternion mat3_cast()

### DIFF
--- a/glm/gtc/quaternion.inl
+++ b/glm/gtc/quaternion.inl
@@ -603,17 +603,17 @@ namespace detail
 		T qwy(q.w * q.y);
 		T qwz(q.w * q.z);
 
-		Result[0][0] = 1 - 2 * (qyy +  qzz);
-		Result[0][1] = 2 * (qxy + qwz);
-		Result[0][2] = 2 * (qxz - qwy);
+		Result[0][0] = T(1) - T(2) * (qyy +  qzz);
+		Result[0][1] = T(2) * (qxy + qwz);
+		Result[0][2] = T(2) * (qxz - qwy);
 
-		Result[1][0] = 2 * (qxy - qwz);
-		Result[1][1] = 1 - 2 * (qxx +  qzz);
-		Result[1][2] = 2 * (qyz + qwx);
+		Result[1][0] = T(2) * (qxy - qwz);
+		Result[1][1] = T(1) - T(2) * (qxx +  qzz);
+		Result[1][2] = T(2) * (qyz + qwx);
 
-		Result[2][0] = 2 * (qxz + qwy);
-		Result[2][1] = 2 * (qyz - qwx);
-		Result[2][2] = 1 - 2 * (qxx +  qyy);
+		Result[2][0] = T(2) * (qxz + qwy);
+		Result[2][1] = T(2) * (qyz - qwx);
+		Result[2][2] = T(1) - T(2) * (qxx +  qyy);
 		return Result;
 	}
 


### PR DESCRIPTION
This fixes issues when `int` is not explicitly convertible to type `T`, and for example only has an `operator*` defined that takes two Ts but not a T and an int.

All the other functions in that file already use this syntax, so the missing ones here are most likely an oversight.