### PR TITLE
Fixed bug on the faceforward function.

### DIFF
--- a/glm/detail/func_geometric_simd.inl
+++ b/glm/detail/func_geometric_simd.inl
@@ -67,7 +67,7 @@ namespace detail
 		GLM_FUNC_QUALIFIER static tvec4<float, P> call(tvec4<float, P> const& N, tvec4<float, P> const& I, tvec4<float, P> const& Nref)
 		{
 			tvec4<float, P> result(uninitialize);
-			result.data = glm_vec4_faceforward(N.data. I.data, Nref.data);
+			result.data = glm_vec4_faceforward(N.data, I.data, Nref.data);
 			return result;
 		}
 	};


### PR DESCRIPTION
Fixes the Clang warnings reported on Linux and C++ 11. Also, I suppose this is what the original programmer meant to write.