### PR TITLE
Fixed missing conversion to T

### DIFF
--- a/glm/gtc/matrix_transform.inl
+++ b/glm/gtc/matrix_transform.inl
@@ -168,7 +168,7 @@ namespace glm
 		T bottom, T top
 	)
 	{
-		tmat4x4<T, defaultp> Result(T(1));
+		tmat4x4<T, defaultp> Result(static_cast<T>(1));
 		Result[0][0] = static_cast<T>(2) / (right - left);
 		Result[1][1] = static_cast<T>(2) / (top - bottom);
 		Result[2][2] = - static_cast<T>(1);

--- a/glm/gtc/matrix_transform.inl
+++ b/glm/gtc/matrix_transform.inl
@@ -168,7 +168,7 @@ namespace glm
 		T bottom, T top
 	)
 	{
-		tmat4x4<T, defaultp> Result(1);
+		tmat4x4<T, defaultp> Result(T(1));
 		Result[0][0] = static_cast<T>(2) / (right - left);
 		Result[1][1] = static_cast<T>(2) / (top - bottom);
 		Result[2][2] = - static_cast<T>(1);


### PR DESCRIPTION
This makes `ortho` work with `GLM_FORCE_UNRESTRICTED_GENTYPE`.