### PR TITLE
Properly set cuda compiler version

### DIFF
--- a/glm/simd/platform.h
+++ b/glm/simd/platform.h
@@ -146,8 +146,12 @@
 #	endif
 #	if CUDA_VERSION < 7000
 #		error "GLM requires CUDA 7.0 or higher"
-#	else
-#		define GLM_COMPILER GLM_COMPILER_CUDA
+#	elif (CUDA_VERSION >= 7000 && CUDA_VERSION < 7500)
+#		define GLM_COMPILER GLM_COMPILER_CUDA70
+#	elif (CUDA_VERSION >= 7500 && CUDA_VERSION < 8000)
+#		define GLM_COMPILER GLM_COMPILER_CUDA75
+#	elif (CUDA_VERSION >= 8000)
+#		define GLM_COMPILER GLM_COMPILER_CUDA80
 #	endif
 
 // Clang


### PR DESCRIPTION
While compiling using nvcc, the `CUDA_VERSION` was always set to `GLM_COMPILER_CUDA` instead of versioned ones like `GLM_COMPILER_CUDA75`. 

As a result, many compiler features was not enabled even they should be and `GLM_LANG` is not correct. This caused some problems while linking object files built from gcc and nvcc. Here's an example: https://gist.github.com/blahgeek/d6118aeb9c667a449ee1561cd3038a76 (#612 may be also related to this)
