### PR TITLE
request to add version info to include, package install, and project …

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,8 +4,12 @@ if (NOT CMAKE_VERSION VERSION_LESS "3.1")
 	cmake_policy(SET CMP0054 NEW)
 endif()
 
-project(glm)
 set(GLM_VERSION "0.9.9")
+
+# On windows sets default install directory to C:\Program Files\glm-<version>
+set(GLM_PACKAGE_NAME glm-${GLM_VERSION})
+project(${GLM_PACKAGE_NAME})
+
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
@@ -171,9 +175,10 @@ include_directories("${PROJECT_SOURCE_DIR}/test/external")
 add_subdirectory(glm)
 add_subdirectory(test)
 
-set(GLM_INSTALL_CONFIGDIR "${CMAKE_INSTALL_LIBDIR}/cmake/glm")
+set(GLM_INSTALL_CONFIGDIR "${CMAKE_INSTALL_LIBDIR}/cmake/${GLM_PACKAGE_NAME}")
 if (GLM_INSTALL_ENABLE)
-	install(DIRECTORY glm DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+    # Now include dir will have glm version info allowing multiple installs in same install path
+	install(DIRECTORY glm DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${GLM_PACKAGE_NAME})
 endif()
 
 write_basic_package_version_file("${CMAKE_CURRENT_BINARY_DIR}/glmConfigVersion.cmake" VERSION ${GLM_VERSION} COMPATIBILITY AnyNewerVersion)


### PR DESCRIPTION
Requesting to

    add version info to project name

set(GLM_VERSION "0.9.9")

set(GLM_PACKAGE_NAME glm-${GLM_VERSION})
project(${GLM_PACKAGE_NAME})

thus by default:

CMAKE_INSTALL_PREFIX C:/Program Files/glm-0.9.9

using cmake-gui. This way multiple versions installed on windows using defaults won't blast each other away.

    add version info to glm include directory again allowing multiple installs to not blast each other away in installed to same CMAKE_INSTALL_PREFIX

3> -- Installing: C:/projects/glm/install/include/glm-0.9.9/glm
3> -- Installing: C:/projects/glm/install/include/glm-0.9.9/glm/CMakeLists.txt
3> -- Installing: C:/projects/glm/install/include/glm-0.9.9/glm/common.hpp
3> -- Installing: C:/projects/glm/install/include/glm-0.9.9/glm/detail

Not sure why CMakeLists.txt and others are installing here... I did not make any attempt to fix this... just added version info to include directory. Might want to add some FILES_MATCHING, PATTERN or EXCLUDE bits to install to filter out the cruft.

    add version info to package install lib/cmake/glm now lib/cmake/glm-
    3> -- Up-to-date: C:/projects/glm/install/lib/cmake/glm-0.9.9/glmConfig.cmake
    3> -- Up-to-date: C:/projects/glm/install/lib/cmake/glm-0.9.9/glmConfigVersion.cmake
    3> -- Up-to-date: C:/projects/glm/install/lib/cmake/glm-0.9.9/glmTargets.cmake

There might be theme starting to develop right about now.