### PR TITLE
Fix potential infinite loop in float_distance().

### DIFF
--- a/glm/gtc/ulp.inl
+++ b/glm/gtc/ulp.inl
@@ -287,7 +287,7 @@ namespace glm
 		if(x < y)
 		{
 			T temp = x;
-			while(temp != y)// && ulp < std::numeric_limits<std::size_t>::max())
+			while(temp < y)// && ulp < std::numeric_limits<std::size_t>::max())
 			{
 				++ulp;
 				temp = next_float(temp);
@@ -296,7 +296,7 @@ namespace glm
 		else if(y < x)
 		{
 			T temp = y;
-			while(temp != x)// && ulp < std::numeric_limits<std::size_t>::max())
+			while(temp < x)// && ulp < std::numeric_limits<std::size_t>::max())
 			{
 				++ulp;
 				temp = next_float(temp);


### PR DESCRIPTION
On Debian stretch on the i686 architecture, the test suite was hanging at `core_func_exponential`. After some investigation, it turns out that the cause was the while loops in `float_distance()`. On Intel processors, the FPU has a higher precision than the IEEE float formats, and depending on whether the compiler keeps the variables x and y in registers all the time or spills them onto the stack, the test can pass or hang. I fixed it by turning the `!=` comparison into a `<` one.