### PR TITLE
Avoid problems if countof() is already defined as a macro.

### DIFF
--- a/glm/detail/setup.hpp
+++ b/glm/detail/setup.hpp
@@ -765,12 +765,12 @@ namespace glm
 	namespace glm
 	{
 		template<typename T, std::size_t N>
-		constexpr std::size_t countof(T const (&)[N])
+		constexpr std::size_t _countof(T const (&)[N])
 		{
 			return N;
 		}
 	}//namespace glm
-#	define GLM_COUNTOF(arr) glm::countof(arr)
+#	define GLM_COUNTOF(arr) glm::_countof(arr)
 #elif defined(_MSC_VER)
 #	define GLM_COUNTOF(arr) _countof(arr)
 #else


### PR DESCRIPTION
If a file that includes glm/detail/setup.hpp already has countof() defined as a macro, there will be trouble.  Side-step this issue by renaming GLM's internal countof() implementation.