### PR TITLE
Use correct precision for detail::compute_inversesqrt in glm::fastInverseSqrt

### DIFF
--- a/glm/gtx/fast_square_root.inl
+++ b/glm/gtx/fast_square_root.inl
@@ -26,7 +26,7 @@ namespace glm
 			vec<1, T, P> tmp(detail::compute_inversesqrt<tvec1, genType, lowp, detail::is_aligned<lowp>::value>::call(vec<1, genType, lowp>(x)));
 			return tmp.x;
 #		else
-			return detail::compute_inversesqrt<1, genType, highp, detail::is_aligned<highp>::value>::call(vec<1, genType, lowp>(x)).x;
+			return detail::compute_inversesqrt<1, genType, lowp, detail::is_aligned<lowp>::value>::call(vec<1, genType, lowp>(x)).x;
 #		endif
 	}
 


### PR DESCRIPTION
I noticed when profiling my code that `glm::fastLength`'s usage of `glm::fastInverseSqrt` pulls in the generic `detail::compute_inversesqrt`, which just calls out to `sqrtf()`. This was the case regardless of the precision of the vectors involved.

This change resolves that, by ensuring for usage with type `float` that the optimized `detail::compute_inversesqrt` specialization is used. With this change, no call is made to `sqrtf()` when calling `glm::fastInverseSqrt`.

I also noticed that the version under `ifdef __CUDACC__` already seemed to use `lowp` so this also brings the two cases closer together in terms of implementation.