### PR TITLE
Fixed stray ')' that was breaking gtx/matrix_interpolation.

### DIFF
--- a/glm/gtx/matrix_interpolation.inl
+++ b/glm/gtx/matrix_interpolation.inl
@@ -75,7 +75,7 @@ namespace glm
 		if (glm::abs(s) < T(0.001))
 			s = (T)1.0;
 		T const angleCos = (mat[0][0] + mat[1][1] + mat[2][2] - (T)1.0) * (T)0.5;
-		if (angleCos - static_cast<T>(1)) < epsilon)
+		if (angleCos - static_cast<T>(1) < epsilon)
 			angle = pi<T>() * static_cast<T>(0.25);
 		else
 			angle = acos(angleCos);


### PR DESCRIPTION
Removed a stray parenthesis that had sneaked in and broken `gtx/matrix_interpolation`.