### PR TITLE
inherit from vec<>

### DIFF
--- a/glm/detail/func_common.hpp
+++ b/glm/detail/func_common.hpp
@@ -27,7 +27,7 @@ namespace glm
 	/// @see <a href="http://www.opengl.org/sdk/docs/manglsl/xhtml/abs.xml">GLSL abs man page</a>
 	/// @see <a href="http://www.opengl.org/registry/doc/GLSLangSpec.4.20.8.pdf">GLSL 4.20.8 specification, section 8.3 Common Functions</a>
 	template<typename genType>
-	GLM_FUNC_DECL genType abs(genType x);
+	GLM_FUNC_DECL GLM_ONLY_SCALAR(genType) abs(genType x);
 
 	template<length_t L, typename T, precision P, template<length_t, typename, precision> class vecType>
 	GLM_FUNC_DECL vecType<L, T, P> abs(vecType<L, T, P> const & x);
@@ -102,7 +102,7 @@ namespace glm
 	/// @see <a href="http://www.opengl.org/sdk/docs/manglsl/xhtml/fract.xml">GLSL fract man page</a>
 	/// @see <a href="http://www.opengl.org/registry/doc/GLSLangSpec.4.20.8.pdf">GLSL 4.20.8 specification, section 8.3 Common Functions</a>
 	template<typename genType>
-	GLM_FUNC_DECL genType fract(genType x);
+	GLM_FUNC_DECL GLM_ONLY_SCALAR(genType) fract(genType x);
 
 	template<length_t L, typename T, precision P, template<length_t, typename, precision> class vecType>
 	GLM_FUNC_DECL vecType<L, T, P> fract(vecType<L, T, P> const & x);
@@ -115,7 +115,7 @@ namespace glm
 	/// @see <a href="http://www.opengl.org/sdk/docs/manglsl/xhtml/mod.xml">GLSL mod man page</a>
 	/// @see <a href="http://www.opengl.org/registry/doc/GLSLangSpec.4.20.8.pdf">GLSL 4.20.8 specification, section 8.3 Common Functions</a>
 	template<typename genType>
-	GLM_FUNC_DECL genType mod(genType x, genType y);
+	GLM_FUNC_DECL GLM_ONLY_SCALAR(genType) mod(genType x, genType y);
 
 	template<length_t L, typename T, precision P, template<length_t, typename, precision> class vecType>
 	GLM_FUNC_DECL vecType<L, T, P> mod(vecType<L, T, P> const & x, T y);
@@ -133,7 +133,7 @@ namespace glm
 	/// @see <a href="http://www.opengl.org/sdk/docs/manglsl/xhtml/modf.xml">GLSL modf man page</a>
 	/// @see <a href="http://www.opengl.org/registry/doc/GLSLangSpec.4.20.8.pdf">GLSL 4.20.8 specification, section 8.3 Common Functions</a>
 	template<typename genType>
-	GLM_FUNC_DECL genType modf(genType x, genType & i);
+	GLM_FUNC_DECL GLM_ONLY_SCALAR(genType) modf(genType x, genType & i);
 
 	/// Returns y if y < x; otherwise, it returns x.
 	///
@@ -142,7 +142,7 @@ namespace glm
 	/// @see <a href="http://www.opengl.org/sdk/docs/manglsl/xhtml/min.xml">GLSL min man page</a>
 	/// @see <a href="http://www.opengl.org/registry/doc/GLSLangSpec.4.20.8.pdf">GLSL 4.20.8 specification, section 8.3 Common Functions</a>
 	template<typename genType>
-	GLM_FUNC_DECL genType min(genType x, genType y);
+	GLM_FUNC_DECL GLM_ONLY_SCALAR(genType) min(genType x, genType y);
 
 	template<length_t L, typename T, precision P, template<length_t, typename, precision> class vecType>
 	GLM_FUNC_DECL vecType<L, T, P> min(vecType<L, T, P> const & x, T y);
@@ -157,7 +157,7 @@ namespace glm
 	/// @see <a href="http://www.opengl.org/sdk/docs/manglsl/xhtml/max.xml">GLSL max man page</a>
 	/// @see <a href="http://www.opengl.org/registry/doc/GLSLangSpec.4.20.8.pdf">GLSL 4.20.8 specification, section 8.3 Common Functions</a>
 	template<typename genType>
-	GLM_FUNC_DECL genType max(genType x, genType y);
+	GLM_FUNC_DECL GLM_ONLY_SCALAR(genType) max(genType x, genType y);
 
 	template<length_t L, typename T, precision P, template<length_t, typename, precision> class vecType>
 	GLM_FUNC_DECL vecType<L, T, P> max(vecType<L, T, P> const & x, T y);
@@ -173,7 +173,7 @@ namespace glm
 	/// @see <a href="http://www.opengl.org/sdk/docs/manglsl/xhtml/clamp.xml">GLSL clamp man page</a>
 	/// @see <a href="http://www.opengl.org/registry/doc/GLSLangSpec.4.20.8.pdf">GLSL 4.20.8 specification, section 8.3 Common Functions</a>
 	template<typename genType>
-	GLM_FUNC_DECL genType clamp(genType x, genType minVal, genType maxVal);
+	GLM_FUNC_DECL GLM_ONLY_SCALAR(genType) clamp(genType x, genType minVal, genType maxVal);
 
 	template<length_t L, typename T, precision P, template<length_t, typename, precision> class vecType>
 	GLM_FUNC_DECL vecType<L, T, P> clamp(vecType<L, T, P> const & x, T minVal, T maxVal);
@@ -230,14 +230,14 @@ namespace glm
 	GLM_FUNC_DECL vecType<L, T, P> mix(vecType<L, T, P> const & x, vecType<L, T, P> const & y, U a);
 
 	template<typename genTypeT, typename genTypeU>
-	GLM_FUNC_DECL genTypeT mix(genTypeT x, genTypeT y, genTypeU a);
+	GLM_FUNC_DECL GLM_ONLY_SCALAR(genTypeT) mix(genTypeT x, genTypeT y, genTypeU a);
 
 	/// Returns 0.0 if x < edge, otherwise it returns 1.0 for each component of a genType.
 	/// 
 	/// @see <a href="http://www.opengl.org/sdk/docs/manglsl/xhtml/step.xml">GLSL step man page</a>
 	/// @see <a href="http://www.opengl.org/registry/doc/GLSLangSpec.4.20.8.pdf">GLSL 4.20.8 specification, section 8.3 Common Functions</a>
 	template<typename genType>
-	GLM_FUNC_DECL genType step(genType edge, genType x);
+	GLM_FUNC_DECL GLM_ONLY_SCALAR(genType) step(genType edge, genType x);
 
 	/// Returns 0.0 if x < edge, otherwise it returns 1.0.
 	/// 
@@ -268,7 +268,7 @@ namespace glm
 	/// @see <a href="http://www.opengl.org/sdk/docs/manglsl/xhtml/smoothstep.xml">GLSL smoothstep man page</a>
 	/// @see <a href="http://www.opengl.org/registry/doc/GLSLangSpec.4.20.8.pdf">GLSL 4.20.8 specification, section 8.3 Common Functions</a>
 	template<typename genType>
-	GLM_FUNC_DECL genType smoothstep(genType edge0, genType edge1, genType x);
+	GLM_FUNC_DECL GLM_ONLY_SCALAR(genType) smoothstep(genType edge0, genType edge1, genType x);
 
 	template<length_t L, typename T, precision P, template<length_t, typename, precision> class vecType>
 	GLM_FUNC_DECL vecType<L, T, P> smoothstep(T edge0, T edge1, vecType<L, T, P> const & x);
@@ -387,7 +387,7 @@ namespace glm
 	/// @see <a href="http://www.opengl.org/sdk/docs/manglsl/xhtml/fma.xml">GLSL fma man page</a>
 	/// @see <a href="http://www.opengl.org/registry/doc/GLSLangSpec.4.20.8.pdf">GLSL 4.20.8 specification, section 8.3 Common Functions</a>
 	template<typename genType>
-	GLM_FUNC_DECL genType fma(genType const & a, genType const & b, genType const & c);
+	GLM_FUNC_DECL GLM_ONLY_SCALAR(genType) fma(genType const & a, genType const & b, genType const & c);
 
 	/// Splits x into a floating-point significand in the range
 	/// [0.5, 1.0) and an integral exponent of two, such that:
@@ -404,7 +404,7 @@ namespace glm
 	/// @see <a href="http://www.opengl.org/sdk/docs/manglsl/xhtml/frexp.xml">GLSL frexp man page</a>
 	/// @see <a href="http://www.opengl.org/registry/doc/GLSLangSpec.4.20.8.pdf">GLSL 4.20.8 specification, section 8.3 Common Functions</a>
 	template<typename genType, typename genIType>
-	GLM_FUNC_DECL genType frexp(genType const & x, genIType & exp);
+	GLM_FUNC_DECL GLM_ONLY_SCALAR(genType) frexp(genType const & x, genIType & exp);
 
 	/// Builds a floating-point number from x and the
 	/// corresponding integral exponent of two in exp, returning:
@@ -418,7 +418,7 @@ namespace glm
 	/// @see <a href="http://www.opengl.org/sdk/docs/manglsl/xhtml/ldexp.xml">GLSL ldexp man page</a>; 
 	/// @see <a href="http://www.opengl.org/registry/doc/GLSLangSpec.4.20.8.pdf">GLSL 4.20.8 specification, section 8.3 Common Functions</a>
 	template<typename genType, typename genIType>
-	GLM_FUNC_DECL genType ldexp(genType const & x, genIType const & exp);
+	GLM_FUNC_DECL GLM_ONLY_SCALAR(genType) ldexp(genType const & x, genIType const & exp);
 
 	/// @}
 }//namespace glm

--- a/glm/detail/func_common.inl
+++ b/glm/detail/func_common.inl
@@ -12,7 +12,7 @@ namespace glm
 {
 	// min
 	template<typename genType>
-	GLM_FUNC_QUALIFIER genType min(genType x, genType y)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR(genType) min(genType x, genType y)
 	{
 		GLM_STATIC_ASSERT(std::numeric_limits<genType>::is_iec559 || std::numeric_limits<genType>::is_integer || GLM_UNRESTRICTED_GENTYPE, "'min' only accept floating-point or integer inputs");
 		return x < y ? x : y;
@@ -20,7 +20,7 @@ namespace glm
 
 	// max
 	template<typename genType>
-	GLM_FUNC_QUALIFIER genType max(genType x, genType y)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR(genType) max(genType x, genType y)
 	{
 		GLM_STATIC_ASSERT(std::numeric_limits<genType>::is_iec559 || std::numeric_limits<genType>::is_integer || GLM_UNRESTRICTED_GENTYPE, "'max' only accept floating-point or integer inputs");
 
@@ -40,7 +40,7 @@ namespace glm
 		using ::std::round;
 #	else
 		template<typename genType>
-		GLM_FUNC_QUALIFIER genType round(genType x)
+		GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR(genType) round(genType x)
 		{
 			GLM_STATIC_ASSERT(std::numeric_limits<genType>::is_iec559, "'round' only accept floating-point inputs");
 
@@ -53,7 +53,7 @@ namespace glm
 		using ::std::trunc;
 #	else
 		template<typename genType>
-		GLM_FUNC_QUALIFIER genType trunc(genType x)
+		GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR(genType) trunc(genType x)
 		{
 			GLM_STATIC_ASSERT(std::numeric_limits<genType>::is_iec559, "'trunc' only accept floating-point inputs");
 
@@ -306,7 +306,7 @@ namespace detail
 }//namespace detail
 
 	template<typename genFIType>
-	GLM_FUNC_QUALIFIER genFIType abs(genFIType x)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR(genFIType) abs(genFIType x)
 	{
 		return detail::compute_abs<genFIType, std::numeric_limits<genFIType>::is_signed>::call(x);
 	}
@@ -320,7 +320,7 @@ namespace detail
 	// sign
 	// fast and works for any type
 	template<typename genFIType> 
-	GLM_FUNC_QUALIFIER genFIType sign(genFIType x)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR(genFIType) sign(genFIType x)
 	{
 		GLM_STATIC_ASSERT(
 			std::numeric_limits<genFIType>::is_iec559 || (std::numeric_limits<genFIType>::is_signed && std::numeric_limits<genFIType>::is_integer),
@@ -365,7 +365,7 @@ namespace detail
 /*
 	// roundEven
 	template<typename genType>
-	GLM_FUNC_QUALIFIER genType roundEven(genType const& x)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR(genType) roundEven(genType const& x)
 	{
 		GLM_STATIC_ASSERT(std::numeric_limits<genType>::is_iec559, "'roundEven' only accept floating-point inputs");
 
@@ -375,7 +375,7 @@ namespace detail
 
 	// roundEven
 	template<typename genType>
-	GLM_FUNC_QUALIFIER genType roundEven(genType x)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR(genType) roundEven(genType x)
 	{
 		GLM_STATIC_ASSERT(std::numeric_limits<genType>::is_iec559, "'roundEven' only accept floating-point inputs");
 		
@@ -423,7 +423,7 @@ namespace detail
 
 	// fract
 	template<typename genType>
-	GLM_FUNC_QUALIFIER genType fract(genType x)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR(genType) fract(genType x)
 	{
 		return fract(vec<1, genType>(x)).x;
 	}
@@ -437,7 +437,7 @@ namespace detail
 
 	// mod
 	template<typename genType>
-	GLM_FUNC_QUALIFIER genType mod(genType x, genType y)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR(genType) mod(genType x, genType y)
 	{
 #		if GLM_COMPILER & GLM_COMPILER_CUDA
 			// Another Cuda compiler bug https://github.com/g-truc/glm/issues/530
@@ -462,7 +462,7 @@ namespace detail
 
 	// modf
 	template<typename genType>
-	GLM_FUNC_QUALIFIER genType modf(genType x, genType & i)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR(genType) modf(genType x, genType & i)
 	{
 		GLM_STATIC_ASSERT(std::numeric_limits<genType>::is_iec559, "'modf' only accept floating-point inputs");
 		return std::modf(x, &i);
@@ -540,7 +540,7 @@ namespace detail
 
 	// clamp
 	template<typename genType>
-	GLM_FUNC_QUALIFIER genType clamp(genType x, genType minVal, genType maxVal)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR(genType) clamp(genType x, genType minVal, genType maxVal)
 	{
 		GLM_STATIC_ASSERT(std::numeric_limits<genType>::is_iec559 || std::numeric_limits<genType>::is_integer || GLM_UNRESTRICTED_GENTYPE, "'clamp' only accept floating-point or integer inputs");
 		return min(max(x, minVal), maxVal);
@@ -561,7 +561,7 @@ namespace detail
 	}
 
 	template<typename genTypeT, typename genTypeU>
-	GLM_FUNC_QUALIFIER genTypeT mix(genTypeT x, genTypeT y, genTypeU a)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR(genTypeT) mix(genTypeT x, genTypeT y, genTypeU a)
 	{
 		return detail::compute_mix<genTypeT, genTypeU>::call(x, y, a);
 	}
@@ -580,7 +580,7 @@ namespace detail
 
 	// step
 	template<typename genType>
-	GLM_FUNC_QUALIFIER genType step(genType edge, genType x)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR(genType) step(genType edge, genType x)
 	{
 		return mix(static_cast<genType>(1), static_cast<genType>(0), glm::lessThan(x, edge));
 	}
@@ -599,7 +599,7 @@ namespace detail
 
 	// smoothstep
 	template<typename genType>
-	GLM_FUNC_QUALIFIER genType smoothstep(genType edge0, genType edge1, genType x)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR(genType) smoothstep(genType edge0, genType edge1, genType x)
 	{
 		GLM_STATIC_ASSERT(std::numeric_limits<genType>::is_iec559 || GLM_UNRESTRICTED_GENTYPE, "'smoothstep' only accept floating-point inputs");
 
@@ -739,13 +739,13 @@ namespace detail
 	}
 	
 	template<typename genType>
-	GLM_FUNC_QUALIFIER genType fma(genType const & a, genType const & b, genType const & c)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR(genType) fma(genType const & a, genType const & b, genType const & c)
 	{
 		return a * b + c;
 	}
 
 	template<typename genType>
-	GLM_FUNC_QUALIFIER genType frexp(genType x, int & exp)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR(genType) frexp(genType x, int & exp)
 	{
 		GLM_STATIC_ASSERT(std::numeric_limits<genType>::is_iec559 || GLM_UNRESTRICTED_GENTYPE, "'frexp' only accept floating-point inputs");
 
@@ -794,7 +794,7 @@ namespace detail
 	}
 
 	template<typename genType>
-	GLM_FUNC_QUALIFIER genType ldexp(genType const & x, int const & exp)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR(genType) ldexp(genType const & x, int const & exp)
 	{
 		GLM_STATIC_ASSERT(std::numeric_limits<genType>::is_iec559 || GLM_UNRESTRICTED_GENTYPE, "'ldexp' only accept floating-point inputs");
 

--- a/glm/detail/func_geometric.inl
+++ b/glm/detail/func_geometric.inl
@@ -129,7 +129,7 @@ namespace detail
 
 	// length
 	template<typename genType>
-	GLM_FUNC_QUALIFIER genType length(genType x)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR(genType) length(genType x)
 	{
 		GLM_STATIC_ASSERT(std::numeric_limits<genType>::is_iec559, "'length' accepts only floating-point inputs");
 
@@ -146,7 +146,7 @@ namespace detail
 
 	// distance
 	template<typename genType>
-	GLM_FUNC_QUALIFIER genType distance(genType const & p0, genType const & p1)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR(genType) distance(genType const & p0, genType const & p1)
 	{
 		GLM_STATIC_ASSERT(std::numeric_limits<genType>::is_iec559, "'distance' accepts only floating-point inputs");
 
@@ -161,7 +161,7 @@ namespace detail
 
 	// dot
 	template<typename T>
-	GLM_FUNC_QUALIFIER T dot(T x, T y)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR(T) dot(T x, T y)
 	{
 		GLM_STATIC_ASSERT(std::numeric_limits<T>::is_iec559, "'dot' accepts only floating-point inputs");
 		return x * y;
@@ -190,7 +190,7 @@ namespace detail
 
 	// normalize
 	template<typename genType>
-	GLM_FUNC_QUALIFIER genType normalize(genType const & x)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR(genType) normalize(genType const & x)
 	{
 		GLM_STATIC_ASSERT(std::numeric_limits<genType>::is_iec559, "'normalize' accepts only floating-point inputs");
 
@@ -207,7 +207,7 @@ namespace detail
 
 	// faceforward
 	template<typename genType>
-	GLM_FUNC_QUALIFIER genType faceforward(genType const & N, genType const & I, genType const & Nref)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR(genType) faceforward(genType const & N, genType const & I, genType const & Nref)
 	{
 		return dot(Nref, I) < static_cast<genType>(0) ? N : -N;
 	}
@@ -220,7 +220,7 @@ namespace detail
 
 	// reflect
 	template<typename genType>
-	GLM_FUNC_QUALIFIER genType reflect(genType const & I, genType const & N)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR(genType) reflect(genType const & I, genType const & N)
 	{
 		return I - N * dot(N, I) * genType(2);
 	}
@@ -233,7 +233,7 @@ namespace detail
 
 	// refract
 	template<typename genType>
-	GLM_FUNC_QUALIFIER genType refract(genType const & I, genType const & N, genType eta)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR(genType) refract(genType const & I, genType const & N, genType eta)
 	{
 		GLM_STATIC_ASSERT(std::numeric_limits<genType>::is_iec559, "'refract' accepts only floating-point inputs");
 		genType const dotValue(dot(N, I));

--- a/glm/detail/type_vec1.hpp
+++ b/glm/detail/type_vec1.hpp
@@ -128,19 +128,19 @@ namespace glm
 		template<typename U>
 		GLM_FUNC_DECL vec & operator=(vec<1, U, P> const& v);
 		template<typename U>
-		GLM_FUNC_DECL vec & operator+=(U scalar);
+		GLM_FUNC_DECL GLM_ONLY_SCALAR2(vec, 1, T, P, U)  operator+=(U scalar);
 		template<typename U>
 		GLM_FUNC_DECL vec & operator+=(vec<1, U, P> const& v);
 		template<typename U>
-		GLM_FUNC_DECL vec & operator-=(U scalar);
+		GLM_FUNC_DECL GLM_ONLY_SCALAR2(vec, 1, T, P, U)  operator-=(U scalar);
 		template<typename U>
 		GLM_FUNC_DECL vec & operator-=(vec<1, U, P> const& v);
 		template<typename U>
-		GLM_FUNC_DECL vec & operator*=(U scalar);
+		GLM_FUNC_DECL GLM_ONLY_SCALAR2(vec, 1, T, P, U)  operator*=(U scalar);
 		template<typename U>
 		GLM_FUNC_DECL vec & operator*=(vec<1, U, P> const& v);
 		template<typename U>
-		GLM_FUNC_DECL vec & operator/=(U scalar);
+		GLM_FUNC_DECL GLM_ONLY_SCALAR2(vec, 1, T, P, U)  operator/=(U scalar);
 		template<typename U>
 		GLM_FUNC_DECL vec & operator/=(vec<1, U, P> const& v);
 
@@ -154,27 +154,27 @@ namespace glm
 		// -- Unary bit operators --
 
 		template<typename U>
-		GLM_FUNC_DECL vec & operator%=(U scalar);
+		GLM_FUNC_DECL GLM_ONLY_SCALAR2(vec, 1, T, P, U)  operator%=(U scalar);
 		template<typename U>
 		GLM_FUNC_DECL vec & operator%=(vec<1, U, P> const& v);
 		template<typename U>
-		GLM_FUNC_DECL vec & operator&=(U scalar);
+		GLM_FUNC_DECL GLM_ONLY_SCALAR2(vec, 1, T, P, U)  operator&=(U scalar);
 		template<typename U>
 		GLM_FUNC_DECL vec & operator&=(vec<1, U, P> const& v);
 		template<typename U>
-		GLM_FUNC_DECL vec & operator|=(U scalar);
+		GLM_FUNC_DECL GLM_ONLY_SCALAR2(vec, 1, T, P, U)  operator|=(U scalar);
 		template<typename U>
 		GLM_FUNC_DECL vec & operator|=(vec<1, U, P> const& v);
 		template<typename U>
-		GLM_FUNC_DECL vec & operator^=(U scalar);
+		GLM_FUNC_DECL GLM_ONLY_SCALAR2(vec, 1, T, P, U)  operator^=(U scalar);
 		template<typename U>
 		GLM_FUNC_DECL vec & operator^=(vec<1, U, P> const& v);
 		template<typename U>
-		GLM_FUNC_DECL vec & operator<<=(U scalar);
+		GLM_FUNC_DECL GLM_ONLY_SCALAR2(vec, 1, T, P, U)  operator<<=(U scalar);
 		template<typename U>
 		GLM_FUNC_DECL vec & operator<<=(vec<1, U, P> const& v);
 		template<typename U>
-		GLM_FUNC_DECL vec & operator>>=(U scalar);
+		GLM_FUNC_DECL GLM_ONLY_SCALAR2(vec, 1, T, P, U)  operator>>=(U scalar);
 		template<typename U>
 		GLM_FUNC_DECL vec & operator>>=(vec<1, U, P> const& v);
 	};

--- a/glm/detail/type_vec1.hpp
+++ b/glm/detail/type_vec1.hpp
@@ -128,19 +128,19 @@ namespace glm
 		template<typename U>
 		GLM_FUNC_DECL vec & operator=(vec<1, U, P> const& v);
 		template<typename U>
-		GLM_FUNC_DECL GLM_ONLY_SCALAR2(vec, 1, T, P, U)  operator+=(U scalar);
+		GLM_FUNC_DECL_ONLY_SCALAR(U)  operator+=(U scalar);
 		template<typename U>
 		GLM_FUNC_DECL vec & operator+=(vec<1, U, P> const& v);
 		template<typename U>
-		GLM_FUNC_DECL GLM_ONLY_SCALAR2(vec, 1, T, P, U)  operator-=(U scalar);
+		GLM_FUNC_DECL_ONLY_SCALAR(U)  operator-=(U scalar);
 		template<typename U>
 		GLM_FUNC_DECL vec & operator-=(vec<1, U, P> const& v);
 		template<typename U>
-		GLM_FUNC_DECL GLM_ONLY_SCALAR2(vec, 1, T, P, U)  operator*=(U scalar);
+		GLM_FUNC_DECL_ONLY_SCALAR(U)  operator*=(U scalar);
 		template<typename U>
 		GLM_FUNC_DECL vec & operator*=(vec<1, U, P> const& v);
 		template<typename U>
-		GLM_FUNC_DECL GLM_ONLY_SCALAR2(vec, 1, T, P, U)  operator/=(U scalar);
+		GLM_FUNC_DECL_ONLY_SCALAR(U)  operator/=(U scalar);
 		template<typename U>
 		GLM_FUNC_DECL vec & operator/=(vec<1, U, P> const& v);
 
@@ -154,27 +154,27 @@ namespace glm
 		// -- Unary bit operators --
 
 		template<typename U>
-		GLM_FUNC_DECL GLM_ONLY_SCALAR2(vec, 1, T, P, U)  operator%=(U scalar);
+		GLM_FUNC_DECL_ONLY_SCALAR(U)  operator%=(U scalar);
 		template<typename U>
 		GLM_FUNC_DECL vec & operator%=(vec<1, U, P> const& v);
 		template<typename U>
-		GLM_FUNC_DECL GLM_ONLY_SCALAR2(vec, 1, T, P, U)  operator&=(U scalar);
+		GLM_FUNC_DECL_ONLY_SCALAR(U)  operator&=(U scalar);
 		template<typename U>
 		GLM_FUNC_DECL vec & operator&=(vec<1, U, P> const& v);
 		template<typename U>
-		GLM_FUNC_DECL GLM_ONLY_SCALAR2(vec, 1, T, P, U)  operator|=(U scalar);
+		GLM_FUNC_DECL_ONLY_SCALAR(U)  operator|=(U scalar);
 		template<typename U>
 		GLM_FUNC_DECL vec & operator|=(vec<1, U, P> const& v);
 		template<typename U>
-		GLM_FUNC_DECL GLM_ONLY_SCALAR2(vec, 1, T, P, U)  operator^=(U scalar);
+		GLM_FUNC_DECL_ONLY_SCALAR(U)  operator^=(U scalar);
 		template<typename U>
 		GLM_FUNC_DECL vec & operator^=(vec<1, U, P> const& v);
 		template<typename U>
-		GLM_FUNC_DECL GLM_ONLY_SCALAR2(vec, 1, T, P, U)  operator<<=(U scalar);
+		GLM_FUNC_DECL_ONLY_SCALAR(U)  operator<<=(U scalar);
 		template<typename U>
 		GLM_FUNC_DECL vec & operator<<=(vec<1, U, P> const& v);
 		template<typename U>
-		GLM_FUNC_DECL GLM_ONLY_SCALAR2(vec, 1, T, P, U)  operator>>=(U scalar);
+		GLM_FUNC_DECL_ONLY_SCALAR(U)  operator>>=(U scalar);
 		template<typename U>
 		GLM_FUNC_DECL vec & operator>>=(vec<1, U, P> const& v);
 	};

--- a/glm/detail/type_vec1.inl
+++ b/glm/detail/type_vec1.inl
@@ -101,7 +101,7 @@ namespace glm
 
 	template<typename T, precision P>
 	template<typename U> 
-	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 1, T, P, U)  tvec1<T, P>::operator+=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 1, T, P, U)  vec<1, T, P>::operator+=(U scalar)
 	{
 		this->x += static_cast<T>(scalar);
 		return *this;
@@ -117,7 +117,7 @@ namespace glm
 
 	template<typename T, precision P>
 	template<typename U> 
-	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 1, T, P, U)  tvec1<T, P>::operator-=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 1, T, P, U)  vec<1, T, P>::operator-=(U scalar)
 	{
 		this->x -= static_cast<T>(scalar);
 		return *this;
@@ -133,7 +133,7 @@ namespace glm
 
 	template<typename T, precision P>
 	template<typename U> 
-	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 1, T, P, U)  tvec1<T, P>::operator*=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 1, T, P, U)  vec<1, T, P>::operator*=(U scalar)
 	{
 		this->x *= static_cast<T>(scalar);
 		return *this;
@@ -149,7 +149,7 @@ namespace glm
 
 	template<typename T, precision P>
 	template<typename U> 
-	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 1, T, P, U)  tvec1<T, P>::operator/=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 1, T, P, U)  vec<1, T, P>::operator/=(U scalar)
 	{
 		this->x /= static_cast<T>(scalar);
 		return *this;
@@ -199,7 +199,7 @@ namespace glm
 
 	template<typename T, precision P>
 	template<typename U> 
-	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 1, T, P, U)  tvec1<T, P>::operator%=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 1, T, P, U)  vec<1, T, P>::operator%=(U scalar)
 	{
 		this->x %= static_cast<T>(scalar);
 		return *this;
@@ -215,7 +215,7 @@ namespace glm
 
 	template<typename T, precision P>
 	template<typename U> 
-	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 1, T, P, U)  tvec1<T, P>::operator&=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 1, T, P, U)  vec<1, T, P>::operator&=(U scalar)
 	{
 		this->x &= static_cast<T>(scalar);
 		return *this;
@@ -231,7 +231,7 @@ namespace glm
 
 	template<typename T, precision P>
 	template<typename U> 
-	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 1, T, P, U)  tvec1<T, P>::operator|=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 1, T, P, U)  vec<1, T, P>::operator|=(U scalar)
 	{
 		this->x |= static_cast<T>(scalar);
 		return *this;
@@ -247,7 +247,7 @@ namespace glm
 
 	template<typename T, precision P>
 	template<typename U> 
-	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 1, T, P, U)  tvec1<T, P>::operator^=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 1, T, P, U)  vec<1, T, P>::operator^=(U scalar)
 	{
 		this->x ^= static_cast<T>(scalar);
 		return *this;
@@ -263,7 +263,7 @@ namespace glm
 
 	template<typename T, precision P>
 	template<typename U> 
-	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 1, T, P, U)  tvec1<T, P>::operator<<=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 1, T, P, U)  vec<1, T, P>::operator<<=(U scalar)
 	{
 		this->x <<= static_cast<T>(scalar);
 		return *this;
@@ -271,7 +271,7 @@ namespace glm
 
 	template<typename T, precision P>
 	template<typename U> 
-	GLM_FUNC_QUALIFIER tvec1<T, P> & tvec1<T, P>::operator<<=(tvec1<U, P> const & v)
+	GLM_FUNC_QUALIFIER vec<1, T, P> & vec<1, T, P>::operator<<=(vec<1, U, P> const & v)
 	{
 		this->x <<= static_cast<T>(v.x);
 		return *this;
@@ -279,7 +279,7 @@ namespace glm
 
 	template<typename T, precision P>
 	template<typename U> 
-	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 1, T, P, U)  tvec1<T, P>::operator>>=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 1, T, P, U)  vec<1, T, P>::operator>>=(U scalar)
 	{
 		this->x >>= static_cast<T>(scalar);
 		return *this;

--- a/glm/detail/type_vec1.inl
+++ b/glm/detail/type_vec1.inl
@@ -101,7 +101,7 @@ namespace glm
 
 	template<typename T, precision P>
 	template<typename U> 
-	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(tvec1,T, P, U)  tvec1<T, P>::operator+=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 1, T, P, U)  tvec1<T, P>::operator+=(U scalar)
 	{
 		this->x += static_cast<T>(scalar);
 		return *this;
@@ -117,7 +117,7 @@ namespace glm
 
 	template<typename T, precision P>
 	template<typename U> 
-	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(tvec1,T, P, U)  tvec1<T, P>::operator-=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 1, T, P, U)  tvec1<T, P>::operator-=(U scalar)
 	{
 		this->x -= static_cast<T>(scalar);
 		return *this;
@@ -133,7 +133,7 @@ namespace glm
 
 	template<typename T, precision P>
 	template<typename U> 
-	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(tvec1,T, P, U)  tvec1<T, P>::operator*=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 1, T, P, U)  tvec1<T, P>::operator*=(U scalar)
 	{
 		this->x *= static_cast<T>(scalar);
 		return *this;
@@ -149,7 +149,7 @@ namespace glm
 
 	template<typename T, precision P>
 	template<typename U> 
-	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(tvec1,T, P, U)  tvec1<T, P>::operator/=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 1, T, P, U)  tvec1<T, P>::operator/=(U scalar)
 	{
 		this->x /= static_cast<T>(scalar);
 		return *this;
@@ -199,7 +199,7 @@ namespace glm
 
 	template<typename T, precision P>
 	template<typename U> 
-	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(tvec1,T, P, U)  tvec1<T, P>::operator%=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 1, T, P, U)  tvec1<T, P>::operator%=(U scalar)
 	{
 		this->x %= static_cast<T>(scalar);
 		return *this;
@@ -215,7 +215,7 @@ namespace glm
 
 	template<typename T, precision P>
 	template<typename U> 
-	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(tvec1,T, P, U)  tvec1<T, P>::operator&=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 1, T, P, U)  tvec1<T, P>::operator&=(U scalar)
 	{
 		this->x &= static_cast<T>(scalar);
 		return *this;
@@ -231,7 +231,7 @@ namespace glm
 
 	template<typename T, precision P>
 	template<typename U> 
-	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(tvec1,T, P, U)  tvec1<T, P>::operator|=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 1, T, P, U)  tvec1<T, P>::operator|=(U scalar)
 	{
 		this->x |= static_cast<T>(scalar);
 		return *this;
@@ -247,7 +247,7 @@ namespace glm
 
 	template<typename T, precision P>
 	template<typename U> 
-	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(tvec1,T, P, U)  tvec1<T, P>::operator^=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 1, T, P, U)  tvec1<T, P>::operator^=(U scalar)
 	{
 		this->x ^= static_cast<T>(scalar);
 		return *this;
@@ -263,7 +263,7 @@ namespace glm
 
 	template<typename T, precision P>
 	template<typename U> 
-	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(tvec1,T, P, U)  tvec1<T, P>::operator<<=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 1, T, P, U)  tvec1<T, P>::operator<<=(U scalar)
 	{
 		this->x <<= static_cast<T>(scalar);
 		return *this;
@@ -279,7 +279,7 @@ namespace glm
 
 	template<typename T, precision P>
 	template<typename U> 
-	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(tvec1,T, P, U)  tvec1<T, P>::operator>>=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 1, T, P, U)  tvec1<T, P>::operator>>=(U scalar)
 	{
 		this->x >>= static_cast<T>(scalar);
 		return *this;

--- a/glm/detail/type_vec1.inl
+++ b/glm/detail/type_vec1.inl
@@ -101,7 +101,7 @@ namespace glm
 
 	template<typename T, precision P>
 	template<typename U> 
-	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 1, T, P, U)  vec<1, T, P>::operator+=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR_VEC(vec, 1, T, P, U)  vec<1, T, P>::operator+=(U scalar)
 	{
 		this->x += static_cast<T>(scalar);
 		return *this;
@@ -117,7 +117,7 @@ namespace glm
 
 	template<typename T, precision P>
 	template<typename U> 
-	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 1, T, P, U)  vec<1, T, P>::operator-=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR_VEC(vec, 1, T, P, U)  vec<1, T, P>::operator-=(U scalar)
 	{
 		this->x -= static_cast<T>(scalar);
 		return *this;
@@ -133,7 +133,7 @@ namespace glm
 
 	template<typename T, precision P>
 	template<typename U> 
-	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 1, T, P, U)  vec<1, T, P>::operator*=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR_VEC(vec, 1, T, P, U)  vec<1, T, P>::operator*=(U scalar)
 	{
 		this->x *= static_cast<T>(scalar);
 		return *this;
@@ -149,7 +149,7 @@ namespace glm
 
 	template<typename T, precision P>
 	template<typename U> 
-	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 1, T, P, U)  vec<1, T, P>::operator/=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR_VEC(vec, 1, T, P, U)  vec<1, T, P>::operator/=(U scalar)
 	{
 		this->x /= static_cast<T>(scalar);
 		return *this;
@@ -199,7 +199,7 @@ namespace glm
 
 	template<typename T, precision P>
 	template<typename U> 
-	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 1, T, P, U)  vec<1, T, P>::operator%=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR_VEC(vec, 1, T, P, U)  vec<1, T, P>::operator%=(U scalar)
 	{
 		this->x %= static_cast<T>(scalar);
 		return *this;
@@ -215,7 +215,7 @@ namespace glm
 
 	template<typename T, precision P>
 	template<typename U> 
-	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 1, T, P, U)  vec<1, T, P>::operator&=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR_VEC(vec, 1, T, P, U)  vec<1, T, P>::operator&=(U scalar)
 	{
 		this->x &= static_cast<T>(scalar);
 		return *this;
@@ -231,7 +231,7 @@ namespace glm
 
 	template<typename T, precision P>
 	template<typename U> 
-	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 1, T, P, U)  vec<1, T, P>::operator|=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR_VEC(vec, 1, T, P, U)  vec<1, T, P>::operator|=(U scalar)
 	{
 		this->x |= static_cast<T>(scalar);
 		return *this;
@@ -247,7 +247,7 @@ namespace glm
 
 	template<typename T, precision P>
 	template<typename U> 
-	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 1, T, P, U)  vec<1, T, P>::operator^=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR_VEC(vec, 1, T, P, U)  vec<1, T, P>::operator^=(U scalar)
 	{
 		this->x ^= static_cast<T>(scalar);
 		return *this;
@@ -263,7 +263,7 @@ namespace glm
 
 	template<typename T, precision P>
 	template<typename U> 
-	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 1, T, P, U)  vec<1, T, P>::operator<<=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR_VEC(vec, 1, T, P, U)  vec<1, T, P>::operator<<=(U scalar)
 	{
 		this->x <<= static_cast<T>(scalar);
 		return *this;
@@ -279,7 +279,7 @@ namespace glm
 
 	template<typename T, precision P>
 	template<typename U> 
-	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 1, T, P, U)  vec<1, T, P>::operator>>=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR_VEC(vec, 1, T, P, U)  vec<1, T, P>::operator>>=(U scalar)
 	{
 		this->x >>= static_cast<T>(scalar);
 		return *this;

--- a/glm/detail/type_vec1.inl
+++ b/glm/detail/type_vec1.inl
@@ -101,7 +101,7 @@ namespace glm
 
 	template<typename T, precision P>
 	template<typename U> 
-	GLM_FUNC_QUALIFIER vec<1, T, P> & vec<1, T, P>::operator+=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(tvec1,T, P, U)  tvec1<T, P>::operator+=(U scalar)
 	{
 		this->x += static_cast<T>(scalar);
 		return *this;
@@ -117,7 +117,7 @@ namespace glm
 
 	template<typename T, precision P>
 	template<typename U> 
-	GLM_FUNC_QUALIFIER vec<1, T, P> & vec<1, T, P>::operator-=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(tvec1,T, P, U)  tvec1<T, P>::operator-=(U scalar)
 	{
 		this->x -= static_cast<T>(scalar);
 		return *this;
@@ -133,7 +133,7 @@ namespace glm
 
 	template<typename T, precision P>
 	template<typename U> 
-	GLM_FUNC_QUALIFIER vec<1, T, P> & vec<1, T, P>::operator*=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(tvec1,T, P, U)  tvec1<T, P>::operator*=(U scalar)
 	{
 		this->x *= static_cast<T>(scalar);
 		return *this;
@@ -149,7 +149,7 @@ namespace glm
 
 	template<typename T, precision P>
 	template<typename U> 
-	GLM_FUNC_QUALIFIER vec<1, T, P> & vec<1, T, P>::operator/=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(tvec1,T, P, U)  tvec1<T, P>::operator/=(U scalar)
 	{
 		this->x /= static_cast<T>(scalar);
 		return *this;
@@ -199,7 +199,7 @@ namespace glm
 
 	template<typename T, precision P>
 	template<typename U> 
-	GLM_FUNC_QUALIFIER vec<1, T, P> & vec<1, T, P>::operator%=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(tvec1,T, P, U)  tvec1<T, P>::operator%=(U scalar)
 	{
 		this->x %= static_cast<T>(scalar);
 		return *this;
@@ -215,7 +215,7 @@ namespace glm
 
 	template<typename T, precision P>
 	template<typename U> 
-	GLM_FUNC_QUALIFIER vec<1, T, P> & vec<1, T, P>::operator&=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(tvec1,T, P, U)  tvec1<T, P>::operator&=(U scalar)
 	{
 		this->x &= static_cast<T>(scalar);
 		return *this;
@@ -231,7 +231,7 @@ namespace glm
 
 	template<typename T, precision P>
 	template<typename U> 
-	GLM_FUNC_QUALIFIER vec<1, T, P> & vec<1, T, P>::operator|=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(tvec1,T, P, U)  tvec1<T, P>::operator|=(U scalar)
 	{
 		this->x |= static_cast<T>(scalar);
 		return *this;
@@ -247,7 +247,7 @@ namespace glm
 
 	template<typename T, precision P>
 	template<typename U> 
-	GLM_FUNC_QUALIFIER vec<1, T, P> & vec<1, T, P>::operator^=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(tvec1,T, P, U)  tvec1<T, P>::operator^=(U scalar)
 	{
 		this->x ^= static_cast<T>(scalar);
 		return *this;
@@ -263,7 +263,7 @@ namespace glm
 
 	template<typename T, precision P>
 	template<typename U> 
-	GLM_FUNC_QUALIFIER vec<1, T, P> & vec<1, T, P>::operator<<=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(tvec1,T, P, U)  tvec1<T, P>::operator<<=(U scalar)
 	{
 		this->x <<= static_cast<T>(scalar);
 		return *this;
@@ -271,7 +271,7 @@ namespace glm
 
 	template<typename T, precision P>
 	template<typename U> 
-	GLM_FUNC_QUALIFIER vec<1, T, P> & vec<1, T, P>::operator<<=(vec<1, U, P> const & v)
+	GLM_FUNC_QUALIFIER tvec1<T, P> & tvec1<T, P>::operator<<=(tvec1<U, P> const & v)
 	{
 		this->x <<= static_cast<T>(v.x);
 		return *this;
@@ -279,7 +279,7 @@ namespace glm
 
 	template<typename T, precision P>
 	template<typename U> 
-	GLM_FUNC_QUALIFIER vec<1, T, P> & vec<1, T, P>::operator>>=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(tvec1,T, P, U)  tvec1<T, P>::operator>>=(U scalar)
 	{
 		this->x >>= static_cast<T>(scalar);
 		return *this;

--- a/glm/detail/type_vec2.hpp
+++ b/glm/detail/type_vec2.hpp
@@ -134,25 +134,25 @@ namespace glm
 		template<typename U>
 		GLM_FUNC_DECL vec& operator=(vec<2, U, P> const& v);
 		template<typename U>
-		GLM_FUNC_DECL GLM_ONLY_SCALAR2(vec, 2, T, P, U)  operator+=(U scalar);
+		GLM_FUNC_DECL_ONLY_SCALAR(U)  operator+=(U scalar);
 		template<typename U>
 		GLM_FUNC_DECL vec& operator+=(vec<1, U, P> const& v);
 		template<typename U>
 		GLM_FUNC_DECL vec& operator+=(vec<2, U, P> const& v);
 		template<typename U>
-		GLM_FUNC_DECL GLM_ONLY_SCALAR2(vec, 2, T, P, U)  operator-=(U scalar);
+		GLM_FUNC_DECL_ONLY_SCALAR(U)  operator-=(U scalar);
 		template<typename U>
 		GLM_FUNC_DECL vec& operator-=(vec<1, U, P> const& v);
 		template<typename U>
 		GLM_FUNC_DECL vec& operator-=(vec<2, U, P> const& v);
 		template<typename U>
-		GLM_FUNC_DECL GLM_ONLY_SCALAR2(vec, 2, T, P, U)  operator*=(U scalar);
+		GLM_FUNC_DECL_ONLY_SCALAR(U)  operator*=(U scalar);
 		template<typename U>
 		GLM_FUNC_DECL vec& operator*=(vec<1, U, P> const& v);
 		template<typename U>
 		GLM_FUNC_DECL vec& operator*=(vec<2, U, P> const& v);
 		template<typename U>
-		GLM_FUNC_DECL GLM_ONLY_SCALAR2(vec, 2, T, P, U)  operator/=(U scalar);
+		GLM_FUNC_DECL_ONLY_SCALAR(U)  operator/=(U scalar);
 		template<typename U>
 		GLM_FUNC_DECL vec& operator/=(vec<1, U, P> const& v);
 		template<typename U>
@@ -168,37 +168,37 @@ namespace glm
 		// -- Unary bit operators --
 
 		template<typename U> 
-		GLM_FUNC_DECL GLM_ONLY_SCALAR2(vec, 2, T, P, U)  operator%=(U scalar);
+		GLM_FUNC_DECL_ONLY_SCALAR(U)  operator%=(U scalar);
 		template<typename U> 
 		GLM_FUNC_DECL vec & operator%=(vec<1, U, P> const & v);
 		template<typename U> 
 		GLM_FUNC_DECL vec & operator%=(vec<2, U, P> const & v);
 		template<typename U> 
-		GLM_FUNC_DECL GLM_ONLY_SCALAR2(vec, 2, T, P, U)  operator&=(U scalar);
+		GLM_FUNC_DECL_ONLY_SCALAR(U)  operator&=(U scalar);
 		template<typename U> 
 		GLM_FUNC_DECL vec & operator&=(vec<1, U, P> const & v);
 		template<typename U> 
 		GLM_FUNC_DECL vec & operator&=(vec<2, U, P> const & v);
 		template<typename U> 
-		GLM_FUNC_DECL GLM_ONLY_SCALAR2(vec, 2, T, P, U)  operator|=(U scalar);
+		GLM_FUNC_DECL_ONLY_SCALAR(U)  operator|=(U scalar);
 		template<typename U> 
 		GLM_FUNC_DECL vec & operator|=(vec<1, U, P> const & v);
 		template<typename U> 
 		GLM_FUNC_DECL vec & operator|=(vec<2, U, P> const & v);
 		template<typename U> 
-		GLM_FUNC_DECL GLM_ONLY_SCALAR2(vec, 2, T, P, U)  operator^=(U scalar);
+		GLM_FUNC_DECL_ONLY_SCALAR(U)  operator^=(U scalar);
 		template<typename U> 
 		GLM_FUNC_DECL vec & operator^=(vec<1, U, P> const & v);
 		template<typename U> 
 		GLM_FUNC_DECL vec & operator^=(vec<2, U, P> const & v);
 		template<typename U> 
-		GLM_FUNC_DECL GLM_ONLY_SCALAR2(vec, 2, T, P, U)  operator<<=(U scalar);
+		GLM_FUNC_DECL_ONLY_SCALAR(U)  operator<<=(U scalar);
 		template<typename U> 
 		GLM_FUNC_DECL vec & operator<<=(vec<1, U, P> const & v);
 		template<typename U> 
 		GLM_FUNC_DECL vec & operator<<=(vec<2, U, P> const & v);
 		template<typename U> 
-		GLM_FUNC_DECL GLM_ONLY_SCALAR2(vec, 2, T, P, U)  operator>>=(U scalar);
+		GLM_FUNC_DECL_ONLY_SCALAR(U)  operator>>=(U scalar);
 		template<typename U> 
 		GLM_FUNC_DECL vec & operator>>=(vec<1, U, P> const & v);
 		template<typename U> 

--- a/glm/detail/type_vec2.hpp
+++ b/glm/detail/type_vec2.hpp
@@ -134,25 +134,25 @@ namespace glm
 		template<typename U>
 		GLM_FUNC_DECL vec& operator=(vec<2, U, P> const& v);
 		template<typename U>
-		GLM_FUNC_DECL vec& operator+=(U scalar);
+		GLM_FUNC_DECL GLM_ONLY_SCALAR2(vec, 2, T, P, U)  operator+=(U scalar);
 		template<typename U>
 		GLM_FUNC_DECL vec& operator+=(vec<1, U, P> const& v);
 		template<typename U>
 		GLM_FUNC_DECL vec& operator+=(vec<2, U, P> const& v);
 		template<typename U>
-		GLM_FUNC_DECL vec& operator-=(U scalar);
+		GLM_FUNC_DECL GLM_ONLY_SCALAR2(vec, 2, T, P, U)  operator-=(U scalar);
 		template<typename U>
 		GLM_FUNC_DECL vec& operator-=(vec<1, U, P> const& v);
 		template<typename U>
 		GLM_FUNC_DECL vec& operator-=(vec<2, U, P> const& v);
 		template<typename U>
-		GLM_FUNC_DECL vec& operator*=(U scalar);
+		GLM_FUNC_DECL GLM_ONLY_SCALAR2(vec, 2, T, P, U)  operator*=(U scalar);
 		template<typename U>
 		GLM_FUNC_DECL vec& operator*=(vec<1, U, P> const& v);
 		template<typename U>
 		GLM_FUNC_DECL vec& operator*=(vec<2, U, P> const& v);
 		template<typename U>
-		GLM_FUNC_DECL vec& operator/=(U scalar);
+		GLM_FUNC_DECL GLM_ONLY_SCALAR2(vec, 2, T, P, U)  operator/=(U scalar);
 		template<typename U>
 		GLM_FUNC_DECL vec& operator/=(vec<1, U, P> const& v);
 		template<typename U>
@@ -168,37 +168,37 @@ namespace glm
 		// -- Unary bit operators --
 
 		template<typename U> 
-		GLM_FUNC_DECL vec & operator%=(U scalar);
+		GLM_FUNC_DECL GLM_ONLY_SCALAR2(vec, 2, T, P, U)  operator%=(U scalar);
 		template<typename U> 
 		GLM_FUNC_DECL vec & operator%=(vec<1, U, P> const & v);
 		template<typename U> 
 		GLM_FUNC_DECL vec & operator%=(vec<2, U, P> const & v);
 		template<typename U> 
-		GLM_FUNC_DECL vec & operator&=(U scalar);
+		GLM_FUNC_DECL GLM_ONLY_SCALAR2(vec, 2, T, P, U)  operator&=(U scalar);
 		template<typename U> 
 		GLM_FUNC_DECL vec & operator&=(vec<1, U, P> const & v);
 		template<typename U> 
 		GLM_FUNC_DECL vec & operator&=(vec<2, U, P> const & v);
 		template<typename U> 
-		GLM_FUNC_DECL vec & operator|=(U scalar);
+		GLM_FUNC_DECL GLM_ONLY_SCALAR2(vec, 2, T, P, U)  operator|=(U scalar);
 		template<typename U> 
 		GLM_FUNC_DECL vec & operator|=(vec<1, U, P> const & v);
 		template<typename U> 
 		GLM_FUNC_DECL vec & operator|=(vec<2, U, P> const & v);
 		template<typename U> 
-		GLM_FUNC_DECL vec & operator^=(U scalar);
+		GLM_FUNC_DECL GLM_ONLY_SCALAR2(vec, 2, T, P, U)  operator^=(U scalar);
 		template<typename U> 
 		GLM_FUNC_DECL vec & operator^=(vec<1, U, P> const & v);
 		template<typename U> 
 		GLM_FUNC_DECL vec & operator^=(vec<2, U, P> const & v);
 		template<typename U> 
-		GLM_FUNC_DECL vec & operator<<=(U scalar);
+		GLM_FUNC_DECL GLM_ONLY_SCALAR2(vec, 2, T, P, U)  operator<<=(U scalar);
 		template<typename U> 
 		GLM_FUNC_DECL vec & operator<<=(vec<1, U, P> const & v);
 		template<typename U> 
 		GLM_FUNC_DECL vec & operator<<=(vec<2, U, P> const & v);
 		template<typename U> 
-		GLM_FUNC_DECL vec & operator>>=(U scalar);
+		GLM_FUNC_DECL GLM_ONLY_SCALAR2(vec, 2, T, P, U)  operator>>=(U scalar);
 		template<typename U> 
 		GLM_FUNC_DECL vec & operator>>=(vec<1, U, P> const & v);
 		template<typename U> 

--- a/glm/detail/type_vec2.inl
+++ b/glm/detail/type_vec2.inl
@@ -121,7 +121,7 @@ namespace glm
 
 	template<typename T, precision P>
 	template<typename U>
-	GLM_FUNC_QUALIFIER vec<2, T, P> & vec<2, T, P>::operator+=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 2, T, P, U)  tvec2<T, P>::operator+=(U scalar)
 	{
 		this->x += static_cast<T>(scalar);
 		this->y += static_cast<T>(scalar);
@@ -148,7 +148,7 @@ namespace glm
 
 	template<typename T, precision P>
 	template<typename U>
-	GLM_FUNC_QUALIFIER vec<2, T, P> & vec<2, T, P>::operator-=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 2, T, P, U)  tvec2<T, P>::operator-=(U scalar)
 	{
 		this->x -= static_cast<T>(scalar);
 		this->y -= static_cast<T>(scalar);
@@ -175,7 +175,7 @@ namespace glm
 
 	template<typename T, precision P>
 	template<typename U>
-	GLM_FUNC_QUALIFIER vec<2, T, P> & vec<2, T, P>::operator*=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 2, T, P, U)  tvec2<T, P>::operator*=(U scalar)
 	{
 		this->x *= static_cast<T>(scalar);
 		this->y *= static_cast<T>(scalar);
@@ -202,7 +202,7 @@ namespace glm
 
 	template<typename T, precision P>
 	template<typename U>
-	GLM_FUNC_QUALIFIER vec<2, T, P> & vec<2, T, P>::operator/=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 2, T, P, U)  tvec2<T, P>::operator/=(U scalar)
 	{
 		this->x /= static_cast<T>(scalar);
 		this->y /= static_cast<T>(scalar);
@@ -265,7 +265,7 @@ namespace glm
 
 	template<typename T, precision P>
 	template<typename U>
-	GLM_FUNC_QUALIFIER vec<2, T, P> & vec<2, T, P>::operator%=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 2, T, P, U)  tvec2<T, P>::operator%=(U scalar)
 	{
 		this->x %= static_cast<T>(scalar);
 		this->y %= static_cast<T>(scalar);
@@ -292,7 +292,7 @@ namespace glm
 
 	template<typename T, precision P>
 	template<typename U>
-	GLM_FUNC_QUALIFIER vec<2, T, P> & vec<2, T, P>::operator&=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 2, T, P, U)  tvec2<T, P>::operator&=(U scalar)
 	{
 		this->x &= static_cast<T>(scalar);
 		this->y &= static_cast<T>(scalar);
@@ -319,7 +319,7 @@ namespace glm
 
 	template<typename T, precision P>
 	template<typename U>
-	GLM_FUNC_QUALIFIER vec<2, T, P> & vec<2, T, P>::operator|=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 2, T, P, U)  tvec2<T, P>::operator|=(U scalar)
 	{
 		this->x |= static_cast<T>(scalar);
 		this->y |= static_cast<T>(scalar);
@@ -346,7 +346,7 @@ namespace glm
 
 	template<typename T, precision P>
 	template<typename U>
-	GLM_FUNC_QUALIFIER vec<2, T, P> & vec<2, T, P>::operator^=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 2, T, P, U)  tvec2<T, P>::operator^=(U scalar)
 	{
 		this->x ^= static_cast<T>(scalar);
 		this->y ^= static_cast<T>(scalar);
@@ -373,7 +373,7 @@ namespace glm
 
 	template<typename T, precision P>
 	template<typename U>
-	GLM_FUNC_QUALIFIER vec<2, T, P> & vec<2, T, P>::operator<<=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 2, T, P, U)  tvec2<T, P>::operator<<=(U scalar)
 	{
 		this->x <<= static_cast<T>(scalar);
 		this->y <<= static_cast<T>(scalar);
@@ -400,7 +400,7 @@ namespace glm
 
 	template<typename T, precision P>
 	template<typename U>
-	GLM_FUNC_QUALIFIER vec<2, T, P> & vec<2, T, P>::operator>>=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 2, T, P, U)  tvec2<T, P>::operator>>=(U scalar)
 	{
 		this->x >>= static_cast<T>(scalar);
 		this->y >>= static_cast<T>(scalar);

--- a/glm/detail/type_vec2.inl
+++ b/glm/detail/type_vec2.inl
@@ -121,7 +121,7 @@ namespace glm
 
 	template<typename T, precision P>
 	template<typename U>
-	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 2, T, P, U)  tvec2<T, P>::operator+=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 2, T, P, U)  vec<2, T, P>::operator+=(U scalar)
 	{
 		this->x += static_cast<T>(scalar);
 		this->y += static_cast<T>(scalar);
@@ -148,7 +148,7 @@ namespace glm
 
 	template<typename T, precision P>
 	template<typename U>
-	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 2, T, P, U)  tvec2<T, P>::operator-=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 2, T, P, U)  vec<2, T, P>::operator-=(U scalar)
 	{
 		this->x -= static_cast<T>(scalar);
 		this->y -= static_cast<T>(scalar);
@@ -175,7 +175,7 @@ namespace glm
 
 	template<typename T, precision P>
 	template<typename U>
-	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 2, T, P, U)  tvec2<T, P>::operator*=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 2, T, P, U)  vec<2, T, P>::operator*=(U scalar)
 	{
 		this->x *= static_cast<T>(scalar);
 		this->y *= static_cast<T>(scalar);
@@ -202,7 +202,7 @@ namespace glm
 
 	template<typename T, precision P>
 	template<typename U>
-	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 2, T, P, U)  tvec2<T, P>::operator/=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 2, T, P, U)  vec<2, T, P>::operator/=(U scalar)
 	{
 		this->x /= static_cast<T>(scalar);
 		this->y /= static_cast<T>(scalar);
@@ -265,7 +265,7 @@ namespace glm
 
 	template<typename T, precision P>
 	template<typename U>
-	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 2, T, P, U)  tvec2<T, P>::operator%=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 2, T, P, U)  vec<2, T, P>::operator%=(U scalar)
 	{
 		this->x %= static_cast<T>(scalar);
 		this->y %= static_cast<T>(scalar);
@@ -292,7 +292,7 @@ namespace glm
 
 	template<typename T, precision P>
 	template<typename U>
-	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 2, T, P, U)  tvec2<T, P>::operator&=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 2, T, P, U)  vec<2, T, P>::operator&=(U scalar)
 	{
 		this->x &= static_cast<T>(scalar);
 		this->y &= static_cast<T>(scalar);
@@ -319,7 +319,7 @@ namespace glm
 
 	template<typename T, precision P>
 	template<typename U>
-	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 2, T, P, U)  tvec2<T, P>::operator|=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 2, T, P, U)  vec<2, T, P>::operator|=(U scalar)
 	{
 		this->x |= static_cast<T>(scalar);
 		this->y |= static_cast<T>(scalar);
@@ -346,7 +346,7 @@ namespace glm
 
 	template<typename T, precision P>
 	template<typename U>
-	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 2, T, P, U)  tvec2<T, P>::operator^=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 2, T, P, U)  vec<2, T, P>::operator^=(U scalar)
 	{
 		this->x ^= static_cast<T>(scalar);
 		this->y ^= static_cast<T>(scalar);
@@ -373,7 +373,7 @@ namespace glm
 
 	template<typename T, precision P>
 	template<typename U>
-	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 2, T, P, U)  tvec2<T, P>::operator<<=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 2, T, P, U)  vec<2, T, P>::operator<<=(U scalar)
 	{
 		this->x <<= static_cast<T>(scalar);
 		this->y <<= static_cast<T>(scalar);
@@ -400,7 +400,7 @@ namespace glm
 
 	template<typename T, precision P>
 	template<typename U>
-	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 2, T, P, U)  tvec2<T, P>::operator>>=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 2, T, P, U)  vec<2, T, P>::operator>>=(U scalar)
 	{
 		this->x >>= static_cast<T>(scalar);
 		this->y >>= static_cast<T>(scalar);

--- a/glm/detail/type_vec2.inl
+++ b/glm/detail/type_vec2.inl
@@ -121,7 +121,7 @@ namespace glm
 
 	template<typename T, precision P>
 	template<typename U>
-	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 2, T, P, U)  vec<2, T, P>::operator+=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR_VEC(vec, 2, T, P, U)  vec<2, T, P>::operator+=(U scalar)
 	{
 		this->x += static_cast<T>(scalar);
 		this->y += static_cast<T>(scalar);
@@ -148,7 +148,7 @@ namespace glm
 
 	template<typename T, precision P>
 	template<typename U>
-	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 2, T, P, U)  vec<2, T, P>::operator-=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR_VEC(vec, 2, T, P, U)  vec<2, T, P>::operator-=(U scalar)
 	{
 		this->x -= static_cast<T>(scalar);
 		this->y -= static_cast<T>(scalar);
@@ -175,7 +175,7 @@ namespace glm
 
 	template<typename T, precision P>
 	template<typename U>
-	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 2, T, P, U)  vec<2, T, P>::operator*=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR_VEC(vec, 2, T, P, U)  vec<2, T, P>::operator*=(U scalar)
 	{
 		this->x *= static_cast<T>(scalar);
 		this->y *= static_cast<T>(scalar);
@@ -202,7 +202,7 @@ namespace glm
 
 	template<typename T, precision P>
 	template<typename U>
-	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 2, T, P, U)  vec<2, T, P>::operator/=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR_VEC(vec, 2, T, P, U)  vec<2, T, P>::operator/=(U scalar)
 	{
 		this->x /= static_cast<T>(scalar);
 		this->y /= static_cast<T>(scalar);
@@ -265,7 +265,7 @@ namespace glm
 
 	template<typename T, precision P>
 	template<typename U>
-	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 2, T, P, U)  vec<2, T, P>::operator%=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR_VEC(vec, 2, T, P, U)  vec<2, T, P>::operator%=(U scalar)
 	{
 		this->x %= static_cast<T>(scalar);
 		this->y %= static_cast<T>(scalar);
@@ -292,7 +292,7 @@ namespace glm
 
 	template<typename T, precision P>
 	template<typename U>
-	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 2, T, P, U)  vec<2, T, P>::operator&=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR_VEC(vec, 2, T, P, U)  vec<2, T, P>::operator&=(U scalar)
 	{
 		this->x &= static_cast<T>(scalar);
 		this->y &= static_cast<T>(scalar);
@@ -319,7 +319,7 @@ namespace glm
 
 	template<typename T, precision P>
 	template<typename U>
-	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 2, T, P, U)  vec<2, T, P>::operator|=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR_VEC(vec, 2, T, P, U)  vec<2, T, P>::operator|=(U scalar)
 	{
 		this->x |= static_cast<T>(scalar);
 		this->y |= static_cast<T>(scalar);
@@ -346,7 +346,7 @@ namespace glm
 
 	template<typename T, precision P>
 	template<typename U>
-	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 2, T, P, U)  vec<2, T, P>::operator^=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR_VEC(vec, 2, T, P, U)  vec<2, T, P>::operator^=(U scalar)
 	{
 		this->x ^= static_cast<T>(scalar);
 		this->y ^= static_cast<T>(scalar);
@@ -373,7 +373,7 @@ namespace glm
 
 	template<typename T, precision P>
 	template<typename U>
-	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 2, T, P, U)  vec<2, T, P>::operator<<=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR_VEC(vec, 2, T, P, U)  vec<2, T, P>::operator<<=(U scalar)
 	{
 		this->x <<= static_cast<T>(scalar);
 		this->y <<= static_cast<T>(scalar);
@@ -400,7 +400,7 @@ namespace glm
 
 	template<typename T, precision P>
 	template<typename U>
-	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 2, T, P, U)  vec<2, T, P>::operator>>=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR_VEC(vec, 2, T, P, U)  vec<2, T, P>::operator>>=(U scalar)
 	{
 		this->x >>= static_cast<T>(scalar);
 		this->y >>= static_cast<T>(scalar);

--- a/glm/detail/type_vec3.hpp
+++ b/glm/detail/type_vec3.hpp
@@ -155,25 +155,25 @@ namespace glm
 		template<typename U>
 		GLM_FUNC_DECL vec & operator=(vec<3, U, P> const & v);
 		template<typename U>
-		GLM_FUNC_DECL GLM_ONLY_SCALAR2(vec, 3, T, P, U)  operator+=(U scalar);
+		GLM_FUNC_DECL_ONLY_SCALAR(U)  operator+=(U scalar);
 		template<typename U>
 		GLM_FUNC_DECL vec & operator+=(vec<1, U, P> const & v);
 		template<typename U>
 		GLM_FUNC_DECL vec & operator+=(vec<3, U, P> const & v);
 		template<typename U>
-		GLM_FUNC_DECL GLM_ONLY_SCALAR2(vec, 3, T, P, U)  operator-=(U scalar);
+		GLM_FUNC_DECL_ONLY_SCALAR(U)  operator-=(U scalar);
 		template<typename U>
 		GLM_FUNC_DECL vec & operator-=(vec<1, U, P> const & v);
 		template<typename U>
 		GLM_FUNC_DECL vec & operator-=(vec<3, U, P> const & v);
 		template<typename U>
-		GLM_FUNC_DECL GLM_ONLY_SCALAR2(vec, 3, T, P, U)  operator*=(U scalar);
+		GLM_FUNC_DECL_ONLY_SCALAR(U)  operator*=(U scalar);
 		template<typename U>
 		GLM_FUNC_DECL vec & operator*=(vec<1, U, P> const & v);
 		template<typename U>
 		GLM_FUNC_DECL vec & operator*=(vec<3, U, P> const & v);
 		template<typename U>
-		GLM_FUNC_DECL GLM_ONLY_SCALAR2(vec, 3, T, P, U)  operator/=(U scalar);
+		GLM_FUNC_DECL_ONLY_SCALAR(U)  operator/=(U scalar);
 		template<typename U>
 		GLM_FUNC_DECL vec & operator/=(vec<1, U, P> const & v);
 		template<typename U>
@@ -189,37 +189,37 @@ namespace glm
 		// -- Unary bit operators --
 
 		template<typename U>
-		GLM_FUNC_DECL GLM_ONLY_SCALAR2(vec, 3, T, P, U)  operator%=(U scalar);
+		GLM_FUNC_DECL_ONLY_SCALAR(U)  operator%=(U scalar);
 		template<typename U>
 		GLM_FUNC_DECL vec & operator%=(vec<1, U, P> const & v);
 		template<typename U>
 		GLM_FUNC_DECL vec & operator%=(vec<3, U, P> const & v);
 		template<typename U>
-		GLM_FUNC_DECL GLM_ONLY_SCALAR2(vec, 3, T, P, U)  operator&=(U scalar);
+		GLM_FUNC_DECL_ONLY_SCALAR(U)  operator&=(U scalar);
 		template<typename U>
 		GLM_FUNC_DECL vec & operator&=(vec<1, U, P> const & v);
 		template<typename U>
 		GLM_FUNC_DECL vec & operator&=(vec<3, U, P> const & v);
 		template<typename U>
-		GLM_FUNC_DECL GLM_ONLY_SCALAR2(vec, 3, T, P, U)  operator|=(U scalar);
+		GLM_FUNC_DECL_ONLY_SCALAR(U)  operator|=(U scalar);
 		template<typename U>
 		GLM_FUNC_DECL vec & operator|=(vec<1, U, P> const & v);
 		template<typename U>
 		GLM_FUNC_DECL vec & operator|=(vec<3, U, P> const & v);
 		template<typename U>
-		GLM_FUNC_DECL GLM_ONLY_SCALAR2(vec, 3, T, P, U)  operator^=(U scalar);
+		GLM_FUNC_DECL_ONLY_SCALAR(U)  operator^=(U scalar);
 		template<typename U>
 		GLM_FUNC_DECL vec & operator^=(vec<1, U, P> const & v);
 		template<typename U>
 		GLM_FUNC_DECL vec & operator^=(vec<3, U, P> const & v);
 		template<typename U>
-		GLM_FUNC_DECL GLM_ONLY_SCALAR2(vec, 3, T, P, U)  operator<<=(U scalar);
+		GLM_FUNC_DECL_ONLY_SCALAR(U)  operator<<=(U scalar);
 		template<typename U>
 		GLM_FUNC_DECL vec & operator<<=(vec<1, U, P> const & v);
 		template<typename U>
 		GLM_FUNC_DECL vec & operator<<=(vec<3, U, P> const & v);
 		template<typename U>
-		GLM_FUNC_DECL GLM_ONLY_SCALAR2(vec, 3, T, P, U)  operator>>=(U scalar);
+		GLM_FUNC_DECL_ONLY_SCALAR(U)  operator>>=(U scalar);
 		template<typename U>
 		GLM_FUNC_DECL vec & operator>>=(vec<1, U, P> const & v);
 		template<typename U>

--- a/glm/detail/type_vec3.hpp
+++ b/glm/detail/type_vec3.hpp
@@ -155,25 +155,25 @@ namespace glm
 		template<typename U>
 		GLM_FUNC_DECL vec & operator=(vec<3, U, P> const & v);
 		template<typename U>
-		GLM_FUNC_DECL vec & operator+=(U scalar);
+		GLM_FUNC_DECL GLM_ONLY_SCALAR2(vec, 3, T, P, U)  operator+=(U scalar);
 		template<typename U>
 		GLM_FUNC_DECL vec & operator+=(vec<1, U, P> const & v);
 		template<typename U>
 		GLM_FUNC_DECL vec & operator+=(vec<3, U, P> const & v);
 		template<typename U>
-		GLM_FUNC_DECL vec & operator-=(U scalar);
+		GLM_FUNC_DECL GLM_ONLY_SCALAR2(vec, 3, T, P, U)  operator-=(U scalar);
 		template<typename U>
 		GLM_FUNC_DECL vec & operator-=(vec<1, U, P> const & v);
 		template<typename U>
 		GLM_FUNC_DECL vec & operator-=(vec<3, U, P> const & v);
 		template<typename U>
-		GLM_FUNC_DECL vec & operator*=(U scalar);
+		GLM_FUNC_DECL GLM_ONLY_SCALAR2(vec, 3, T, P, U)  operator*=(U scalar);
 		template<typename U>
 		GLM_FUNC_DECL vec & operator*=(vec<1, U, P> const & v);
 		template<typename U>
 		GLM_FUNC_DECL vec & operator*=(vec<3, U, P> const & v);
 		template<typename U>
-		GLM_FUNC_DECL vec & operator/=(U scalar);
+		GLM_FUNC_DECL GLM_ONLY_SCALAR2(vec, 3, T, P, U)  operator/=(U scalar);
 		template<typename U>
 		GLM_FUNC_DECL vec & operator/=(vec<1, U, P> const & v);
 		template<typename U>
@@ -189,37 +189,37 @@ namespace glm
 		// -- Unary bit operators --
 
 		template<typename U>
-		GLM_FUNC_DECL vec & operator%=(U scalar);
+		GLM_FUNC_DECL GLM_ONLY_SCALAR2(vec, 3, T, P, U)  operator%=(U scalar);
 		template<typename U>
 		GLM_FUNC_DECL vec & operator%=(vec<1, U, P> const & v);
 		template<typename U>
 		GLM_FUNC_DECL vec & operator%=(vec<3, U, P> const & v);
 		template<typename U>
-		GLM_FUNC_DECL vec & operator&=(U scalar);
+		GLM_FUNC_DECL GLM_ONLY_SCALAR2(vec, 3, T, P, U)  operator&=(U scalar);
 		template<typename U>
 		GLM_FUNC_DECL vec & operator&=(vec<1, U, P> const & v);
 		template<typename U>
 		GLM_FUNC_DECL vec & operator&=(vec<3, U, P> const & v);
 		template<typename U>
-		GLM_FUNC_DECL vec & operator|=(U scalar);
+		GLM_FUNC_DECL GLM_ONLY_SCALAR2(vec, 3, T, P, U)  operator|=(U scalar);
 		template<typename U>
 		GLM_FUNC_DECL vec & operator|=(vec<1, U, P> const & v);
 		template<typename U>
 		GLM_FUNC_DECL vec & operator|=(vec<3, U, P> const & v);
 		template<typename U>
-		GLM_FUNC_DECL vec & operator^=(U scalar);
+		GLM_FUNC_DECL GLM_ONLY_SCALAR2(vec, 3, T, P, U)  operator^=(U scalar);
 		template<typename U>
 		GLM_FUNC_DECL vec & operator^=(vec<1, U, P> const & v);
 		template<typename U>
 		GLM_FUNC_DECL vec & operator^=(vec<3, U, P> const & v);
 		template<typename U>
-		GLM_FUNC_DECL vec & operator<<=(U scalar);
+		GLM_FUNC_DECL GLM_ONLY_SCALAR2(vec, 3, T, P, U)  operator<<=(U scalar);
 		template<typename U>
 		GLM_FUNC_DECL vec & operator<<=(vec<1, U, P> const & v);
 		template<typename U>
 		GLM_FUNC_DECL vec & operator<<=(vec<3, U, P> const & v);
 		template<typename U>
-		GLM_FUNC_DECL vec & operator>>=(U scalar);
+		GLM_FUNC_DECL GLM_ONLY_SCALAR2(vec, 3, T, P, U)  operator>>=(U scalar);
 		template<typename U>
 		GLM_FUNC_DECL vec & operator>>=(vec<1, U, P> const & v);
 		template<typename U>

--- a/glm/detail/type_vec3.inl
+++ b/glm/detail/type_vec3.inl
@@ -152,7 +152,7 @@ namespace glm
 
 	template<typename T, precision P>
 	template<typename U>
-	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 3, T, P, U)  vec<3, T, P>::operator+=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR_VEC(vec, 3, T, P, U)  vec<3, T, P>::operator+=(U scalar)
 	{
 		this->x += static_cast<T>(scalar);
 		this->y += static_cast<T>(scalar);
@@ -182,7 +182,7 @@ namespace glm
 
 	template<typename T, precision P>
 	template<typename U>
-	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 3, T, P, U)  vec<3, T, P>::operator-=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR_VEC(vec, 3, T, P, U)  vec<3, T, P>::operator-=(U scalar)
 	{
 		this->x -= static_cast<T>(scalar);
 		this->y -= static_cast<T>(scalar);
@@ -212,7 +212,7 @@ namespace glm
 
 	template<typename T, precision P>
 	template<typename U>
-	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 3, T, P, U)  vec<3, T, P>::operator*=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR_VEC(vec, 3, T, P, U)  vec<3, T, P>::operator*=(U scalar)
 	{
 		this->x *= static_cast<T>(scalar);
 		this->y *= static_cast<T>(scalar);
@@ -242,7 +242,7 @@ namespace glm
 
 	template<typename T, precision P>
 	template<typename U>
-	GLM_FUNC_DECL GLM_ONLY_SCALAR2(vec, 3, T, P, U)  vec<3, T, P>::operator/=(U v)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR_VEC(vec, 3, T, P, U) vec<3, T, P>::operator/=(U v)
 	{
 		this->x /= static_cast<T>(v);
 		this->y /= static_cast<T>(v);
@@ -310,7 +310,7 @@ namespace glm
 
 	template<typename T, precision P>
 	template<typename U>
-	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 3, T, P, U)  vec<3, T, P>::operator%=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR_VEC(vec, 3, T, P, U)  vec<3, T, P>::operator%=(U scalar)
 	{
 		this->x %= scalar;
 		this->y %= scalar;
@@ -340,7 +340,7 @@ namespace glm
 
 	template<typename T, precision P>
 	template<typename U>
-	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 3, T, P, U)  vec<3, T, P>::operator&=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR_VEC(vec, 3, T, P, U)  vec<3, T, P>::operator&=(U scalar)
 	{
 		this->x &= scalar;
 		this->y &= scalar;
@@ -370,7 +370,7 @@ namespace glm
 
 	template<typename T, precision P>
 	template<typename U>
-	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 3, T, P, U)  vec<3, T, P>::operator|=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR_VEC(vec, 3, T, P, U)  vec<3, T, P>::operator|=(U scalar)
 	{
 		this->x |= scalar;
 		this->y |= scalar;
@@ -400,7 +400,7 @@ namespace glm
 
 	template<typename T, precision P>
 	template<typename U> 
-	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 3, T, P, U)  vec<3, T, P>::operator^=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR_VEC(vec, 3, T, P, U)  vec<3, T, P>::operator^=(U scalar)
 	{
 		this->x ^= scalar;
 		this->y ^= scalar;
@@ -430,7 +430,7 @@ namespace glm
 
 	template<typename T, precision P>
 	template<typename U> 
-	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 3, T, P, U)  vec<3, T, P>::operator<<=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR_VEC(vec, 3, T, P, U)  vec<3, T, P>::operator<<=(U scalar)
 	{
 		this->x <<= scalar;
 		this->y <<= scalar;
@@ -460,7 +460,7 @@ namespace glm
 
 	template<typename T, precision P>
 	template<typename U> 
-	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 3, T, P, U)  vec<3, T, P>::operator>>=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR_VEC(vec, 3, T, P, U)  vec<3, T, P>::operator>>=(U scalar)
 	{
 		this->x >>= static_cast<T>(scalar);
 		this->y >>= static_cast<T>(scalar);

--- a/glm/detail/type_vec3.inl
+++ b/glm/detail/type_vec3.inl
@@ -152,7 +152,7 @@ namespace glm
 
 	template<typename T, precision P>
 	template<typename U>
-	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 3, T, P, U)  tvec3<T, P>::operator+=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 3, T, P, U)  vec<3, T, P>::operator+=(U scalar)
 	{
 		this->x += static_cast<T>(scalar);
 		this->y += static_cast<T>(scalar);
@@ -182,7 +182,7 @@ namespace glm
 
 	template<typename T, precision P>
 	template<typename U>
-	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 3, T, P, U)  tvec3<T, P>::operator-=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 3, T, P, U)  vec<3, T, P>::operator-=(U scalar)
 	{
 		this->x -= static_cast<T>(scalar);
 		this->y -= static_cast<T>(scalar);
@@ -212,7 +212,7 @@ namespace glm
 
 	template<typename T, precision P>
 	template<typename U>
-	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 3, T, P, U)  tvec3<T, P>::operator*=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 3, T, P, U)  vec<3, T, P>::operator*=(U scalar)
 	{
 		this->x *= static_cast<T>(scalar);
 		this->y *= static_cast<T>(scalar);
@@ -242,7 +242,7 @@ namespace glm
 
 	template<typename T, precision P>
 	template<typename U>
-	GLM_FUNC_DECL GLM_ONLY_SCALAR2(vec, 3, T, P, U)  tvec3<T, P>::operator/=(U v)
+	GLM_FUNC_DECL GLM_ONLY_SCALAR2(vec, 3, T, P, U)  vec<3, T, P>::operator/=(U v)
 	{
 		this->x /= static_cast<T>(v);
 		this->y /= static_cast<T>(v);
@@ -310,7 +310,7 @@ namespace glm
 
 	template<typename T, precision P>
 	template<typename U>
-	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 3, T, P, U)  tvec3<T, P>::operator%=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 3, T, P, U)  vec<3, T, P>::operator%=(U scalar)
 	{
 		this->x %= scalar;
 		this->y %= scalar;
@@ -340,7 +340,7 @@ namespace glm
 
 	template<typename T, precision P>
 	template<typename U>
-	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 3, T, P, U)  tvec3<T, P>::operator&=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 3, T, P, U)  vec<3, T, P>::operator&=(U scalar)
 	{
 		this->x &= scalar;
 		this->y &= scalar;
@@ -370,7 +370,7 @@ namespace glm
 
 	template<typename T, precision P>
 	template<typename U>
-	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 3, T, P, U)  tvec3<T, P>::operator|=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 3, T, P, U)  vec<3, T, P>::operator|=(U scalar)
 	{
 		this->x |= scalar;
 		this->y |= scalar;
@@ -400,7 +400,7 @@ namespace glm
 
 	template<typename T, precision P>
 	template<typename U> 
-	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 3, T, P, U)  tvec3<T, P>::operator^=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 3, T, P, U)  vec<3, T, P>::operator^=(U scalar)
 	{
 		this->x ^= scalar;
 		this->y ^= scalar;
@@ -430,7 +430,7 @@ namespace glm
 
 	template<typename T, precision P>
 	template<typename U> 
-	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 3, T, P, U)  tvec3<T, P>::operator<<=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 3, T, P, U)  vec<3, T, P>::operator<<=(U scalar)
 	{
 		this->x <<= scalar;
 		this->y <<= scalar;
@@ -460,7 +460,7 @@ namespace glm
 
 	template<typename T, precision P>
 	template<typename U> 
-	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 3, T, P, U)  tvec3<T, P>::operator>>=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 3, T, P, U)  vec<3, T, P>::operator>>=(U scalar)
 	{
 		this->x >>= static_cast<T>(scalar);
 		this->y >>= static_cast<T>(scalar);

--- a/glm/detail/type_vec3.inl
+++ b/glm/detail/type_vec3.inl
@@ -152,7 +152,7 @@ namespace glm
 
 	template<typename T, precision P>
 	template<typename U>
-	GLM_FUNC_QUALIFIER vec<3, T, P> & vec<3, T, P>::operator+=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 3, T, P, U)  tvec3<T, P>::operator+=(U scalar)
 	{
 		this->x += static_cast<T>(scalar);
 		this->y += static_cast<T>(scalar);
@@ -182,7 +182,7 @@ namespace glm
 
 	template<typename T, precision P>
 	template<typename U>
-	GLM_FUNC_QUALIFIER vec<3, T, P> & vec<3, T, P>::operator-=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 3, T, P, U)  tvec3<T, P>::operator-=(U scalar)
 	{
 		this->x -= static_cast<T>(scalar);
 		this->y -= static_cast<T>(scalar);
@@ -212,7 +212,7 @@ namespace glm
 
 	template<typename T, precision P>
 	template<typename U>
-	GLM_FUNC_QUALIFIER vec<3, T, P> & vec<3, T, P>::operator*=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 3, T, P, U)  tvec3<T, P>::operator*=(U scalar)
 	{
 		this->x *= static_cast<T>(scalar);
 		this->y *= static_cast<T>(scalar);
@@ -242,7 +242,7 @@ namespace glm
 
 	template<typename T, precision P>
 	template<typename U>
-	GLM_FUNC_QUALIFIER vec<3, T, P> & vec<3, T, P>::operator/=(U v)
+	GLM_FUNC_DECL GLM_ONLY_SCALAR2(vec, 3, T, P, U)  tvec3<T, P>::operator/=(U v)
 	{
 		this->x /= static_cast<T>(v);
 		this->y /= static_cast<T>(v);
@@ -310,7 +310,7 @@ namespace glm
 
 	template<typename T, precision P>
 	template<typename U>
-	GLM_FUNC_QUALIFIER vec<3, T, P> & vec<3, T, P>::operator%=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 3, T, P, U)  tvec3<T, P>::operator%=(U scalar)
 	{
 		this->x %= scalar;
 		this->y %= scalar;
@@ -340,7 +340,7 @@ namespace glm
 
 	template<typename T, precision P>
 	template<typename U>
-	GLM_FUNC_QUALIFIER vec<3, T, P> & vec<3, T, P>::operator&=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 3, T, P, U)  tvec3<T, P>::operator&=(U scalar)
 	{
 		this->x &= scalar;
 		this->y &= scalar;
@@ -370,7 +370,7 @@ namespace glm
 
 	template<typename T, precision P>
 	template<typename U>
-	GLM_FUNC_QUALIFIER vec<3, T, P> & vec<3, T, P>::operator|=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 3, T, P, U)  tvec3<T, P>::operator|=(U scalar)
 	{
 		this->x |= scalar;
 		this->y |= scalar;
@@ -400,7 +400,7 @@ namespace glm
 
 	template<typename T, precision P>
 	template<typename U> 
-	GLM_FUNC_QUALIFIER vec<3, T, P> & vec<3, T, P>::operator^=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 3, T, P, U)  tvec3<T, P>::operator^=(U scalar)
 	{
 		this->x ^= scalar;
 		this->y ^= scalar;
@@ -430,7 +430,7 @@ namespace glm
 
 	template<typename T, precision P>
 	template<typename U> 
-	GLM_FUNC_QUALIFIER vec<3, T, P> & vec<3, T, P>::operator<<=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 3, T, P, U)  tvec3<T, P>::operator<<=(U scalar)
 	{
 		this->x <<= scalar;
 		this->y <<= scalar;
@@ -460,7 +460,7 @@ namespace glm
 
 	template<typename T, precision P>
 	template<typename U> 
-	GLM_FUNC_QUALIFIER vec<3, T, P> & vec<3, T, P>::operator>>=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 3, T, P, U)  tvec3<T, P>::operator>>=(U scalar)
 	{
 		this->x >>= static_cast<T>(scalar);
 		this->y >>= static_cast<T>(scalar);

--- a/glm/detail/type_vec4.hpp
+++ b/glm/detail/type_vec4.hpp
@@ -200,25 +200,25 @@ namespace glm
 		template<typename U>
 		GLM_FUNC_DECL vec<4, T, P>& operator=(vec<4, U, P> const & v);
 		template<typename U>
-		GLM_FUNC_DECL GLM_ONLY_SCALAR2(vec, 4, T, P, U)  operator+=(U scalar);
+		GLM_FUNC_DECL_ONLY_SCALAR(U)  operator+=(U scalar);
 		template<typename U>
 		GLM_FUNC_DECL vec<4, T, P>& operator+=(vec<1, U, P> const & v);
 		template<typename U>
 		GLM_FUNC_DECL vec<4, T, P>& operator+=(vec<4, U, P> const & v);
 		template<typename U>
-		GLM_FUNC_DECL GLM_ONLY_SCALAR2(vec, 4, T, P, U)  operator-=(U scalar);
+		GLM_FUNC_DECL_ONLY_SCALAR(U)  operator-=(U scalar);
 		template<typename U>
 		GLM_FUNC_DECL vec<4, T, P>& operator-=(vec<1, U, P> const & v);
 		template<typename U>
 		GLM_FUNC_DECL vec<4, T, P>& operator-=(vec<4, U, P> const & v);
 		template<typename U>
-		GLM_FUNC_DECL GLM_ONLY_SCALAR2(vec, 4, T, P, U)  operator*=(U scalar);
+		GLM_FUNC_DECL_ONLY_SCALAR(U)  operator*=(U scalar);
 		template<typename U>
 		GLM_FUNC_DECL vec<4, T, P>& operator*=(vec<1, U, P> const& v);
 		template<typename U>
 		GLM_FUNC_DECL vec<4, T, P>& operator*=(vec<4, U, P> const& v);
 		template<typename U>
-		GLM_FUNC_DECL GLM_ONLY_SCALAR2(vec, 4, T, P, U)  operator/=(U scalar);
+		GLM_FUNC_DECL_ONLY_SCALAR(U)  operator/=(U scalar);
 		template<typename U>
 		GLM_FUNC_DECL vec<4, T, P>& operator/=(vec<1, U, P> const & v);
 		template<typename U>
@@ -234,37 +234,37 @@ namespace glm
 		// -- Unary bit operators --
 
 		template<typename U>
-		GLM_FUNC_DECL GLM_ONLY_SCALAR2(vec, 4, T, P, U)  operator%=(U scalar);
+		GLM_FUNC_DECL_ONLY_SCALAR(U)  operator%=(U scalar);
 		template<typename U>
 		GLM_FUNC_DECL vec<4, T, P> & operator%=(vec<1, U, P> const & v);
 		template<typename U>
 		GLM_FUNC_DECL vec<4, T, P> & operator%=(vec<4, U, P> const & v);
 		template<typename U>
-		GLM_FUNC_DECL GLM_ONLY_SCALAR2(vec, 4, T, P, U)  operator&=(U scalar);
+		GLM_FUNC_DECL_ONLY_SCALAR(U)  operator&=(U scalar);
 		template<typename U>
 		GLM_FUNC_DECL vec<4, T, P> & operator&=(vec<1, U, P> const & v);
 		template<typename U>
 		GLM_FUNC_DECL vec<4, T, P> & operator&=(vec<4, U, P> const & v);
 		template<typename U>
-		GLM_FUNC_DECL GLM_ONLY_SCALAR2(vec, 4, T, P, U)  operator|=(U scalar);
+		GLM_FUNC_DECL_ONLY_SCALAR(U)  operator|=(U scalar);
 		template<typename U>
 		GLM_FUNC_DECL vec<4, T, P> & operator|=(vec<1, U, P> const & v);
 		template<typename U>
 		GLM_FUNC_DECL vec<4, T, P> & operator|=(vec<4, U, P> const & v);
 		template<typename U>
-		GLM_FUNC_DECL GLM_ONLY_SCALAR2(vec, 4, T, P, U)  operator^=(U scalar);
+		GLM_FUNC_DECL_ONLY_SCALAR(U)  operator^=(U scalar);
 		template<typename U>
 		GLM_FUNC_DECL vec<4, T, P> & operator^=(vec<1, U, P> const & v);
 		template<typename U>
 		GLM_FUNC_DECL vec<4, T, P> & operator^=(vec<4, U, P> const & v);
 		template<typename U>
-		GLM_FUNC_DECL GLM_ONLY_SCALAR2(vec, 4, T, P, U)  operator<<=(U scalar);
+		GLM_FUNC_DECL_ONLY_SCALAR(U)  operator<<=(U scalar);
 		template<typename U>
 		GLM_FUNC_DECL vec<4, T, P> & operator<<=(vec<1, U, P> const & v);
 		template<typename U>
 		GLM_FUNC_DECL vec<4, T, P> & operator<<=(vec<4, U, P> const & v);
 		template<typename U>
-		GLM_FUNC_DECL GLM_ONLY_SCALAR2(vec, 4, T, P, U)  operator>>=(U scalar);
+		GLM_FUNC_DECL_ONLY_SCALAR(U)  operator>>=(U scalar);
 		template<typename U>
 		GLM_FUNC_DECL vec<4, T, P> & operator>>=(vec<1, U, P> const & v);
 		template<typename U>

--- a/glm/detail/type_vec4.hpp
+++ b/glm/detail/type_vec4.hpp
@@ -200,25 +200,25 @@ namespace glm
 		template<typename U>
 		GLM_FUNC_DECL vec<4, T, P>& operator=(vec<4, U, P> const & v);
 		template<typename U>
-		GLM_FUNC_DECL vec<4, T, P>& operator+=(U scalar);
+		GLM_FUNC_DECL GLM_ONLY_SCALAR2(vec, 4, T, P, U)  operator+=(U scalar);
 		template<typename U>
 		GLM_FUNC_DECL vec<4, T, P>& operator+=(vec<1, U, P> const & v);
 		template<typename U>
 		GLM_FUNC_DECL vec<4, T, P>& operator+=(vec<4, U, P> const & v);
 		template<typename U>
-		GLM_FUNC_DECL vec<4, T, P>& operator-=(U scalar);
+		GLM_FUNC_DECL GLM_ONLY_SCALAR2(vec, 4, T, P, U)  operator-=(U scalar);
 		template<typename U>
 		GLM_FUNC_DECL vec<4, T, P>& operator-=(vec<1, U, P> const & v);
 		template<typename U>
 		GLM_FUNC_DECL vec<4, T, P>& operator-=(vec<4, U, P> const & v);
 		template<typename U>
-		GLM_FUNC_DECL vec<4, T, P>& operator*=(U scalar);
+		GLM_FUNC_DECL GLM_ONLY_SCALAR2(vec, 4, T, P, U)  operator*=(U scalar);
 		template<typename U>
 		GLM_FUNC_DECL vec<4, T, P>& operator*=(vec<1, U, P> const& v);
 		template<typename U>
 		GLM_FUNC_DECL vec<4, T, P>& operator*=(vec<4, U, P> const& v);
 		template<typename U>
-		GLM_FUNC_DECL vec<4, T, P>& operator/=(U scalar);
+		GLM_FUNC_DECL GLM_ONLY_SCALAR2(vec, 4, T, P, U)  operator/=(U scalar);
 		template<typename U>
 		GLM_FUNC_DECL vec<4, T, P>& operator/=(vec<1, U, P> const & v);
 		template<typename U>
@@ -234,37 +234,37 @@ namespace glm
 		// -- Unary bit operators --
 
 		template<typename U>
-		GLM_FUNC_DECL vec<4, T, P> & operator%=(U scalar);
+		GLM_FUNC_DECL GLM_ONLY_SCALAR2(vec, 4, T, P, U)  operator%=(U scalar);
 		template<typename U>
 		GLM_FUNC_DECL vec<4, T, P> & operator%=(vec<1, U, P> const & v);
 		template<typename U>
 		GLM_FUNC_DECL vec<4, T, P> & operator%=(vec<4, U, P> const & v);
 		template<typename U>
-		GLM_FUNC_DECL vec<4, T, P> & operator&=(U scalar);
+		GLM_FUNC_DECL GLM_ONLY_SCALAR2(vec, 4, T, P, U)  operator&=(U scalar);
 		template<typename U>
 		GLM_FUNC_DECL vec<4, T, P> & operator&=(vec<1, U, P> const & v);
 		template<typename U>
 		GLM_FUNC_DECL vec<4, T, P> & operator&=(vec<4, U, P> const & v);
 		template<typename U>
-		GLM_FUNC_DECL vec<4, T, P> & operator|=(U scalar);
+		GLM_FUNC_DECL GLM_ONLY_SCALAR2(vec, 4, T, P, U)  operator|=(U scalar);
 		template<typename U>
 		GLM_FUNC_DECL vec<4, T, P> & operator|=(vec<1, U, P> const & v);
 		template<typename U>
 		GLM_FUNC_DECL vec<4, T, P> & operator|=(vec<4, U, P> const & v);
 		template<typename U>
-		GLM_FUNC_DECL vec<4, T, P> & operator^=(U scalar);
+		GLM_FUNC_DECL GLM_ONLY_SCALAR2(vec, 4, T, P, U)  operator^=(U scalar);
 		template<typename U>
 		GLM_FUNC_DECL vec<4, T, P> & operator^=(vec<1, U, P> const & v);
 		template<typename U>
 		GLM_FUNC_DECL vec<4, T, P> & operator^=(vec<4, U, P> const & v);
 		template<typename U>
-		GLM_FUNC_DECL vec<4, T, P> & operator<<=(U scalar);
+		GLM_FUNC_DECL GLM_ONLY_SCALAR2(vec, 4, T, P, U)  operator<<=(U scalar);
 		template<typename U>
 		GLM_FUNC_DECL vec<4, T, P> & operator<<=(vec<1, U, P> const & v);
 		template<typename U>
 		GLM_FUNC_DECL vec<4, T, P> & operator<<=(vec<4, U, P> const & v);
 		template<typename U>
-		GLM_FUNC_DECL vec<4, T, P> & operator>>=(U scalar);
+		GLM_FUNC_DECL GLM_ONLY_SCALAR2(vec, 4, T, P, U)  operator>>=(U scalar);
 		template<typename U>
 		GLM_FUNC_DECL vec<4, T, P> & operator>>=(vec<1, U, P> const & v);
 		template<typename U>

--- a/glm/detail/type_vec4.inl
+++ b/glm/detail/type_vec4.inl
@@ -365,7 +365,7 @@ namespace detail
 
 	template<typename T, precision P>
 	template<typename U>
-	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 4, T, P, U)  vec<4, T, P>::operator+=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR_VEC(vec, 4, T, P, U)  vec<4, T, P>::operator+=(U scalar)
 	{
 		return (*this = detail::compute_vec4_add<T, P, detail::is_aligned<P>::value>::call(*this, vec<4, T, P>(scalar)));
 	}
@@ -386,7 +386,7 @@ namespace detail
 
 	template<typename T, precision P>
 	template<typename U>
-	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 4, T, P, U)  vec<4, T, P>::operator-=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR_VEC(vec, 4, T, P, U)  vec<4, T, P>::operator-=(U scalar)
 	{
 		return (*this = detail::compute_vec4_sub<T, P, detail::is_aligned<P>::value>::call(*this, vec<4, T, P>(scalar)));
 	}
@@ -407,7 +407,7 @@ namespace detail
 
 	template<typename T, precision P>
 	template<typename U>
-	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 4, T, P, U)  vec<4, T, P>::operator*=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR_VEC(vec, 4, T, P, U)  vec<4, T, P>::operator*=(U scalar)
 	{
 		return (*this = detail::compute_vec4_mul<T, P, detail::is_aligned<P>::value>::call(*this, vec<4, T, P>(scalar)));
 	}
@@ -428,7 +428,7 @@ namespace detail
 
 	template<typename T, precision P>
 	template<typename U>
-	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 4, T, P, U)  vec<4, T, P>::operator/=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR_VEC(vec, 4, T, P, U)  vec<4, T, P>::operator/=(U scalar)
 	{
 		return (*this = detail::compute_vec4_div<T, P, detail::is_aligned<P>::value>::call(*this, vec<4, T, P>(scalar)));
 	}
@@ -489,7 +489,7 @@ namespace detail
 
 	template<typename T, precision P>
 	template<typename U>
-	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 4, T, P, U)  vec<4, T, P>::operator%=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR_VEC(vec, 4, T, P, U)  vec<4, T, P>::operator%=(U scalar)
 	{
 		return (*this = detail::compute_vec4_mod<T, P, detail::is_aligned<P>::value>::call(*this, vec<4, T, P>(scalar)));
 	}
@@ -510,7 +510,7 @@ namespace detail
 
 	template<typename T, precision P>
 	template<typename U>
-	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 4, T, P, U)  vec<4, T, P>::operator&=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR_VEC(vec, 4, T, P, U)  vec<4, T, P>::operator&=(U scalar)
 	{
 		return (*this = detail::compute_vec4_and<T, P, detail::is_int<T>::value, sizeof(T) * 8, detail::is_aligned<P>::value>::call(*this, vec<4, T, P>(scalar)));
 	}
@@ -531,7 +531,7 @@ namespace detail
 
 	template<typename T, precision P>
 	template<typename U>
-	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 4, T, P, U)  vec<4, T, P>::operator|=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR_VEC(vec, 4, T, P, U)  vec<4, T, P>::operator|=(U scalar)
 	{
 		return (*this = detail::compute_vec4_or<T, P, detail::is_int<T>::value, sizeof(T) * 8, detail::is_aligned<P>::value>::call(*this, vec<4, T, P>(scalar)));
 	}
@@ -552,7 +552,7 @@ namespace detail
 
 	template<typename T, precision P>
 	template<typename U>
-	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 4, T, P, U)  vec<4, T, P>::operator^=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR_VEC(vec, 4, T, P, U)  vec<4, T, P>::operator^=(U scalar)
 	{
 		return (*this = detail::compute_vec4_xor<T, P, detail::is_int<T>::value, sizeof(T) * 8, detail::is_aligned<P>::value>::call(*this, vec<4, T, P>(scalar)));
 	}
@@ -573,7 +573,7 @@ namespace detail
 
 	template<typename T, precision P>
 	template<typename U>
-	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 4, T, P, U)  vec<4, T, P>::operator<<=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR_VEC(vec, 4, T, P, U)  vec<4, T, P>::operator<<=(U scalar)
 	{
 		return (*this = detail::compute_vec4_shift_left<T, P, detail::is_int<T>::value, sizeof(T) * 8, detail::is_aligned<P>::value>::call(*this, vec<4, T, P>(scalar)));
 	}
@@ -594,7 +594,7 @@ namespace detail
 
 	template<typename T, precision P>
 	template<typename U>
-	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 4, T, P, U)  vec<4, T, P>::operator>>=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR_VEC(vec, 4, T, P, U)  vec<4, T, P>::operator>>=(U scalar)
 	{
 		return (*this = detail::compute_vec4_shift_right<T, P, detail::is_int<T>::value, sizeof(T) * 8, detail::is_aligned<P>::value>::call(*this, vec<4, T, P>(scalar)));
 	}

--- a/glm/detail/type_vec4.inl
+++ b/glm/detail/type_vec4.inl
@@ -365,7 +365,7 @@ namespace detail
 
 	template<typename T, precision P>
 	template<typename U>
-	GLM_FUNC_QUALIFIER vec<4, T, P> & vec<4, T, P>::operator+=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 4, T, P, U)  tvec4<T, P>::operator+=(U scalar)
 	{
 		return (*this = detail::compute_vec4_add<T, P, detail::is_aligned<P>::value>::call(*this, vec<4, T, P>(scalar)));
 	}
@@ -386,7 +386,7 @@ namespace detail
 
 	template<typename T, precision P>
 	template<typename U>
-	GLM_FUNC_QUALIFIER vec<4, T, P> & vec<4, T, P>::operator-=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 4, T, P, U)  tvec4<T, P>::operator-=(U scalar)
 	{
 		return (*this = detail::compute_vec4_sub<T, P, detail::is_aligned<P>::value>::call(*this, vec<4, T, P>(scalar)));
 	}
@@ -407,7 +407,7 @@ namespace detail
 
 	template<typename T, precision P>
 	template<typename U>
-	GLM_FUNC_QUALIFIER vec<4, T, P> & vec<4, T, P>::operator*=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 4, T, P, U)  tvec4<T, P>::operator*=(U scalar)
 	{
 		return (*this = detail::compute_vec4_mul<T, P, detail::is_aligned<P>::value>::call(*this, vec<4, T, P>(scalar)));
 	}
@@ -428,7 +428,7 @@ namespace detail
 
 	template<typename T, precision P>
 	template<typename U>
-	GLM_FUNC_QUALIFIER vec<4, T, P> & vec<4, T, P>::operator/=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 4, T, P, U)  tvec4<T, P>::operator/=(U scalar)
 	{
 		return (*this = detail::compute_vec4_div<T, P, detail::is_aligned<P>::value>::call(*this, vec<4, T, P>(scalar)));
 	}
@@ -489,7 +489,7 @@ namespace detail
 
 	template<typename T, precision P>
 	template<typename U>
-	GLM_FUNC_QUALIFIER vec<4, T, P> & vec<4, T, P>::operator%=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 4, T, P, U)  tvec4<T, P>::operator%=(U scalar)
 	{
 		return (*this = detail::compute_vec4_mod<T, P, detail::is_aligned<P>::value>::call(*this, vec<4, T, P>(scalar)));
 	}
@@ -510,7 +510,7 @@ namespace detail
 
 	template<typename T, precision P>
 	template<typename U>
-	GLM_FUNC_QUALIFIER vec<4, T, P> & vec<4, T, P>::operator&=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 4, T, P, U)  tvec4<T, P>::operator&=(U scalar)
 	{
 		return (*this = detail::compute_vec4_and<T, P, detail::is_int<T>::value, sizeof(T) * 8, detail::is_aligned<P>::value>::call(*this, vec<4, T, P>(scalar)));
 	}
@@ -531,7 +531,7 @@ namespace detail
 
 	template<typename T, precision P>
 	template<typename U>
-	GLM_FUNC_QUALIFIER vec<4, T, P> & vec<4, T, P>::operator|=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 4, T, P, U)  tvec4<T, P>::operator|=(U scalar)
 	{
 		return (*this = detail::compute_vec4_or<T, P, detail::is_int<T>::value, sizeof(T) * 8, detail::is_aligned<P>::value>::call(*this, vec<4, T, P>(scalar)));
 	}
@@ -552,7 +552,7 @@ namespace detail
 
 	template<typename T, precision P>
 	template<typename U>
-	GLM_FUNC_QUALIFIER vec<4, T, P> & vec<4, T, P>::operator^=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 4, T, P, U)  tvec4<T, P>::operator^=(U scalar)
 	{
 		return (*this = detail::compute_vec4_xor<T, P, detail::is_int<T>::value, sizeof(T) * 8, detail::is_aligned<P>::value>::call(*this, vec<4, T, P>(scalar)));
 	}
@@ -573,7 +573,7 @@ namespace detail
 
 	template<typename T, precision P>
 	template<typename U>
-	GLM_FUNC_QUALIFIER vec<4, T, P> & vec<4, T, P>::operator<<=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 4, T, P, U)  tvec4<T, P>::operator<<=(U scalar)
 	{
 		return (*this = detail::compute_vec4_shift_left<T, P, detail::is_int<T>::value, sizeof(T) * 8, detail::is_aligned<P>::value>::call(*this, vec<4, T, P>(scalar)));
 	}
@@ -594,7 +594,7 @@ namespace detail
 
 	template<typename T, precision P>
 	template<typename U>
-	GLM_FUNC_QUALIFIER vec<4, T, P> & vec<4, T, P>::operator>>=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 4, T, P, U)  tvec4<T, P>::operator>>=(U scalar)
 	{
 		return (*this = detail::compute_vec4_shift_right<T, P, detail::is_int<T>::value, sizeof(T) * 8, detail::is_aligned<P>::value>::call(*this, vec<4, T, P>(scalar)));
 	}

--- a/glm/detail/type_vec4.inl
+++ b/glm/detail/type_vec4.inl
@@ -365,7 +365,7 @@ namespace detail
 
 	template<typename T, precision P>
 	template<typename U>
-	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 4, T, P, U)  tvec4<T, P>::operator+=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 4, T, P, U)  vec<4, T, P>::operator+=(U scalar)
 	{
 		return (*this = detail::compute_vec4_add<T, P, detail::is_aligned<P>::value>::call(*this, vec<4, T, P>(scalar)));
 	}
@@ -386,7 +386,7 @@ namespace detail
 
 	template<typename T, precision P>
 	template<typename U>
-	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 4, T, P, U)  tvec4<T, P>::operator-=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 4, T, P, U)  vec<4, T, P>::operator-=(U scalar)
 	{
 		return (*this = detail::compute_vec4_sub<T, P, detail::is_aligned<P>::value>::call(*this, vec<4, T, P>(scalar)));
 	}
@@ -407,7 +407,7 @@ namespace detail
 
 	template<typename T, precision P>
 	template<typename U>
-	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 4, T, P, U)  tvec4<T, P>::operator*=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 4, T, P, U)  vec<4, T, P>::operator*=(U scalar)
 	{
 		return (*this = detail::compute_vec4_mul<T, P, detail::is_aligned<P>::value>::call(*this, vec<4, T, P>(scalar)));
 	}
@@ -428,7 +428,7 @@ namespace detail
 
 	template<typename T, precision P>
 	template<typename U>
-	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 4, T, P, U)  tvec4<T, P>::operator/=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 4, T, P, U)  vec<4, T, P>::operator/=(U scalar)
 	{
 		return (*this = detail::compute_vec4_div<T, P, detail::is_aligned<P>::value>::call(*this, vec<4, T, P>(scalar)));
 	}
@@ -489,7 +489,7 @@ namespace detail
 
 	template<typename T, precision P>
 	template<typename U>
-	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 4, T, P, U)  tvec4<T, P>::operator%=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 4, T, P, U)  vec<4, T, P>::operator%=(U scalar)
 	{
 		return (*this = detail::compute_vec4_mod<T, P, detail::is_aligned<P>::value>::call(*this, vec<4, T, P>(scalar)));
 	}
@@ -510,7 +510,7 @@ namespace detail
 
 	template<typename T, precision P>
 	template<typename U>
-	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 4, T, P, U)  tvec4<T, P>::operator&=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 4, T, P, U)  vec<4, T, P>::operator&=(U scalar)
 	{
 		return (*this = detail::compute_vec4_and<T, P, detail::is_int<T>::value, sizeof(T) * 8, detail::is_aligned<P>::value>::call(*this, vec<4, T, P>(scalar)));
 	}
@@ -531,7 +531,7 @@ namespace detail
 
 	template<typename T, precision P>
 	template<typename U>
-	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 4, T, P, U)  tvec4<T, P>::operator|=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 4, T, P, U)  vec<4, T, P>::operator|=(U scalar)
 	{
 		return (*this = detail::compute_vec4_or<T, P, detail::is_int<T>::value, sizeof(T) * 8, detail::is_aligned<P>::value>::call(*this, vec<4, T, P>(scalar)));
 	}
@@ -552,7 +552,7 @@ namespace detail
 
 	template<typename T, precision P>
 	template<typename U>
-	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 4, T, P, U)  tvec4<T, P>::operator^=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 4, T, P, U)  vec<4, T, P>::operator^=(U scalar)
 	{
 		return (*this = detail::compute_vec4_xor<T, P, detail::is_int<T>::value, sizeof(T) * 8, detail::is_aligned<P>::value>::call(*this, vec<4, T, P>(scalar)));
 	}
@@ -573,7 +573,7 @@ namespace detail
 
 	template<typename T, precision P>
 	template<typename U>
-	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 4, T, P, U)  tvec4<T, P>::operator<<=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 4, T, P, U)  vec<4, T, P>::operator<<=(U scalar)
 	{
 		return (*this = detail::compute_vec4_shift_left<T, P, detail::is_int<T>::value, sizeof(T) * 8, detail::is_aligned<P>::value>::call(*this, vec<4, T, P>(scalar)));
 	}
@@ -594,7 +594,7 @@ namespace detail
 
 	template<typename T, precision P>
 	template<typename U>
-	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 4, T, P, U)  tvec4<T, P>::operator>>=(U scalar)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR2(vec, 4, T, P, U)  vec<4, T, P>::operator>>=(U scalar)
 	{
 		return (*this = detail::compute_vec4_shift_right<T, P, detail::is_int<T>::value, sizeof(T) * 8, detail::is_aligned<P>::value>::call(*this, vec<4, T, P>(scalar)));
 	}

--- a/glm/fwd.hpp
+++ b/glm/fwd.hpp
@@ -9,6 +9,18 @@
 #include "detail/type_float.hpp"
 #include "detail/type_vec.hpp"
 #include "detail/type_mat.hpp"
+namespace glm
+{
+	template<typename T> struct is_vec {
+		template <length_t L, typename T, precision P, template <length_t, typename, precision> class vecType> static int8	test(vecType<L, T, P>*);
+		static int16	test(...);
+		enum { value = sizeof(test((T*)0)) == sizeof(int8) };
+	};
+	template<bool B, typename T>	struct meta_if { typedef T type; };
+	template<typename T>			struct meta_if<false, T> {};
+#define GLM_ONLY_SCALAR(T)			typename meta_if<!is_vec<T>::value, T>::type
+#define GLM_ONLY_SCALAR2(V,L,T,P,U)	typename meta_if<!is_vec<U>::value, V<L,T,P> >::type &
+}//namespace glm
 
 //////////////////////
 // GLM_GTC_quaternion

--- a/glm/fwd.hpp
+++ b/glm/fwd.hpp
@@ -19,7 +19,8 @@ namespace glm
 	template<bool B, typename T>	struct meta_if { typedef T type; };
 	template<typename T>			struct meta_if<false, T> {};
 #define GLM_ONLY_SCALAR(T)			typename meta_if<!is_vec<T>::value, T>::type
-#define GLM_ONLY_SCALAR2(V,L,T,P,U)	typename meta_if<!is_vec<U>::value, V<L,T,P> >::type &
+#define GLM_ONLY_SCALAR_VEC(V,L,T,P,U)	typename meta_if<!is_vec<U>::value, V<L,T,P> >::type &
+#define GLM_FUNC_DECL_ONLY_SCALAR(U)	GLM_FUNC_DECL typename meta_if<!is_vec<U>::value, vec>::type &
 }//namespace glm
 
 //////////////////////

--- a/glm/fwd.hpp
+++ b/glm/fwd.hpp
@@ -11,10 +11,10 @@
 #include "detail/type_mat.hpp"
 namespace glm
 {
-	template<typename T> struct is_vec {
+	template<typename X> struct is_vec {
 		template <length_t L, typename T, precision P, template <length_t, typename, precision> class vecType> static int8	test(vecType<L, T, P>*);
 		static int16	test(...);
-		enum { value = sizeof(test((T*)0)) == sizeof(int8) };
+		enum { value = sizeof(test((X*)0)) == sizeof(int8) };
 	};
 	template<bool B, typename T>	struct meta_if { typedef T type; };
 	template<typename T>			struct meta_if<false, T> {};

--- a/glm/gtx/norm.inl
+++ b/glm/gtx/norm.inl
@@ -17,7 +17,7 @@ namespace detail
 }//namespace detail
 
 	template<typename genType>
-	GLM_FUNC_QUALIFIER genType length2(genType x)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR(genType) length2(genType x)
 	{
 		GLM_STATIC_ASSERT(std::numeric_limits<genType>::is_iec559, "'length2' accepts only floating-point inputs");
 		return x * x;
@@ -31,7 +31,7 @@ namespace detail
 	}
 
 	template<typename T>
-	GLM_FUNC_QUALIFIER T distance2(T p0, T p1)
+	GLM_FUNC_QUALIFIER GLM_ONLY_SCALAR(T) distance2(T p0, T p1)
 	{
 		GLM_STATIC_ASSERT(std::numeric_limits<T>::is_iec559, "'distance2' accepts only floating-point inputs");
 		return length2(p1 - p0);


### PR DESCRIPTION
use SFINAE to prevent things inheriting from vec<> matching genType in scalar functions