### PR TITLE
Added a quaternion-based "Look At" function

### DIFF
--- a/glm/gtx/quaternion.hpp
+++ b/glm/gtx/quaternion.hpp
@@ -177,10 +177,10 @@ namespace glm
 		vec<3, T, P> const & orig, 
 		vec<3, T, P> const & dest);
 
-		/// Build a look at quaternion based on the default handedness.
+	/// Build a look at quaternion based on the default handedness.
 	///
 	/// @param direction Desired direction of the camera.
-	/// @param up Up vector, how the camera is oriented.. Typically (0, 0, 1).
+	/// @param up Up vector, how the camera is oriented. Typically (0, 1, 0).
 	template<typename T, precision P>
 	GLM_FUNC_DECL tquat<T, P> quatLookAt(
 		tvec3<T, P> const & direction,
@@ -189,7 +189,7 @@ namespace glm
 	/// Build a right-handed look at quaternion.
 	///
 	/// @param direction Desired direction of the camera.
-	/// @param up Up vector, how the camera is oriented. Typically (0, 0, 1).
+	/// @param up Up vector, how the camera is oriented. Typically (0, 1, 0).
 	template<typename T, precision P>
 	GLM_FUNC_DECL tquat<T, P> quatLookAtRH(
 		tvec3<T, P> const & direction,
@@ -199,7 +199,7 @@ namespace glm
 	///
 	/// @param eye Position of the camera
 	/// @param direction Desired direction onto which the +z-axis gets mapped
-	/// @param up Up vector, how the camera is oriented. Typically (0, 0, 1).
+	/// @param up Up vector, how the camera is oriented. Typically (0, 1, 0).
 	template <typename T, precision P>
 	GLM_FUNC_DECL tquat<T, P> quatLookAtLH(
 		tvec3<T, P> const & direction,

--- a/glm/gtx/quaternion.hpp
+++ b/glm/gtx/quaternion.hpp
@@ -177,6 +177,34 @@ namespace glm
 		vec<3, T, P> const & orig, 
 		vec<3, T, P> const & dest);
 
+		/// Build a look at quaternion based on the default handedness.
+	///
+	/// @param direction Desired direction of the camera.
+	/// @param up Up vector, how the camera is oriented.. Typically (0, 0, 1).
+	template<typename T, precision P>
+	GLM_FUNC_DECL tquat<T, P> quatLookAt(
+		tvec3<T, P> const & direction,
+		tvec3<T, P> const & up);
+
+	/// Build a right-handed look at quaternion.
+	///
+	/// @param direction Desired direction of the camera.
+	/// @param up Up vector, how the camera is oriented. Typically (0, 0, 1).
+	template<typename T, precision P>
+	GLM_FUNC_DECL tquat<T, P> quatLookAtRH(
+		tvec3<T, P> const & direction,
+		tvec3<T, P> const & up);
+
+	/// Build a left-handed look at quaternion.
+	///
+	/// @param eye Position of the camera
+	/// @param direction Desired direction onto which the +z-axis gets mapped
+	/// @param up Up vector, how the camera is oriented. Typically (0, 0, 1).
+	template <typename T, precision P>
+	GLM_FUNC_DECL tquat<T, P> quatLookAtLH(
+		tvec3<T, P> const & direction,
+		tvec3<T, P> const & up);
+	
 	/// Returns the squared length of x.
 	/// 
 	/// @see gtx_quaternion

--- a/glm/gtx/quaternion.hpp
+++ b/glm/gtx/quaternion.hpp
@@ -200,7 +200,7 @@ namespace glm
 	/// @param eye Position of the camera
 	/// @param direction Desired direction onto which the +z-axis gets mapped
 	/// @param up Up vector, how the camera is oriented. Typically (0, 1, 0).
-	template <typename T, precision P>
+	template<typename T, precision P>
 	GLM_FUNC_DECL tquat<T, P> quatLookAtLH(
 		tvec3<T, P> const & direction,
 		tvec3<T, P> const & up);

--- a/glm/gtx/quaternion.inl
+++ b/glm/gtx/quaternion.inl
@@ -208,5 +208,39 @@ namespace glm
 			rotationAxis.y * invs,
 			rotationAxis.z * invs);
 	}
+	
+	template<typename T, precision P>
+	GLM_FUNC_QUALIFIER tquat<T, P> quatLookAt(tvec3<T, P> const& direction, tvec3<T, P> const& up)
+	{
+#		if GLM_COORDINATE_SYSTEM == GLM_LEFT_HANDED
+			return quatLookAtLH(direction, up);
+#		else
+			return quatLookAtRH(direction, up);
+# 		endif
+	}
+
+	template<typename T, precision P>
+	GLM_FUNC_QUALIFIER tquat<T, P> quatLookAtRH(tvec3<T, P> const& direction, tvec3<T, P> const& up)
+	{
+		tmat3x3<T, P> Result(uninitialize);
+
+		Result[2] = -normalize(direction);
+		Result[0] = normalize(cross(up, Result[2]));
+		Result[1] = cross(Result[2], Result[0]);
+
+		return quat_cast(Result);
+	}
+
+	template<typename T, precision P>
+	GLM_FUNC_QUALIFIER tquat<T, P> quatLookAtLH(tvec3<T, P> const& direction, tvec3<T, P> const& up)
+	{
+		tmat3x3<T, P> Result(uninitialize);
+
+		Result[2] = normalize(direction);
+		Result[0] = normalize(cross(up, Result[2]));
+		Result[1] = cross(Result[2], Result[0]);
+
+		return quat_cast(Result);
+	}
 
 }//namespace glm

--- a/test/gtx/gtx_quaternion.cpp
+++ b/test/gtx/gtx_quaternion.cpp
@@ -107,7 +107,7 @@ int test_quatLookAt()
 	return Error;
 }
 
-int main1()
+int main()
 {
 	int Error = 0;
 

--- a/test/gtx/gtx_quaternion.cpp
+++ b/test/gtx/gtx_quaternion.cpp
@@ -90,7 +90,7 @@ int test_log()
 	return Error;
 }
 
-int test_quatLookAt()
+int test_quat_lookAt()
 {
 	int Error(0);
 
@@ -115,7 +115,7 @@ int main()
 	Error += test_rotation();
 	Error += test_quat_fastMix();
 	Error += test_quat_shortMix();
-	Error += test_quatLookAt();
+	Error += test_quat_lookAt();
 
 	return Error;
 }

--- a/test/gtx/gtx_quaternion.cpp
+++ b/test/gtx/gtx_quaternion.cpp
@@ -90,7 +90,24 @@ int test_log()
 	return Error;
 }
 
-int main()
+int test_quatLookAt()
+{
+	int Error(0);
+
+	glm::vec3 eye(0.0f);
+	glm::vec3 center(1.1f, -2.0f, 3.1416f);
+	glm::vec3 up = glm::vec3(-0.17f, 7.23f, -1.744f);
+
+	glm::quat test_quat = glm::quatLookAt(center - eye, up);
+	glm::quat test_mat = glm::conjugate(glm::quat_cast(glm::lookAt(eye, center, up)));
+
+	Error += static_cast<int>(glm::abs(glm::length(test_quat) - 1.0f) > glm::epsilon<float>());
+	Error += static_cast<int>(glm::min(glm::length(test_quat + (-test_mat)), glm::length(test_quat + test_mat)) > glm::epsilon<float>());
+
+	return Error;
+}
+
+int main1()
 {
 	int Error = 0;
 
@@ -98,6 +115,7 @@ int main()
 	Error += test_rotation();
 	Error += test_quat_fastMix();
 	Error += test_quat_shortMix();
+	Error += test_quatLookAt();
 
 	return Error;
 }


### PR DESCRIPTION
As suggested in [this feature request](https://github.com/g-truc/glm/issues/23) this function computes a unit quaternion that describes the rotation between screen coordinates and a given camera orientation specified by a view and up directions. The rotation quatLookAt(target - eye, up) is the inverse of the rotational part of lookAt(eye, center, up) and therefore one has to take the conjugate to compute a view matrix.

Instead of implementing it directly by means of quaternions, I chose to compute the according rotation matrix and then convert it into a quaternion since benchmarks indicated that this is faster than using quaternions only. The handedness of the coordinates is taken into account in the same fashion as in the matrix lookAt.

The test checks if a certain camera configuration produces a unit quaternion and if it is equivalent to the corresponding matrix lookAt.