### PR TITLE
quatLookAt: removed internal normalization of input direction

### DIFF
--- a/glm/gtx/quaternion.hpp
+++ b/glm/gtx/quaternion.hpp
@@ -185,7 +185,7 @@ namespace glm
 
 	/// Build a look at quaternion based on the default handedness.
 	///
-	/// @param direction Desired direction of the camera.
+	/// @param direction Desired forward direction. Needs to be normalized.
 	/// @param up Up vector, how the camera is oriented. Typically (0, 1, 0).
 	template<typename T, qualifier Q>
 	GLM_FUNC_DECL tquat<T, Q> quatLookAt(
@@ -194,7 +194,7 @@ namespace glm
 
 	/// Build a right-handed look at quaternion.
 	///
-	/// @param direction Desired direction of the camera.
+	/// @param direction Desired forward direction onto which the -z-axis gets mapped. Needs to be normalized.
 	/// @param up Up vector, how the camera is oriented. Typically (0, 1, 0).
 	template<typename T, qualifier Q>
 	GLM_FUNC_DECL tquat<T, Q> quatLookAtRH(
@@ -203,7 +203,7 @@ namespace glm
 
 	/// Build a left-handed look at quaternion.
 	///
-	/// @param direction Desired direction onto which the +z-axis gets mapped
+	/// @param direction Desired forward direction onto which the +z-axis gets mapped. Needs to be normalized.
 	/// @param up Up vector, how the camera is oriented. Typically (0, 1, 0).
 	template<typename T, qualifier Q>
 	GLM_FUNC_DECL tquat<T, Q> quatLookAtLH(

--- a/glm/gtx/quaternion.inl
+++ b/glm/gtx/quaternion.inl
@@ -230,7 +230,7 @@ namespace glm
 	{
 		mat<3, 3, T, Q> Result;
 
-		Result[2] = -normalize(direction);
+		Result[2] = -direction;
 		Result[0] = normalize(cross(up, Result[2]));
 		Result[1] = cross(Result[2], Result[0]);
 
@@ -242,7 +242,7 @@ namespace glm
 	{
 		mat<3, 3, T, Q> Result;
 
-		Result[2] = normalize(direction);
+		Result[2] = direction;
 		Result[0] = normalize(cross(up, Result[2]));
 		Result[1] = cross(Result[2], Result[0]);
 

--- a/test/gtx/gtx_quaternion.cpp
+++ b/test/gtx/gtx_quaternion.cpp
@@ -101,7 +101,7 @@ int test_quat_lookAt()
 	glm::vec3 center(1.1f, -2.0f, 3.1416f);
 	glm::vec3 up = glm::vec3(-0.17f, 7.23f, -1.744f);
 
-	glm::quat test_quat = glm::quatLookAt(center - eye, up);
+	glm::quat test_quat = glm::quatLookAt(glm::normalize(center - eye), up);
 	glm::quat test_mat = glm::conjugate(glm::quat_cast(glm::lookAt(eye, center, up)));
 
 	Error += static_cast<int>(glm::abs(glm::length(test_quat) - 1.0f) > glm::epsilon<float>());

--- a/test/gtx/gtx_quaternion.cpp
+++ b/test/gtx/gtx_quaternion.cpp
@@ -99,7 +99,7 @@ int test_quat_lookAt()
 
 	glm::vec3 eye(0.0f);
 	glm::vec3 center(1.1f, -2.0f, 3.1416f);
-	glm::vec3 up = glm::vec3(-0.17f, 7.23f, -1.744f);
+	glm::vec3 up(-0.17f, 7.23f, -1.744f);
 
 	glm::quat test_quat = glm::quatLookAt(glm::normalize(center - eye), up);
 	glm::quat test_mat = glm::conjugate(glm::quat_cast(glm::lookAt(eye, center, up)));


### PR DESCRIPTION
As mentioned by @stfx, users of the quaternion look at function might already have a normalized input direction at hand and would therefore not want the unnecessary additional normalization inside quatLookAt. In that light, I'd like to put the heavy burden of providing normalized input in the user's hands.

The rotation given by the unit quaternion quatLookAt(normalize(center - eye), up) would now be the equivalent to the inverse of the rotational part of lookAt(eye, center, up).