### PR TITLE
Fix exp2 precision with cxx11

### DIFF
--- a/glm/detail/func_exponential.inl
+++ b/glm/detail/func_exponential.inl
@@ -90,6 +90,9 @@ namespace detail
 		return detail::functor1<L, T, T, Q>::call(log, x);
 	}
 
+#   if GLM_HAS_CXX11_STL
+    using std::exp2;
+#   else
 	//exp2, ln2 = 0.69314718055994530941723212145818f
 	template<typename genType>
 	GLM_FUNC_QUALIFIER genType exp2(genType x)
@@ -98,6 +101,7 @@ namespace detail
 
 		return std::exp(static_cast<genType>(0.69314718055994530941723212145818) * x);
 	}
+#   endif
 
 	template<length_t L, typename T, qualifier Q>
 	GLM_FUNC_QUALIFIER vec<L, T, Q> exp2(vec<L, T, Q> const& x)

--- a/test/core/core_func_exponential.cpp
+++ b/test/core/core_func_exponential.cpp
@@ -113,6 +113,12 @@ static int test_exp2()
 	glm::vec4 E = glm::exp2(glm::vec4(4.f, 3.f, 2.f, 1.f));
 	Error += glm::all(glm::epsilonEqual(E, glm::vec4(16.f, 8.f, 4.f, 2.f), 0.01f)) ? 0 : 1;
 
+#   if GLM_HAS_CXX11_STL
+    //large exponent
+    float F = glm::exp2(23.f);
+    Error += glm::epsilonEqual(F, 8388608.f, 0.01f) ? 0 : 1;
+#   endif
+    
 	return Error;
 }
 


### PR DESCRIPTION
Hi all,

when developing a GLSL shader prototype with glm, I hit a bug with larger integer exponents in glm::exp2. The results were just imprecise. The reason is that glm::exp2 is currently implemented by exp and then a multiplication with a constants. With larger numbers, this leads to precision problems. In C++11 there is std::exp2 which can be used and seems to be precise (at least on xcode8).

There is also a exp2f in C99 but I didn't find the appropriate feature define and I didn't want to start messing with your build system.

Regards,
Kai