### PR TITLE
Quaternion subtraction and minor changes to quatLookAt

### DIFF
--- a/glm/gtc/matrix_transform.hpp
+++ b/glm/gtc/matrix_transform.hpp
@@ -702,7 +702,7 @@ namespace glm
 	///
 	/// @param eye Position of the camera
 	/// @param center Position where the camera is looking at
-	/// @param up Normalized up vector, how the camera is oriented. Typically (0, 0, 1)
+	/// @param up Normalized up vector, how the camera is oriented. Typically (0, 1, 0)
 	/// @see gtc_matrix_transform
 	/// @see - frustum(T const& left, T const& right, T const& bottom, T const& top, T const& nearVal, T const& farVal) frustum(T const& left, T const& right, T const& bottom, T const& top, T const& nearVal, T const& farVal)
 	template<typename T, qualifier Q>
@@ -713,7 +713,7 @@ namespace glm
 	///
 	/// @param eye Position of the camera
 	/// @param center Position where the camera is looking at
-	/// @param up Normalized up vector, how the camera is oriented. Typically (0, 0, 1)
+	/// @param up Normalized up vector, how the camera is oriented. Typically (0, 1, 0)
 	/// @see gtc_matrix_transform
 	/// @see - frustum(T const& left, T const& right, T const& bottom, T const& top, T const& nearVal, T const& farVal) frustum(T const& left, T const& right, T const& bottom, T const& top, T const& nearVal, T const& farVal)
 	/// @see <a href="https://www.khronos.org/registry/OpenGL-Refpages/gl2.1/xhtml/gluLookAt.xml">gluLookAt man page</a> 

--- a/glm/gtc/quaternion.hpp
+++ b/glm/gtc/quaternion.hpp
@@ -143,6 +143,9 @@ namespace glm
 	GLM_FUNC_DECL tquat<T, Q> operator+(tquat<T, Q> const& q, tquat<T, Q> const& p);
 
 	template<typename T, qualifier Q>
+	GLM_FUNC_DECL tquat<T, Q> operator-(tquat<T, Q> const& q, tquat<T, Q> const& p);
+
+	template<typename T, qualifier Q>
 	GLM_FUNC_DECL tquat<T, Q> operator*(tquat<T, Q> const& q, tquat<T, Q> const& p);
 
 	template<typename T, qualifier Q>

--- a/glm/gtc/quaternion.inl
+++ b/glm/gtc/quaternion.inl
@@ -308,7 +308,6 @@ namespace detail
 		return tquat<T, Q>(q) += p;
 	}
 
-
 	template<typename T, qualifier Q>
 	GLM_FUNC_QUALIFIER tquat<T, Q> operator-(tquat<T, Q> const& q, tquat<T, Q> const& p)
 	{

--- a/glm/gtc/quaternion.inl
+++ b/glm/gtc/quaternion.inl
@@ -308,6 +308,13 @@ namespace detail
 		return tquat<T, Q>(q) += p;
 	}
 
+
+	template<typename T, qualifier Q>
+	GLM_FUNC_QUALIFIER tquat<T, Q> operator-(tquat<T, Q> const& q, tquat<T, Q> const& p)
+	{
+		return tquat<T, Q>(q) -= p;
+	}
+
 	template<typename T, qualifier Q>
 	GLM_FUNC_QUALIFIER tquat<T, Q> operator*(tquat<T, Q> const& q, tquat<T, Q> const& p)
 	{

--- a/glm/gtx/quaternion.inl
+++ b/glm/gtx/quaternion.inl
@@ -232,9 +232,9 @@ namespace glm
 	{
 		mat<3, 3, T, Q> Result;
 
-		Result[2] = -direction;
-		Result[0] = normalize(cross(up, Result[2]));
-		Result[1] = cross(Result[2], Result[0]);
+		Result[0] = normalize(cross(direction, up));	// new right
+		Result[1] = cross(Result[0], direction);		// new up
+		Result[2] = -direction;							// new forward
 
 		return quat_cast(Result);
 	}
@@ -244,9 +244,9 @@ namespace glm
 	{
 		mat<3, 3, T, Q> Result;
 
-		Result[2] = direction;
-		Result[0] = normalize(cross(up, Result[2]));
-		Result[1] = cross(Result[2], Result[0]);
+		Result[0] = normalize(cross(up, direction));		// new right
+		Result[1] = cross(direction, Result[0]);		// new up
+		Result[2] = direction;							// new forward			
 
 		return quat_cast(Result);
 	}

--- a/glm/gtx/quaternion.inl
+++ b/glm/gtx/quaternion.inl
@@ -232,11 +232,11 @@ namespace glm
 	{
 		mat<3, 3, T, Q> result;
 
-		result[0] = normalize(cross(direction, up));	// new right
-		result[1] = cross(result[0], direction);	// new up
-		result[2] = -direction;				// new forward
+		result[0] = normalize(cross(direction, up));
+		result[1] = cross(result[0], direction);
+		result[2] = -direction;
 
-		return quat_cast(Result);
+		return quat_cast(result);
 	}
 
 	template<typename T, qualifier Q>
@@ -244,9 +244,9 @@ namespace glm
 	{
 		mat<3, 3, T, Q> result;
 
-		result[0] = normalize(cross(up, direction));		// new right
-		result[1] = cross(direction, result[0]);		// new up
-		result[2] = direction;					// new forward			
+		result[0] = normalize(cross(up, direction));
+		result[1] = cross(direction, result[0]);
+		result[2] = direction;			
 
 		return quat_cast(result);
 	}

--- a/glm/gtx/quaternion.inl
+++ b/glm/gtx/quaternion.inl
@@ -246,7 +246,7 @@ namespace glm
 
 		result[0] = normalize(cross(up, direction));
 		result[1] = cross(direction, result[0]);
-		result[2] = direction;			
+		result[2] = direction;
 
 		return quat_cast(result);
 	}

--- a/glm/gtx/quaternion.inl
+++ b/glm/gtx/quaternion.inl
@@ -230,11 +230,11 @@ namespace glm
 	template<typename T, qualifier Q>
 	GLM_FUNC_QUALIFIER tquat<T, Q> quatLookAtRH(vec<3, T, Q> const& direction, vec<3, T, Q> const& up)
 	{
-		mat<3, 3, T, Q> Result;
+		mat<3, 3, T, Q> result;
 
-		Result[0] = normalize(cross(direction, up));	// new right
-		Result[1] = cross(Result[0], direction);		// new up
-		Result[2] = -direction;							// new forward
+		result[0] = normalize(cross(direction, up));	// new right
+		result[1] = cross(result[0], direction);	// new up
+		result[2] = -direction;				// new forward
 
 		return quat_cast(Result);
 	}
@@ -242,13 +242,13 @@ namespace glm
 	template<typename T, qualifier Q>
 	GLM_FUNC_QUALIFIER tquat<T, Q> quatLookAtLH(vec<3, T, Q> const& direction, vec<3, T, Q> const& up)
 	{
-		mat<3, 3, T, Q> Result;
+		mat<3, 3, T, Q> result;
 
-		Result[0] = normalize(cross(up, direction));		// new right
-		Result[1] = cross(direction, Result[0]);		// new up
-		Result[2] = direction;							// new forward			
+		result[0] = normalize(cross(up, direction));		// new right
+		result[1] = cross(direction, result[0]);		// new up
+		result[2] = direction;					// new forward			
 
-		return quat_cast(Result);
+		return quat_cast(result);
 	}
 
 }//namespace glm

--- a/test/gtx/gtx_quaternion.cpp
+++ b/test/gtx/gtx_quaternion.cpp
@@ -105,13 +105,13 @@ int test_quat_lookAt()
 	glm::quat test_quat_LH = glm::quatLookAtLH(glm::normalize(center - eye), up);
 	glm::quat test_mat_LH = glm::conjugate(glm::quat_cast(glm::lookAtLH(eye, center, up)));
 	Error += static_cast<int>(glm::abs(glm::length(test_quat_LH) - 1.0f) > glm::epsilon<float>());
-	Error += static_cast<int>(glm::min(glm::length(test_quat_LH + (-test_mat_LH)), glm::length(test_quat_LH + test_mat_RH)) > glm::epsilon<float>());
+	Error += static_cast<int>(glm::min(glm::length(test_quat_LH - test_mat_LH), glm::length(test_quat_LH + test_mat_RH)) > glm::epsilon<float>());
 
 	// Test right-handed implementation
 	glm::quat test_quat_RH = glm::quatLookAtRH(glm::normalize(center - eye), up);
 	glm::quat test_mat_RH = glm::conjugate(glm::quat_cast(glm::lookAtRH(eye, center, up)));
 	Error += static_cast<int>(glm::abs(glm::length(test_quat_RH) - 1.0f) > glm::epsilon<float>());
-	Error += static_cast<int>(glm::min(glm::length(test_quat_RH + (-test_mat_RH)), glm::length(test_quat_RH + test_mat_RH)) > glm::epsilon<float>());
+	Error += static_cast<int>(glm::min(glm::length(test_quat_RH - test_mat_RH), glm::length(test_quat_RH + test_mat_RH)) > glm::epsilon<float>());
 	
 	return Error;
 }

--- a/test/gtx/gtx_quaternion.cpp
+++ b/test/gtx/gtx_quaternion.cpp
@@ -105,7 +105,7 @@ int test_quat_lookAt()
 	glm::quat test_quat_LH = glm::quatLookAtLH(glm::normalize(center - eye), up);
 	glm::quat test_mat_LH = glm::conjugate(glm::quat_cast(glm::lookAtLH(eye, center, up)));
 	Error += static_cast<int>(glm::abs(glm::length(test_quat_LH) - 1.0f) > glm::epsilon<float>());
-	Error += static_cast<int>(glm::min(glm::length(test_quat_LH - test_mat_LH), glm::length(test_quat_LH + test_mat_RH)) > glm::epsilon<float>());
+	Error += static_cast<int>(glm::min(glm::length(test_quat_LH - test_mat_LH), glm::length(test_quat_LH + test_mat_LH)) > glm::epsilon<float>());
 
 	// Test right-handed implementation
 	glm::quat test_quat_RH = glm::quatLookAtRH(glm::normalize(center - eye), up);

--- a/test/gtx/gtx_quaternion.cpp
+++ b/test/gtx/gtx_quaternion.cpp
@@ -101,12 +101,18 @@ int test_quat_lookAt()
 	glm::vec3 center(1.1f, -2.0f, 3.1416f);
 	glm::vec3 up(-0.17f, 7.23f, -1.744f);
 
-	glm::quat test_quat = glm::quatLookAt(glm::normalize(center - eye), up);
-	glm::quat test_mat = glm::conjugate(glm::quat_cast(glm::lookAt(eye, center, up)));
+	// Test left-handed implementation
+	glm::quat test_quat_LH = glm::quatLookAtLH(glm::normalize(center - eye), up);
+	glm::quat test_mat_LH = glm::conjugate(glm::quat_cast(glm::lookAtLH(eye, center, up)));
+	Error += static_cast<int>(glm::abs(glm::length(test_quat_LH) - 1.0f) > glm::epsilon<float>());
+	Error += static_cast<int>(glm::min(glm::length(test_quat_LH + (-test_mat_LH)), glm::length(test_quat_LH + test_mat_RH)) > glm::epsilon<float>());
 
-	Error += static_cast<int>(glm::abs(glm::length(test_quat) - 1.0f) > glm::epsilon<float>());
-	Error += static_cast<int>(glm::min(glm::length(test_quat + (-test_mat)), glm::length(test_quat + test_mat)) > glm::epsilon<float>());
-
+	// Test right-handed implementation
+	glm::quat test_quat_RH = glm::quatLookAtRH(glm::normalize(center - eye), up);
+	glm::quat test_mat_RH = glm::conjugate(glm::quat_cast(glm::lookAtRH(eye, center, up)));
+	Error += static_cast<int>(glm::abs(glm::length(test_quat_RH) - 1.0f) > glm::epsilon<float>());
+	Error += static_cast<int>(glm::min(glm::length(test_quat_RH + (-test_mat_RH)), glm::length(test_quat_RH + test_mat_RH)) > glm::epsilon<float>());
+	
 	return Error;
 }
 


### PR DESCRIPTION
- Added binary quaternion subtraction to /gtc/quaternion, which seems to have been flying under the radar for a while.
- Fixed a minor typo in the description of the matrix lookAt function in /gtc/matrix_transform.hpp
- quatLookAt: changed the order how the orthogonal matrix is constructed within the function, which is probably the micro-optimisation @stfx had in mind with his pull request. Now we traverse the array of column vectors in a linear fashion. This should make a bit more sense to the reader and maybe to the compilers as well.
- Test: now it compares both the left and right handed implementations with their respective matrix siblings. Before it only tested the right-handed implementation.