### PR TITLE
Remove redundant specializations of `glm::type` for `glm::mat`s and some accompanying cleanup.

### DIFF
--- a/glm/gtx/type_trait.hpp
+++ b/glm/gtx/type_trait.hpp
@@ -47,10 +47,7 @@ namespace glm
 		static bool const is_vec = true;
 		static bool const is_mat = false;
 		static bool const is_quat = false;
-		enum
-		{
-			components = L
-		};
+		static length_t const components = L;
 	};
 
 	template<length_t C, length_t R, typename T, qualifier Q>
@@ -70,10 +67,7 @@ namespace glm
 		static bool const is_vec = false;
 		static bool const is_mat = false;
 		static bool const is_quat = true;
-		enum
-		{
-			components = 4
-		};
+		static length_t const components = 4;
 	};
 
 	template<typename T, qualifier Q>
@@ -82,10 +76,7 @@ namespace glm
 		static bool const is_vec = false;
 		static bool const is_mat = false;
 		static bool const is_quat = true;
-		enum
-		{
-			components = 8
-		};
+		static length_t const components = 8;
 	};
 
 	/// @}

--- a/glm/gtx/type_trait.hpp
+++ b/glm/gtx/type_trait.hpp
@@ -17,18 +17,7 @@
 #endif
 
 // Dependency:
-#include "../detail/type_vec2.hpp"
-#include "../detail/type_vec3.hpp"
-#include "../detail/type_vec4.hpp"
-#include "../detail/type_mat2x2.hpp"
-#include "../detail/type_mat2x3.hpp"
-#include "../detail/type_mat2x4.hpp"
-#include "../detail/type_mat3x2.hpp"
-#include "../detail/type_mat3x3.hpp"
-#include "../detail/type_mat3x4.hpp"
-#include "../detail/type_mat4x2.hpp"
-#include "../detail/type_mat4x3.hpp"
-#include "../detail/type_mat4x4.hpp"
+#include "../detail/qualifier.hpp"
 #include "../gtc/quaternion.hpp"
 #include "../gtx/dual_quaternion.hpp"
 
@@ -64,130 +53,15 @@ namespace glm
 		};
 	};
 
-	template<typename T, qualifier Q>
-	struct type<mat<2, 2, T, Q> >
+	template<length_t C, length_t R, typename T, qualifier Q>
+	struct type<mat<C, R, T, Q> >
 	{
 		static bool const is_vec = false;
 		static bool const is_mat = true;
 		static bool const is_quat = false;
-		enum
-		{
-			components = 2,
-			cols = 2,
-			rows = 2
-		};
-	};
-
-	template<typename T, qualifier Q>
-	struct type<mat<2, 3, T, Q> >
-	{
-		static bool const is_vec = false;
-		static bool const is_mat = true;
-		static bool const is_quat = false;
-		enum
-		{
-			components = 2,
-			cols = 2,
-			rows = 3
-		};
-	};
-
-	template<typename T, qualifier Q>
-	struct type<mat<2, 4, T, Q> >
-	{
-		static bool const is_vec = false;
-		static bool const is_mat = true;
-		static bool const is_quat = false;
-		enum
-		{
-			components = 2,
-			cols = 2,
-			rows = 4
-		};
-	};
-
-	template<typename T, qualifier Q>
-	struct type<mat<3, 2, T, Q> >
-	{
-		static bool const is_vec = false;
-		static bool const is_mat = true;
-		static bool const is_quat = false;
-		enum
-		{
-			components = 3,
-			cols = 3,
-			rows = 2
-		};
-	};
-
-	template<typename T, qualifier Q>
-	struct type<mat<3, 3, T, Q> >
-	{
-		static bool const is_vec = false;
-		static bool const is_mat = true;
-		static bool const is_quat = false;
-		enum
-		{
-			components = 3,
-			cols = 3,
-			rows = 3
-		};
-	};
-
-	template<typename T, qualifier Q>
-	struct type<mat<3, 4, T, Q> >
-	{
-		static bool const is_vec = false;
-		static bool const is_mat = true;
-		static bool const is_quat = false;
-		enum
-		{
-			components = 3,
-			cols = 3,
-			rows = 4
-		};
-	};
-
-	template<typename T, qualifier Q>
-	struct type<mat<4, 2, T, Q> >
-	{
-		static bool const is_vec = false;
-		static bool const is_mat = true;
-		static bool const is_quat = false;
-		enum
-		{
-			components = 4,
-			cols = 4,
-			rows = 2
-		};
-	};
-
-	template<typename T, qualifier Q>
-	struct type<mat<4, 3, T, Q> >
-	{
-		static bool const is_vec = false;
-		static bool const is_mat = true;
-		static bool const is_quat = false;
-		enum
-		{
-			components = 4,
-			cols = 4,
-			rows = 3
-		};
-	};
-
-	template<typename T, qualifier Q>
-	struct type<mat<4, 4, T, Q> >
-	{
-		static bool const is_vec = false;
-		static bool const is_mat = true;
-		static bool const is_quat = false;
-		enum
-		{
-			components = 4,
-			cols = 4,
-			rows = 4
-		};
+		static length_t const components = C;
+		static length_t const cols = C;
+		static length_t const rows = R;
 	};
 
 	template<typename T, qualifier Q>


### PR DESCRIPTION
`glm::type` was specialized for every possible size of `glm::mat`, event though generalization is straightforward and trivial. Apparently this was missed when `glm::tmatNxM`s were replaced with `glm::mat`.