### PR TITLE
made mat::col_type value[] public

### DIFF
--- a/glm/detail/type_mat2x2.hpp
+++ b/glm/detail/type_mat2x2.hpp
@@ -20,7 +20,6 @@ namespace glm
 		typedef mat<2, 2, T, Q> transpose_type;
 		typedef T value_type;
 
-	private:
 		col_type value[2];
 
 	public:

--- a/glm/detail/type_mat2x3.hpp
+++ b/glm/detail/type_mat2x3.hpp
@@ -21,7 +21,6 @@ namespace glm
 		typedef mat<3, 2, T, Q> transpose_type;
 		typedef T value_type;
 
-	private:
 		col_type value[2];
 
 	public:

--- a/glm/detail/type_mat2x4.hpp
+++ b/glm/detail/type_mat2x4.hpp
@@ -21,7 +21,6 @@ namespace glm
 		typedef mat<4, 2, T, Q> transpose_type;
 		typedef T value_type;
 
-	private:
 		col_type value[2];
 
 	public:

--- a/glm/detail/type_mat3x2.hpp
+++ b/glm/detail/type_mat3x2.hpp
@@ -21,7 +21,6 @@ namespace glm
 		typedef mat<2, 3, T, Q> transpose_type;
 		typedef T value_type;
 
-	private:
 		col_type value[3];
 
 	public:

--- a/glm/detail/type_mat3x3.hpp
+++ b/glm/detail/type_mat3x3.hpp
@@ -20,7 +20,6 @@ namespace glm
 		typedef mat<3, 3, T, Q> transpose_type;
 		typedef T value_type;
 
-	private:
 		col_type value[3];
 
 	public:

--- a/glm/detail/type_mat3x4.hpp
+++ b/glm/detail/type_mat3x4.hpp
@@ -21,7 +21,6 @@ namespace glm
 		typedef mat<4, 3, T, Q> transpose_type;
 		typedef T value_type;
 
-	private:
 		col_type value[3];
 
 	public:

--- a/glm/detail/type_mat4x2.hpp
+++ b/glm/detail/type_mat4x2.hpp
@@ -21,7 +21,6 @@ namespace glm
 		typedef mat<2, 4, T, Q> transpose_type;
 		typedef T value_type;
 
-	private:
 		col_type value[4];
 
 	public:

--- a/glm/detail/type_mat4x3.hpp
+++ b/glm/detail/type_mat4x3.hpp
@@ -21,7 +21,6 @@ namespace glm
 		typedef mat<3, 4, T, Q> transpose_type;
 		typedef T value_type;
 
-	private:
 		col_type value[4];
 
 	public:

--- a/glm/detail/type_mat4x4.hpp
+++ b/glm/detail/type_mat4x4.hpp
@@ -20,7 +20,6 @@ namespace glm
 		typedef mat<4, 4, T, Q> transpose_type;
 		typedef T value_type;
 
-	private:
 		col_type value[4];
 
 	public:


### PR DESCRIPTION
Hi,

here's a small change that makes mat<>::col_type mat<>::value[] public.

Reason, in certain use cases, i.e. when writing a file format parser using Boost.Spirit.X3, it requires way less code to move the parsed data into a mat structure when the value[] is public.

Out of curiosity, what was the rationale behind making that variable private?

Regards.