### PR TITLE
Small consistency change

### DIFF
--- a/glm/detail/type_vec4.hpp
+++ b/glm/detail/type_vec4.hpp
@@ -281,7 +281,7 @@ namespace glm
 	// -- Binary operators --
 
 	template<typename T, qualifier Q>
-	GLM_FUNC_DECL vec<4, T, Q> operator+(vec<4, T, Q> const& v, T scalar);
+	GLM_FUNC_DECL vec<4, T, Q> operator+(vec<4, T, Q> const& v, T const & scalar);
 
 	template<typename T, qualifier Q>
 	GLM_FUNC_DECL vec<4, T, Q> operator+(vec<4, T, Q> const& v1, vec<1, T, Q> const& v2);
@@ -296,7 +296,7 @@ namespace glm
 	GLM_FUNC_DECL vec<4, T, Q> operator+(vec<4, T, Q> const& v1, vec<4, T, Q> const& v2);
 
 	template<typename T, qualifier Q>
-	GLM_FUNC_DECL vec<4, T, Q> operator-(vec<4, T, Q> const& v, T scalar);
+	GLM_FUNC_DECL vec<4, T, Q> operator-(vec<4, T, Q> const& v, T const & scalar);
 
 	template<typename T, qualifier Q>
 	GLM_FUNC_DECL vec<4, T, Q> operator-(vec<4, T, Q> const& v1, vec<1, T, Q> const& v2);
@@ -311,7 +311,7 @@ namespace glm
 	GLM_FUNC_DECL vec<4, T, Q> operator-(vec<4, T, Q> const& v1, vec<4, T, Q> const& v2);
 
 	template<typename T, qualifier Q>
-	GLM_FUNC_DECL vec<4, T, Q> operator*(vec<4, T, Q> const& v, T scalar);
+	GLM_FUNC_DECL vec<4, T, Q> operator*(vec<4, T, Q> const& v, T const & scalar);
 
 	template<typename T, qualifier Q>
 	GLM_FUNC_DECL vec<4, T, Q> operator*(vec<4, T, Q> const& v1, vec<1, T, Q> const& v2);
@@ -326,7 +326,7 @@ namespace glm
 	GLM_FUNC_DECL vec<4, T, Q> operator*(vec<4, T, Q> const& v1, vec<4, T, Q> const& v2);
 
 	template<typename T, qualifier Q>
-	GLM_FUNC_DECL vec<4, T, Q> operator/(vec<4, T, Q> const& v, T scalar);
+	GLM_FUNC_DECL vec<4, T, Q> operator/(vec<4, T, Q> const& v, T const & scalar);
 
 	template<typename T, qualifier Q>
 	GLM_FUNC_DECL vec<4, T, Q> operator/(vec<4, T, Q> const& v1, vec<1, T, Q> const& v2);

--- a/glm/detail/type_vec4.inl
+++ b/glm/detail/type_vec4.inl
@@ -627,7 +627,7 @@ namespace detail
 	// -- Binary arithmetic operators --
 
 	template<typename T, qualifier Q>
-	GLM_FUNC_QUALIFIER vec<4, T, Q> operator+(vec<4, T, Q> const& v, T scalar)
+	GLM_FUNC_QUALIFIER vec<4, T, Q> operator+(vec<4, T, Q> const& v, T const & scalar)
 	{
 		return vec<4, T, Q>(v) += scalar;
 	}

--- a/glm/detail/type_vec4.inl
+++ b/glm/detail/type_vec4.inl
@@ -657,7 +657,7 @@ namespace detail
 	}
 
 	template<typename T, qualifier Q>
-	GLM_FUNC_QUALIFIER vec<4, T, Q> operator-(vec<4, T, Q> const& v, T scalar)
+	GLM_FUNC_QUALIFIER vec<4, T, Q> operator-(vec<4, T, Q> const& v, T const & scalar)
 	{
 		return vec<4, T, Q>(v) -= scalar;
 	}
@@ -687,7 +687,7 @@ namespace detail
 	}
 
 	template<typename T, qualifier Q>
-	GLM_FUNC_QUALIFIER vec<4, T, Q> operator*(vec<4, T, Q> const& v, T scalar)
+	GLM_FUNC_QUALIFIER vec<4, T, Q> operator*(vec<4, T, Q> const& v, T const & scalar)
 	{
 		return vec<4, T, Q>(v) *= scalar;
 	}
@@ -717,7 +717,7 @@ namespace detail
 	}
 
 	template<typename T, qualifier Q>
-	GLM_FUNC_QUALIFIER vec<4, T, Q> operator/(vec<4, T, Q> const& v, T scalar)
+	GLM_FUNC_QUALIFIER vec<4, T, Q> operator/(vec<4, T, Q> const& v, T const & scalar)
 	{
 		return vec<4, T, Q>(v) /= scalar;
 	}


### PR DESCRIPTION
I noticed while working on my project that the binary operators for scalars on tvec4 didn't have const & like tvec2 and tvec3 do. So I added them for consistency reasons. 