### PR TITLE
Extension for Euler angles

### DIFF
--- a/glm/gtx/euler_angles.hpp
+++ b/glm/gtx/euler_angles.hpp
@@ -9,6 +9,9 @@
 /// Include <glm/gtx/euler_angles.hpp> to use the features of this extension.
 ///
 /// Build matrices from Euler angles.
+///
+/// Extraction of Euler angles from rotation matrix.
+/// Based on the original paper 2014 Mike Day - Extracting Euler Angles from a Rotation Matrix.
 
 #pragma once
 
@@ -238,6 +241,94 @@ namespace glm
                                             T & t2,
                                             T & t3);
     
+	/// Extracts the (Y * X * Z) Euler angles from the rotation matrix M
+	/// @see gtx_euler_angles
+	template <typename T>
+	GLM_FUNC_DECL void extractEulerAngleYXZ(mat<4, 4, T, defaultp> const & M,
+											T & t1,
+											T & t2,
+											T & t3);
+
+	/// Extracts the (X * Z * X) Euler angles from the rotation matrix M
+	/// @see gtx_euler_angles
+	template <typename T>
+	GLM_FUNC_DECL void extractEulerAngleXZX(mat<4, 4, T, defaultp> const & M,
+											T & t1,
+											T & t2,
+											T & t3);
+
+	/// Extracts the (X * Y * X) Euler angles from the rotation matrix M
+	/// @see gtx_euler_angles
+	template <typename T>
+	GLM_FUNC_DECL void extractEulerAngleXYX(mat<4, 4, T, defaultp> const & M,
+											T & t1,
+											T & t2,
+											T & t3);
+
+	/// Extracts the (Y * X * Y) Euler angles from the rotation matrix M
+	/// @see gtx_euler_angles
+	template <typename T>
+	GLM_FUNC_DECL void extractEulerAngleYXY(mat<4, 4, T, defaultp> const & M,
+											T & t1,
+											T & t2,
+											T & t3);
+
+	/// Extracts the (Y * Z * Y) Euler angles from the rotation matrix M
+	/// @see gtx_euler_angles
+	template <typename T>
+	GLM_FUNC_DECL void extractEulerAngleYZY(mat<4, 4, T, defaultp> const & M,
+											T & t1,
+											T & t2,
+											T & t3);
+
+	/// Extracts the (Z * Y * Z) Euler angles from the rotation matrix M
+	/// @see gtx_euler_angles
+	template <typename T>
+	GLM_FUNC_DECL void extractEulerAngleZYZ(mat<4, 4, T, defaultp> const & M,
+											T & t1,
+											T & t2,
+											T & t3);
+
+	/// Extracts the (Z * X * Z) Euler angles from the rotation matrix M
+	/// @see gtx_euler_angles
+	template <typename T>
+	GLM_FUNC_DECL void extractEulerAngleZXZ(mat<4, 4, T, defaultp> const & M,
+											T & t1,
+											T & t2,
+											T & t3);
+
+	/// Extracts the (X * Z * Y) Euler angles from the rotation matrix M
+	/// @see gtx_euler_angles
+	template <typename T>
+	GLM_FUNC_DECL void extractEulerAngleXZY(mat<4, 4, T, defaultp> const & M,
+											T & t1,
+											T & t2,
+											T & t3);
+
+	/// Extracts the (Y * Z * X) Euler angles from the rotation matrix M
+	/// @see gtx_euler_angles
+	template <typename T>
+	GLM_FUNC_DECL void extractEulerAngleYZX(mat<4, 4, T, defaultp> const & M,
+											T & t1,
+											T & t2,
+											T & t3);
+
+	/// Extracts the (Z * Y * X) Euler angles from the rotation matrix M
+	/// @see gtx_euler_angles
+	template <typename T>
+	GLM_FUNC_DECL void extractEulerAngleZYX(mat<4, 4, T, defaultp> const & M,
+											T & t1,
+											T & t2,
+											T & t3);
+
+	/// Extracts the (Z * X * Y) Euler angles from the rotation matrix M
+	/// @see gtx_euler_angles
+	template <typename T>
+	GLM_FUNC_DECL void extractEulerAngleZXY(mat<4, 4, T, defaultp> const & M,
+											T & t1,
+											T & t2,
+											T & t3);
+
 	/// @}
 }//namespace glm
 

--- a/glm/gtx/euler_angles.hpp
+++ b/glm/gtx/euler_angles.hpp
@@ -46,6 +46,24 @@ namespace glm
 	GLM_FUNC_DECL mat<4, 4, T, defaultp> eulerAngleZ(
 		T const& angleZ);
 
+	/// Creates a 3D 4 * 4 homogeneous derived matrix from the rotation matrix about X-axis.
+	/// @see gtx_euler_angles
+	template <typename T>
+	GLM_FUNC_DECL mat<4, 4, T, defaultp> derivedEulerAngleX(
+		T const & angleX, T const & angularVelocityX);
+
+	/// Creates a 3D 4 * 4 homogeneous derived matrix from the rotation matrix about Y-axis.
+	/// @see gtx_euler_angles
+	template <typename T>
+	GLM_FUNC_DECL mat<4, 4, T, defaultp> derivedEulerAngleY(
+		T const & angleY, T const & angularVelocityY);
+
+	/// Creates a 3D 4 * 4 homogeneous derived matrix from the rotation matrix about Z-axis.
+	/// @see gtx_euler_angles
+	template <typename T>
+	GLM_FUNC_DECL mat<4, 4, T, defaultp> derivedEulerAngleZ(
+		T const & angleZ, T const & angularVelocityZ);
+
 	/// Creates a 3D 4 * 4 homogeneous rotation matrix from euler angles (X * Y).
 	/// @see gtx_euler_angles
 	template<typename T>

--- a/glm/gtx/euler_angles.hpp
+++ b/glm/gtx/euler_angles.hpp
@@ -122,6 +122,86 @@ namespace glm
 		T const& pitch,
 		T const& roll);
     
+	/// Creates a 3D 4 * 4 homogeneous rotation matrix from euler angles (X * Z * X).
+	/// @see gtx_euler_angles
+	template <typename T>
+	GLM_FUNC_DECL mat<4, 4, T, defaultp> eulerAngleXZX(
+		T const & t1,
+		T const & t2,
+		T const & t3);
+
+	/// Creates a 3D 4 * 4 homogeneous rotation matrix from euler angles (X * Y * X).
+	/// @see gtx_euler_angles
+	template <typename T>
+	GLM_FUNC_DECL mat<4, 4, T, defaultp> eulerAngleXYX(
+		T const & t1,
+		T const & t2,
+		T const & t3);
+
+	/// Creates a 3D 4 * 4 homogeneous rotation matrix from euler angles (Y * X * Y).
+	/// @see gtx_euler_angles
+	template <typename T>
+	GLM_FUNC_DECL mat<4, 4, T, defaultp> eulerAngleYXY(
+		T const & t1,
+		T const & t2,
+		T const & t3);
+
+	/// Creates a 3D 4 * 4 homogeneous rotation matrix from euler angles (Y * Z * Y).
+	/// @see gtx_euler_angles
+	template <typename T>
+	GLM_FUNC_DECL mat<4, 4, T, defaultp> eulerAngleYZY(
+		T const & t1,
+		T const & t2,
+		T const & t3);
+
+	/// Creates a 3D 4 * 4 homogeneous rotation matrix from euler angles (Z * Y * Z).
+	/// @see gtx_euler_angles
+	template <typename T>
+	GLM_FUNC_DECL mat<4, 4, T, defaultp> eulerAngleZYZ(
+		T const & t1,
+		T const & t2,
+		T const & t3);
+
+	/// Creates a 3D 4 * 4 homogeneous rotation matrix from euler angles (Z * X * Z).
+	/// @see gtx_euler_angles
+	template <typename T>
+	GLM_FUNC_DECL mat<4, 4, T, defaultp> eulerAngleZXZ(
+		T const & t1,
+		T const & t2,
+		T const & t3);
+
+	/// Creates a 3D 4 * 4 homogeneous rotation matrix from euler angles (X * Z * Y).
+	/// @see gtx_euler_angles
+	template <typename T>
+	GLM_FUNC_DECL mat<4, 4, T, defaultp> eulerAngleXZY(
+		T const & t1,
+		T const & t2,
+		T const & t3);
+
+	/// Creates a 3D 4 * 4 homogeneous rotation matrix from euler angles (Y * Z * X).
+	/// @see gtx_euler_angles
+	template <typename T>
+	GLM_FUNC_DECL mat<4, 4, T, defaultp> eulerAngleYZX(
+		T const & t1,
+		T const & t2,
+		T const & t3);
+
+	/// Creates a 3D 4 * 4 homogeneous rotation matrix from euler angles (Z * Y * X).
+	/// @see gtx_euler_angles
+	template <typename T>
+	GLM_FUNC_DECL mat<4, 4, T, defaultp> eulerAngleZYX(
+		T const & t1,
+		T const & t2,
+		T const & t3);
+
+	/// Creates a 3D 4 * 4 homogeneous rotation matrix from euler angles (Z * X * Y).
+	/// @see gtx_euler_angles
+	template <typename T>
+	GLM_FUNC_DECL mat<4, 4, T, defaultp> eulerAngleZXY(
+		T const & t1,
+		T const & t2,
+		T const & t3);
+
 	/// Creates a 3D 4 * 4 homogeneous rotation matrix from euler angles (Y * X * Z).
 	/// @see gtx_euler_angles
 	template<typename T>

--- a/glm/gtx/euler_angles.inl
+++ b/glm/gtx/euler_angles.inl
@@ -252,6 +252,356 @@ namespace glm
 		return Result;
 	}
 
+	template <typename T>
+	GLM_FUNC_QUALIFIER mat<4, 4, T, defaultp> eulerAngleXZX
+	(
+		T const & t1,
+		T const & t2,
+		T const & t3
+	)
+	{
+		T c1 = glm::cos(t1);
+		T s1 = glm::sin(t1);
+		T c2 = glm::cos(t2);
+		T s2 = glm::sin(t2);
+		T c3 = glm::cos(t3);
+		T s3 = glm::sin(t3);
+
+		mat<4, 4, T, defaultp> Result;
+		Result[0][0] = c2;
+		Result[0][1] = c1 * s2;
+		Result[0][2] = s1 * s2;
+		Result[0][3] = static_cast<T>(0);
+		Result[1][0] =-c3 * s2;
+		Result[1][1] = c1 * c2 * c3 - s1 * s3;
+		Result[1][2] = c1 * s3 + c2 * c3 * s1;
+		Result[1][3] = static_cast<T>(0);
+		Result[2][0] = s2 * s3;
+		Result[2][1] =-c3 * s1 - c1 * c2 * s3;
+		Result[2][2] = c1 * c3 - c2 * s1 * s3;
+		Result[2][3] = static_cast<T>(0);
+		Result[3][0] = static_cast<T>(0);
+		Result[3][1] = static_cast<T>(0);
+		Result[3][2] = static_cast<T>(0);
+		Result[3][3] = static_cast<T>(1);
+		return Result;
+	}
+
+	template <typename T>
+	GLM_FUNC_QUALIFIER mat<4, 4, T, defaultp> eulerAngleXYX
+	(
+		T const & t1,
+		T const & t2,
+		T const & t3
+	)
+	{
+		T c1 = glm::cos(t1);
+		T s1 = glm::sin(t1);
+		T c2 = glm::cos(t2);
+		T s2 = glm::sin(t2);
+		T c3 = glm::cos(t3);
+		T s3 = glm::sin(t3);
+
+		mat<4, 4, T, defaultp> Result;
+		Result[0][0] = c2;
+		Result[0][1] = s1 * s2;
+		Result[0][2] =-c1 * s2;
+		Result[0][3] = static_cast<T>(0);
+		Result[1][0] = s2 * s3;
+		Result[1][1] = c1 * c3 - c2 * s1 * s3;
+		Result[1][2] = c3 * s1 + c1 * c2 * s3;
+		Result[1][3] = static_cast<T>(0);
+		Result[2][0] = c3 * s2;
+		Result[2][1] =-c1 * s3 - c2 * c3 * s1;
+		Result[2][2] = c1 * c2 * c3 - s1 * s3;
+		Result[2][3] = static_cast<T>(0);
+		Result[3][0] = static_cast<T>(0);
+		Result[3][1] = static_cast<T>(0);
+		Result[3][2] = static_cast<T>(0);
+		Result[3][3] = static_cast<T>(1);
+		return Result;
+	}
+
+	template <typename T>
+	GLM_FUNC_QUALIFIER mat<4, 4, T, defaultp> eulerAngleYXY
+	(
+		T const & t1,
+		T const & t2,
+		T const & t3
+	)
+	{
+		T c1 = glm::cos(t1);
+		T s1 = glm::sin(t1);
+		T c2 = glm::cos(t2);
+		T s2 = glm::sin(t2);
+		T c3 = glm::cos(t3);
+		T s3 = glm::sin(t3);
+
+		mat<4, 4, T, defaultp> Result;
+		Result[0][0] = c1 * c3 - c2 * s1 * s3;
+		Result[0][1] = s2* s3;
+		Result[0][2] =-c3 * s1 - c1 * c2 * s3;
+		Result[0][3] = static_cast<T>(0);
+		Result[1][0] = s1 * s2;
+		Result[1][1] = c2;
+		Result[1][2] = c1 * s2;
+		Result[1][3] = static_cast<T>(0);
+		Result[2][0] = c1 * s3 + c2 * c3 * s1;
+		Result[2][1] =-c3 * s2;
+		Result[2][2] = c1 * c2 * c3 - s1 * s3;
+		Result[2][3] = static_cast<T>(0);
+		Result[3][0] = static_cast<T>(0);
+		Result[3][1] = static_cast<T>(0);
+		Result[3][2] = static_cast<T>(0);
+		Result[3][3] = static_cast<T>(1);
+		return Result;
+	}
+
+	template <typename T>
+	GLM_FUNC_QUALIFIER mat<4, 4, T, defaultp> eulerAngleYZY
+	(
+		T const & t1,
+		T const & t2,
+		T const & t3
+	)
+	{
+		T c1 = glm::cos(t1);
+		T s1 = glm::sin(t1);
+		T c2 = glm::cos(t2);
+		T s2 = glm::sin(t2);
+		T c3 = glm::cos(t3);
+		T s3 = glm::sin(t3);
+
+		mat<4, 4, T, defaultp> Result;
+		Result[0][0] = c1 * c2 * c3 - s1 * s3;
+		Result[0][1] = c3 * s2;
+		Result[0][2] =-c1 * s3 - c2 * c3 * s1;
+		Result[0][3] = static_cast<T>(0);
+		Result[1][0] =-c1 * s2;
+		Result[1][1] = c2;
+		Result[1][2] = s1 * s2;
+		Result[1][3] = static_cast<T>(0);
+		Result[2][0] = c3 * s1 + c1 * c2 * s3;
+		Result[2][1] = s2 * s3;
+		Result[2][2] = c1 * c3 - c2 * s1 * s3;
+		Result[2][3] = static_cast<T>(0);
+		Result[3][0] = static_cast<T>(0);
+		Result[3][1] = static_cast<T>(0);
+		Result[3][2] = static_cast<T>(0);
+		Result[3][3] = static_cast<T>(1);
+		return Result;
+	}
+
+	template <typename T>
+	GLM_FUNC_QUALIFIER mat<4, 4, T, defaultp> eulerAngleZYZ
+	(
+		T const & t1,
+		T const & t2,
+		T const & t3
+	)
+	{
+		T c1 = glm::cos(t1);
+		T s1 = glm::sin(t1);
+		T c2 = glm::cos(t2);
+		T s2 = glm::sin(t2);
+		T c3 = glm::cos(t3);
+		T s3 = glm::sin(t3);
+
+		mat<4, 4, T, defaultp> Result;
+		Result[0][0] = c1 * c2 * c3 - s1 * s3;
+		Result[0][1] = c1 * s3 + c2 * c3 * s1;
+		Result[0][2] =-c3 * s2;
+		Result[0][3] = static_cast<T>(0);
+		Result[1][0] =-c3 * s1 - c1 * c2 * s3;
+		Result[1][1] = c1 * c3 - c2 * s1 * s3;
+		Result[1][2] = s2 * s3;
+		Result[1][3] = static_cast<T>(0);
+		Result[2][0] = c1 * s2;
+		Result[2][1] = s1 * s2;
+		Result[2][2] = c2;
+		Result[2][3] = static_cast<T>(0);
+		Result[3][0] = static_cast<T>(0);
+		Result[3][1] = static_cast<T>(0);
+		Result[3][2] = static_cast<T>(0);
+		Result[3][3] = static_cast<T>(1);
+		return Result;
+	}
+
+	template <typename T>
+	GLM_FUNC_QUALIFIER mat<4, 4, T, defaultp> eulerAngleZXZ
+	(
+		T const & t1,
+		T const & t2,
+		T const & t3
+	)
+	{
+		T c1 = glm::cos(t1);
+		T s1 = glm::sin(t1);
+		T c2 = glm::cos(t2);
+		T s2 = glm::sin(t2);
+		T c3 = glm::cos(t3);
+		T s3 = glm::sin(t3);
+
+		mat<4, 4, T, defaultp> Result;
+		Result[0][0] = c1 * c3 - c2 * s1 * s3;
+		Result[0][1] = c3 * s1 + c1 * c2 * s3;
+		Result[0][2] = s2 *s3;
+		Result[0][3] = static_cast<T>(0);
+		Result[1][0] =-c1 * s3 - c2 * c3 * s1;
+		Result[1][1] = c1 * c2 * c3 - s1 * s3;
+		Result[1][2] = c3 * s2;
+		Result[1][3] = static_cast<T>(0);
+		Result[2][0] = s1 * s2;
+		Result[2][1] =-c1 * s2;
+		Result[2][2] = c2;
+		Result[2][3] = static_cast<T>(0);
+		Result[3][0] = static_cast<T>(0);
+		Result[3][1] = static_cast<T>(0);
+		Result[3][2] = static_cast<T>(0);
+		Result[3][3] = static_cast<T>(1);
+		return Result;
+	}
+
+	template <typename T>
+	GLM_FUNC_QUALIFIER mat<4, 4, T, defaultp> eulerAngleXZY
+	(
+		T const & t1,
+		T const & t2,
+		T const & t3
+	)
+	{
+		T c1 = glm::cos(t1);
+		T s1 = glm::sin(t1);
+		T c2 = glm::cos(t2);
+		T s2 = glm::sin(t2);
+		T c3 = glm::cos(t3);
+		T s3 = glm::sin(t3);
+
+		mat<4, 4, T, defaultp> Result;
+		Result[0][0] = c2 * c3;
+		Result[0][1] = s1 * s3 + c1 * c3 * s2;
+		Result[0][2] = c3 * s1 * s2 - c1 * s3;
+		Result[0][3] = static_cast<T>(0);
+		Result[1][0] =-s2;
+		Result[1][1] = c1 * c2;
+		Result[1][2] = c2 * s1;
+		Result[1][3] = static_cast<T>(0);
+		Result[2][0] = c2 * s3;
+		Result[2][1] = c1 * s2 * s3 - c3 * s1;
+		Result[2][2] = c1 * c3 + s1 * s2 *s3;
+		Result[2][3] = static_cast<T>(0);
+		Result[3][0] = static_cast<T>(0);
+		Result[3][1] = static_cast<T>(0);
+		Result[3][2] = static_cast<T>(0);
+		Result[3][3] = static_cast<T>(1);
+		return Result;
+	}
+
+	template <typename T>
+	GLM_FUNC_QUALIFIER mat<4, 4, T, defaultp> eulerAngleYZX
+	(
+		T const & t1,
+		T const & t2,
+		T const & t3
+	)
+	{
+		T c1 = glm::cos(t1);
+		T s1 = glm::sin(t1);
+		T c2 = glm::cos(t2);
+		T s2 = glm::sin(t2);
+		T c3 = glm::cos(t3);
+		T s3 = glm::sin(t3);
+
+		mat<4, 4, T, defaultp> Result;
+		Result[0][0] = c1 * c2;
+		Result[0][1] = s2;
+		Result[0][2] =-c2 * s1;
+		Result[0][3] = static_cast<T>(0);
+		Result[1][0] = s1 * s3 - c1 * c3 * s2;
+		Result[1][1] = c2 * c3;
+		Result[1][2] = c1 * s3 + c3 * s1 * s2;
+		Result[1][3] = static_cast<T>(0);
+		Result[2][0] = c3 * s1 + c1 * s2 * s3;
+		Result[2][1] =-c2 * s3;
+		Result[2][2] = c1 * c3 - s1 * s2 * s3;
+		Result[2][3] = static_cast<T>(0);
+		Result[3][0] = static_cast<T>(0);
+		Result[3][1] = static_cast<T>(0);
+		Result[3][2] = static_cast<T>(0);
+		Result[3][3] = static_cast<T>(1);
+		return Result;
+	}
+
+	template <typename T>
+	GLM_FUNC_QUALIFIER mat<4, 4, T, defaultp> eulerAngleZYX
+	(
+		T const & t1,
+		T const & t2,
+		T const & t3
+	)
+	{
+		T c1 = glm::cos(t1);
+		T s1 = glm::sin(t1);
+		T c2 = glm::cos(t2);
+		T s2 = glm::sin(t2);
+		T c3 = glm::cos(t3);
+		T s3 = glm::sin(t3);
+
+		mat<4, 4, T, defaultp> Result;
+		Result[0][0] = c1 * c2;
+		Result[0][1] = c2 * s1;
+		Result[0][2] =-s2;
+		Result[0][3] = static_cast<T>(0);
+		Result[1][0] = c1 * s2 * s3 - c3 * s1;
+		Result[1][1] = c1 * c3 + s1 * s2 * s3;
+		Result[1][2] = c2 * s3;
+		Result[1][3] = static_cast<T>(0);
+		Result[2][0] = s1 * s3 + c1 * c3 * s2;
+		Result[2][1] = c3 * s1 * s2 - c1 * s3;
+		Result[2][2] = c2 * c3;
+		Result[2][3] = static_cast<T>(0);
+		Result[3][0] = static_cast<T>(0);
+		Result[3][1] = static_cast<T>(0);
+		Result[3][2] = static_cast<T>(0);
+		Result[3][3] = static_cast<T>(1);
+		return Result;
+	}
+
+	template <typename T>
+	GLM_FUNC_QUALIFIER mat<4, 4, T, defaultp> eulerAngleZXY
+	(
+		T const & t1,
+		T const & t2,
+		T const & t3
+	)
+	{
+		T c1 = glm::cos(t1);
+		T s1 = glm::sin(t1);
+		T c2 = glm::cos(t2);
+		T s2 = glm::sin(t2);
+		T c3 = glm::cos(t3);
+		T s3 = glm::sin(t3);
+
+		mat<4, 4, T, defaultp> Result;
+		Result[0][0] = c1 * c3 - s1 * s2 * s3;
+		Result[0][1] = c3 * s1 + c1 * s2 * s3;
+		Result[0][2] =-c2 * s3;
+		Result[0][3] = static_cast<T>(0);
+		Result[1][0] =-c2 * s1;
+		Result[1][1] = c1 * c2;
+		Result[1][2] = s2;
+		Result[1][3] = static_cast<T>(0);
+		Result[2][0] = c1 * s3 + c3 * s1 * s2;
+		Result[2][1] = s1 * s3 - c1 * c3 * s2;
+		Result[2][2] = c2 * c3;
+		Result[2][3] = static_cast<T>(0);
+		Result[3][0] = static_cast<T>(0);
+		Result[3][1] = static_cast<T>(0);
+		Result[3][2] = static_cast<T>(0);
+		Result[3][3] = static_cast<T>(1);
+		return Result;
+	}
+
 	template<typename T>
 	GLM_FUNC_QUALIFIER mat<4, 4, T, defaultp> yawPitchRoll
 	(

--- a/glm/gtx/euler_angles.inl
+++ b/glm/gtx/euler_angles.inl
@@ -53,6 +53,57 @@ namespace glm
 			T(0),	T(0),	T(0), T(1));
 	}
 
+	template <typename T>
+	GLM_FUNC_QUALIFIER mat<4, 4, T, defaultp> derivedEulerAngleX
+	(
+		T const & angleX,
+		T const & angularVelocityX
+	)
+	{
+		T cosX = glm::cos(angleX) * angularVelocityX;
+		T sinX = glm::sin(angleX) * angularVelocityX;
+
+		return mat<4, 4, T, defaultp>(
+			T(0), T(0), T(0), T(0),
+			T(0),-sinX, cosX, T(0),
+			T(0),-cosX,-sinX, T(0),
+			T(0), T(0), T(0), T(0));
+	}
+
+	template <typename T>
+	GLM_FUNC_QUALIFIER mat<4, 4, T, defaultp> derivedEulerAngleY
+	(
+		T const & angleY,
+		T const & angularVelocityY
+	)
+	{
+		T cosY = glm::cos(angleY) * angularVelocityY;
+		T sinY = glm::sin(angleY) * angularVelocityY;
+
+		return mat<4, 4, T, defaultp>(
+			-sinY, T(0), -cosY, T(0),
+			 T(0), T(0),  T(0), T(0),
+			 cosY, T(0), -sinY, T(0),
+			 T(0), T(0),  T(0), T(0));
+	}
+
+	template <typename T>
+	GLM_FUNC_QUALIFIER mat<4, 4, T, defaultp> derivedEulerAngleZ
+	(
+		T const & angleZ,
+		T const & angularVelocityZ
+	)
+	{
+		T cosZ = glm::cos(angleZ) * angularVelocityZ;
+		T sinZ = glm::sin(angleZ) * angularVelocityZ;
+
+		return mat<4, 4, T, defaultp>(
+			-sinZ,  cosZ, T(0), T(0),
+			-cosZ, -sinZ, T(0), T(0),
+			 T(0),  T(0), T(0), T(0),
+			 T(0),  T(0), T(0), T(0));
+	}
+
 	template<typename T>
 	GLM_FUNC_QUALIFIER mat<4, 4, T, defaultp> eulerAngleXY
 	(

--- a/glm/gtx/euler_angles.inl
+++ b/glm/gtx/euler_angles.inl
@@ -710,4 +710,191 @@ namespace glm
         t2 = -T2;
         t3 = -T3;
     }
+
+	template <typename T>
+	GLM_FUNC_QUALIFIER void extractEulerAngleYXZ(mat<4, 4, T, defaultp> const & M,
+												 T & t1,
+												 T & t2,
+												 T & t3)
+	{
+		T T1 = glm::atan2<T, defaultp>(M[2][0], M[2][2]);
+		T C2 = glm::sqrt(M[0][1]*M[0][1] + M[1][1]*M[1][1]);
+		T T2 = glm::atan2<T, defaultp>(-M[2][1], C2);
+		T S1 = glm::sin(T1);
+		T C1 = glm::cos(T1);
+		T T3 = glm::atan2<T, defaultp>(S1*M[1][2] - C1*M[1][0], C1*M[0][0] - S1*M[0][2]);
+		t1 = T1;
+		t2 = T2;
+		t3 = T3;
+	}
+
+	template <typename T>
+	GLM_FUNC_QUALIFIER void extractEulerAngleXZX(mat<4, 4, T, defaultp> const & M,
+												 T & t1,
+												 T & t2,
+												 T & t3)
+	{
+		T T1 = glm::atan2<T, defaultp>(M[0][2], M[0][1]);
+		T S2 = glm::sqrt(M[1][0]*M[1][0] + M[2][0]*M[2][0]);
+		T T2 = glm::atan2<T, defaultp>(S2, M[0][0]);
+		T S1 = glm::sin(T1);
+		T C1 = glm::cos(T1);
+		T T3 = glm::atan2<T, defaultp>(C1*M[1][2] - S1*M[1][1], C1*M[2][2] - S1*M[2][1]);
+		t1 = T1;
+		t2 = T2;
+		t3 = T3;
+	}
+
+	template <typename T>
+	GLM_FUNC_QUALIFIER void extractEulerAngleXYX(mat<4, 4, T, defaultp> const & M,
+												 T & t1,
+												 T & t2,
+												 T & t3)
+	{
+		T T1 = glm::atan2<T, defaultp>(M[0][1], -M[0][2]);
+		T S2 = glm::sqrt(M[1][0]*M[1][0] + M[2][0]*M[2][0]);
+		T T2 = glm::atan2<T, defaultp>(S2, M[0][0]);
+		T S1 = glm::sin(T1);
+		T C1 = glm::cos(T1);
+		T T3 = glm::atan2<T, defaultp>(-C1*M[2][1] - S1*M[2][2], C1*M[1][1] + S1*M[1][2]);
+		t1 = T1;
+		t2 = T2;
+		t3 = T3;
+	}
+
+	template <typename T>
+	GLM_FUNC_QUALIFIER void extractEulerAngleYXY(mat<4, 4, T, defaultp> const & M,
+												 T & t1,
+												 T & t2,
+												 T & t3)
+	{
+		T T1 = glm::atan2<T, defaultp>(M[1][0], M[1][2]);
+		T S2 = glm::sqrt(M[0][1]*M[0][1] + M[2][1]*M[2][1]);
+		T T2 = glm::atan2<T, defaultp>(S2, M[1][1]);
+		T S1 = glm::sin(T1);
+		T C1 = glm::cos(T1);
+		T T3 = glm::atan2<T, defaultp>(C1*M[2][0] - S1*M[2][2], C1*M[0][0] - S1*M[0][2]);
+		t1 = T1;
+		t2 = T2;
+		t3 = T3;
+	}
+
+	template <typename T>
+	GLM_FUNC_QUALIFIER void extractEulerAngleYZY(mat<4, 4, T, defaultp> const & M,
+												 T & t1,
+												 T & t2,
+												 T & t3)
+	{
+		T T1 = glm::atan2<T, defaultp>(M[1][2], -M[1][0]);
+		T S2 = glm::sqrt(M[0][1]*M[0][1] + M[2][1]*M[2][1]);
+		T T2 = glm::atan2<T, defaultp>(S2, M[1][1]);
+		T S1 = glm::sin(T1);
+		T C1 = glm::cos(T1);
+		T T3 = glm::atan2<T, defaultp>(-S1*M[0][0] - C1*M[0][2], S1*M[2][0] + C1*M[2][2]);
+		t1 = T1;
+		t2 = T2;
+		t3 = T3;
+	}
+
+	template <typename T>
+	GLM_FUNC_QUALIFIER void extractEulerAngleZYZ(mat<4, 4, T, defaultp> const & M,
+												 T & t1,
+												 T & t2,
+												 T & t3)
+	{
+		T T1 = glm::atan2<T, defaultp>(M[2][1], M[2][0]);
+		T S2 = glm::sqrt(M[0][2]*M[0][2] + M[1][2]*M[1][2]);
+		T T2 = glm::atan2<T, defaultp>(S2, M[2][2]);
+		T S1 = glm::sin(T1);
+		T C1 = glm::cos(T1);
+		T T3 = glm::atan2<T, defaultp>(C1*M[0][1] - S1*M[0][0], C1*M[1][1] - S1*M[1][0]);
+		t1 = T1;
+		t2 = T2;
+		t3 = T3;
+	}
+
+	template <typename T>
+	GLM_FUNC_QUALIFIER void extractEulerAngleZXZ(mat<4, 4, T, defaultp> const & M,
+												 T & t1,
+												 T & t2,
+												 T & t3)
+	{
+		T T1 = glm::atan2<T, defaultp>(M[2][0], -M[2][1]);
+		T S2 = glm::sqrt(M[0][2]*M[0][2] + M[1][2]*M[1][2]);
+		T T2 = glm::atan2<T, defaultp>(S2, M[2][2]);
+		T S1 = glm::sin(T1);
+		T C1 = glm::cos(T1);
+		T T3 = glm::atan2<T, defaultp>(-C1*M[1][0] - S1*M[1][1], C1*M[0][0] + S1*M[0][1]);
+		t1 = T1;
+		t2 = T2;
+		t3 = T3;
+	}
+
+	template <typename T>
+	GLM_FUNC_QUALIFIER void extractEulerAngleXZY(mat<4, 4, T, defaultp> const & M,
+												 T & t1,
+												 T & t2,
+												 T & t3)
+	{
+		T T1 = glm::atan2<T, defaultp>(M[1][2], M[1][1]);
+		T C2 = glm::sqrt(M[0][0]*M[0][0] + M[2][0]*M[2][0]);
+		T T2 = glm::atan2<T, defaultp>(-M[1][0], C2);
+		T S1 = glm::sin(T1);
+		T C1 = glm::cos(T1);
+		T T3 = glm::atan2<T, defaultp>(S1*M[0][1] - C1*M[0][2], C1*M[2][2] - S1*M[2][1]);
+		t1 = T1;
+		t2 = T2;
+		t3 = T3;
+	}
+
+	template <typename T>
+	GLM_FUNC_QUALIFIER void extractEulerAngleYZX(mat<4, 4, T, defaultp> const & M,
+												 T & t1,
+												 T & t2,
+												 T & t3)
+	{
+		T T1 = glm::atan2<T, defaultp>(-M[0][2], M[0][0]);
+		T C2 = glm::sqrt(M[1][1]*M[1][1] + M[2][1]*M[2][1]);
+		T T2 = glm::atan2<T, defaultp>(M[0][1], C2);
+		T S1 = glm::sin(T1);
+		T C1 = glm::cos(T1);
+		T T3 = glm::atan2<T, defaultp>(S1*M[1][0] + C1*M[1][2], S1*M[2][0] + C1*M[2][2]);
+		t1 = T1;
+		t2 = T2;
+		t3 = T3;
+	}
+
+	template <typename T>
+	GLM_FUNC_QUALIFIER void extractEulerAngleZYX(mat<4, 4, T, defaultp> const & M,
+												 T & t1,
+												 T & t2,
+												 T & t3)
+	{
+		T T1 = glm::atan2<T, defaultp>(M[0][1], M[0][0]);
+		T C2 = glm::sqrt(M[1][2]*M[1][2] + M[2][2]*M[2][2]);
+		T T2 = glm::atan2<T, defaultp>(-M[0][2], C2);
+		T S1 = glm::sin(T1);
+		T C1 = glm::cos(T1);
+		T T3 = glm::atan2<T, defaultp>(S1*M[2][0] - C1*M[2][1], C1*M[1][1] - S1*M[1][0]);
+		t1 = T1;
+		t2 = T2;
+		t3 = T3;
+	}
+
+	template <typename T>
+	GLM_FUNC_QUALIFIER void extractEulerAngleZXY(mat<4, 4, T, defaultp> const & M,
+												 T & t1,
+												 T & t2,
+												 T & t3)
+	{
+		T T1 = glm::atan2<T, defaultp>(-M[1][0], M[1][1]);
+		T C2 = glm::sqrt(M[0][2]*M[0][2] + M[2][2]*M[2][2]);
+		T T2 = glm::atan2<T, defaultp>(M[1][2], C2);
+		T S1 = glm::sin(T1);
+		T C1 = glm::cos(T1);
+		T T3 = glm::atan2<T, defaultp>(C1*M[2][0] + S1*M[2][1], C1*M[0][0] + S1*M[0][1]);
+		t1 = T1;
+		t2 = T2;
+		t3 = T3;
+	}
 }//namespace glm

--- a/test/gtx/gtx_euler_angle.cpp
+++ b/test/gtx/gtx_euler_angle.cpp
@@ -2,10 +2,14 @@
 
 #define GLM_ENABLE_EXPERIMENTAL
 #include <glm/gtc/matrix_transform.hpp>
+#include <glm/gtx/matrix_cross_product.hpp>
+#include <glm/gtx/matrix_operation.hpp>
 #include <glm/gtc/epsilon.hpp>
 #include <glm/gtx/string_cast.hpp>
 #include <glm/gtx/euler_angles.hpp>
 #include <cstdio>
+#include <vector>
+#include <utility>
 
 namespace test_eulerAngleX
 {
@@ -135,6 +139,62 @@ namespace test_eulerAngleZ
 		return Error;
 	}
 }//namespace test_eulerAngleZ
+
+namespace test_derivedEulerAngles
+{
+	bool epsilonEqual(glm::mat4 const& mat1, glm::mat4 const& mat2, glm::mat4::value_type const& epsilon)
+	{
+		return glm::all(glm::epsilonEqual(mat1[0], mat2[0], epsilon)) ?
+				(
+					glm::all(glm::epsilonEqual(mat1[1], mat2[1], epsilon)) ?
+					(
+						glm::all(glm::epsilonEqual(mat1[2], mat2[2], epsilon)) ?
+						(
+							glm::all(glm::epsilonEqual(mat1[3], mat2[3], epsilon)) ? true : false
+						) : false
+					) : false
+				) : false;
+	}
+
+	template<typename RotationFunc, typename TestDerivedFunc>
+	int test(RotationFunc rotationFunc, TestDerivedFunc testDerivedFunc, const glm::vec3& basis)
+	{
+		int Error = 0;
+
+		typedef glm::vec3::value_type value;
+		value const zeroAngle(0.0f);
+		value const Angle(glm::pi<float>() * 0.75f);
+		value const negativeAngle(-Angle);
+		value const zeroAngleVelocity(0.0f);
+		value const AngleVelocity(glm::pi<float>() * 0.27f);
+		value const negativeAngleVelocity(-AngleVelocity);
+
+		typedef std::pair<value,value> AngleAndAngleVelocity;
+		std::vector<AngleAndAngleVelocity> testPairs;
+		testPairs.push_back(AngleAndAngleVelocity(zeroAngle, zeroAngleVelocity));
+		testPairs.push_back(AngleAndAngleVelocity(zeroAngle, AngleVelocity));
+		testPairs.push_back(AngleAndAngleVelocity(zeroAngle, negativeAngleVelocity));
+		testPairs.push_back(AngleAndAngleVelocity(Angle, zeroAngleVelocity));
+		testPairs.push_back(AngleAndAngleVelocity(Angle, AngleVelocity));
+		testPairs.push_back(AngleAndAngleVelocity(Angle, negativeAngleVelocity));
+		testPairs.push_back(AngleAndAngleVelocity(negativeAngle, zeroAngleVelocity));
+		testPairs.push_back(AngleAndAngleVelocity(negativeAngle, AngleVelocity));
+		testPairs.push_back(AngleAndAngleVelocity(negativeAngle, negativeAngleVelocity));
+
+		for (size_t i = 0, size = testPairs.size(); i < size; ++i)
+		{
+			AngleAndAngleVelocity const& pair = testPairs.at(i);
+
+			glm::mat4 const W = glm::matrixCross4(basis * pair.second);
+			glm::mat4 const rotMt = glm::transpose(rotationFunc(pair.first));
+			glm::mat4 const derivedRotM = testDerivedFunc(pair.first, pair.second);
+
+			Error += epsilonEqual(W, derivedRotM * rotMt, 0.00001f) ? 0 : 1;
+		}
+
+		return Error;
+	}
+}//namespace test_derivedEulerAngles
 
 namespace test_eulerAngleXY
 {
@@ -310,13 +370,140 @@ namespace test_eulerAngleYXZ
 	}
 }//namespace eulerAngleYXZ
 
+namespace test_eulerAngles
+{
+	template<typename TestRotationFunc>
+	int test(TestRotationFunc testRotationFunc, glm::vec3 const& I, glm::vec3 const& J, glm::vec3 const& K)
+	{
+		int Error = 0;
+
+		typedef glm::mat4::value_type value;
+		value const minAngle(-glm::pi<value>());
+		value const maxAngle(glm::pi<value>());
+		value const maxAngleWithDelta(maxAngle - 0.0000001f);
+		value const minMidAngle(-glm::pi<value>() * 0.5f);
+		value const maxMidAngle(glm::pi<value>() * 0.5f);
+
+		std::vector<glm::vec3> testEulerAngles;
+		testEulerAngles.push_back(glm::vec3(1.046f, 0.52f, -0.785f));
+		testEulerAngles.push_back(glm::vec3(minAngle, minMidAngle, minAngle));
+		testEulerAngles.push_back(glm::vec3(minAngle, minMidAngle, maxAngle));
+		testEulerAngles.push_back(glm::vec3(minAngle, minMidAngle, maxAngleWithDelta));
+		testEulerAngles.push_back(glm::vec3(minAngle, maxMidAngle, minAngle));
+		testEulerAngles.push_back(glm::vec3(minAngle, maxMidAngle, maxAngle));
+		testEulerAngles.push_back(glm::vec3(minAngle, maxMidAngle, maxAngleWithDelta));
+		testEulerAngles.push_back(glm::vec3(maxAngle, minMidAngle, minAngle));
+		testEulerAngles.push_back(glm::vec3(maxAngle, minMidAngle, maxAngle));
+		testEulerAngles.push_back(glm::vec3(maxAngle, minMidAngle, maxAngleWithDelta));
+		testEulerAngles.push_back(glm::vec3(maxAngleWithDelta, minMidAngle, maxAngle));
+		testEulerAngles.push_back(glm::vec3(maxAngleWithDelta, minMidAngle, maxAngleWithDelta));
+		testEulerAngles.push_back(glm::vec3(maxAngle, maxMidAngle, minAngle));
+		testEulerAngles.push_back(glm::vec3(maxAngleWithDelta, maxMidAngle, minAngle));
+		testEulerAngles.push_back(glm::vec3(maxAngle, maxMidAngle, maxAngle));
+		testEulerAngles.push_back(glm::vec3(maxAngle, maxMidAngle, maxAngleWithDelta));
+		testEulerAngles.push_back(glm::vec3(maxAngleWithDelta, maxMidAngle, maxAngle));
+		testEulerAngles.push_back(glm::vec3(maxAngleWithDelta, maxMidAngle, maxAngleWithDelta));
+		testEulerAngles.push_back(glm::vec3(minAngle, 0.0f, minAngle));
+		testEulerAngles.push_back(glm::vec3(minAngle, 0.0f, maxAngle));
+		testEulerAngles.push_back(glm::vec3(maxAngle, maxAngle, minAngle));
+		testEulerAngles.push_back(glm::vec3(maxAngle, maxAngle, maxAngle));
+
+		for (size_t i = 0, size = testEulerAngles.size(); i < size; ++i)
+		{
+			glm::vec3 const& angles = testEulerAngles.at(i);
+			glm::mat4 const rotationEuler = testRotationFunc(angles.x, angles.y, angles.z);
+
+			glm::mat4 rotationDumb = glm::diagonal4x4(glm::mat4::col_type(1.0f));
+			rotationDumb = glm::rotate(rotationDumb, angles.x, I);
+			rotationDumb = glm::rotate(rotationDumb, angles.y, J);
+			rotationDumb = glm::rotate(rotationDumb, angles.z, K);
+
+			glm::vec4 const V(1.0f,1.0f,1.0f,1.0f);
+			glm::vec4 const V1 = rotationEuler * V;
+			glm::vec4 const V2 = rotationDumb * V;
+
+			Error += glm::all(glm::epsilonEqual(V1, V2, 0.00001f)) ? 0 : 1;
+		}
+
+		return Error;
+	}
+}//namespace test_extractsEulerAngles
+
+namespace test_extractsEulerAngles
+{
+	template<typename RotationFunc, typename TestExtractionFunc>
+	int test(RotationFunc rotationFunc, TestExtractionFunc testExtractionFunc)
+	{
+		int Error = 0;
+
+		typedef glm::mat4::value_type value;
+		value const minAngle(-glm::pi<value>());
+		value const maxAngle(glm::pi<value>());
+		value const maxAngleWithDelta(maxAngle - 0.0000001f);
+		value const minMidAngle(-glm::pi<value>() * 0.5f);
+		value const maxMidAngle(glm::pi<value>() * 0.5f);
+
+		std::vector<glm::vec3> testEulerAngles;
+		testEulerAngles.push_back(glm::vec3(1.046f, 0.52f, -0.785f));
+		testEulerAngles.push_back(glm::vec3(minAngle, minMidAngle, minAngle));
+		testEulerAngles.push_back(glm::vec3(minAngle, minMidAngle, maxAngle));
+		testEulerAngles.push_back(glm::vec3(minAngle, minMidAngle, maxAngleWithDelta));
+		testEulerAngles.push_back(glm::vec3(minAngle, maxMidAngle, minAngle));
+		testEulerAngles.push_back(glm::vec3(minAngle, maxMidAngle, maxAngle));
+		testEulerAngles.push_back(glm::vec3(minAngle, maxMidAngle, maxAngleWithDelta));
+		testEulerAngles.push_back(glm::vec3(maxAngle, minMidAngle, minAngle));
+		testEulerAngles.push_back(glm::vec3(maxAngle, minMidAngle, maxAngle));
+		testEulerAngles.push_back(glm::vec3(maxAngle, minMidAngle, maxAngleWithDelta));
+		testEulerAngles.push_back(glm::vec3(maxAngleWithDelta, minMidAngle, maxAngle));
+		testEulerAngles.push_back(glm::vec3(maxAngleWithDelta, minMidAngle, maxAngleWithDelta));
+		testEulerAngles.push_back(glm::vec3(maxAngle, maxMidAngle, minAngle));
+		testEulerAngles.push_back(glm::vec3(maxAngleWithDelta, maxMidAngle, minAngle));
+		testEulerAngles.push_back(glm::vec3(maxAngle, maxMidAngle, maxAngle));
+		testEulerAngles.push_back(glm::vec3(maxAngle, maxMidAngle, maxAngleWithDelta));
+		testEulerAngles.push_back(glm::vec3(maxAngleWithDelta, maxMidAngle, maxAngle));
+		testEulerAngles.push_back(glm::vec3(maxAngleWithDelta, maxMidAngle, maxAngleWithDelta));
+		testEulerAngles.push_back(glm::vec3(minAngle, 0.0f, minAngle));
+		testEulerAngles.push_back(glm::vec3(minAngle, 0.0f, maxAngle));
+		testEulerAngles.push_back(glm::vec3(maxAngle, maxAngle, minAngle));
+		testEulerAngles.push_back(glm::vec3(maxAngle, maxAngle, maxAngle));
+
+		for (size_t i = 0, size = testEulerAngles.size(); i < size; ++i)
+		{
+			glm::vec3 const& angles = testEulerAngles.at(i);
+			glm::mat4 const rotation = rotationFunc(angles.x, angles.y, angles.z);
+
+			glm::vec3 extractedEulerAngles(0.0f);
+			testExtractionFunc(rotation, extractedEulerAngles.x, extractedEulerAngles.y, extractedEulerAngles.z);
+			glm::mat4 const extractedRotation = rotationFunc(extractedEulerAngles.x, extractedEulerAngles.y, extractedEulerAngles.z);
+
+			glm::vec4 const V(1.0f,1.0f,1.0f,1.0f);
+			glm::vec4 const V1 = rotation * V;
+			glm::vec4 const V2 = extractedRotation * V;
+
+			Error += glm::all(glm::epsilonEqual(V1, V2, 0.00001f)) ? 0 : 1;
+		}
+
+		return Error;
+	}
+}//namespace test_extractsEulerAngles
+
 int main()
 { 
 	int Error = 0;
 
+	typedef glm::mat4::value_type value;
+	glm::vec3 const X(1.0f, 0.0f, 0.0f);
+	glm::vec3 const Y(0.0f, 1.0f, 0.0f);
+	glm::vec3 const Z(0.0f, 0.0f, 1.0f);
+
 	Error += test_eulerAngleX::test();
 	Error += test_eulerAngleY::test();
 	Error += test_eulerAngleZ::test();
+
+	Error += test_derivedEulerAngles::test(glm::eulerAngleX<value>, glm::derivedEulerAngleX<value>, X);
+	Error += test_derivedEulerAngles::test(glm::eulerAngleY<value>, glm::derivedEulerAngleY<value>, Y);
+	Error += test_derivedEulerAngles::test(glm::eulerAngleZ<value>, glm::derivedEulerAngleZ<value>, Z);
+
 	Error += test_eulerAngleXY::test();
 	Error += test_eulerAngleYX::test();
 	Error += test_eulerAngleXZ::test();
@@ -324,6 +511,29 @@ int main()
 	Error += test_eulerAngleYZ::test();
 	Error += test_eulerAngleZY::test();
 	Error += test_eulerAngleYXZ::test();
+
+	Error += test_eulerAngles::test(glm::eulerAngleXZX<value>, X, Z, X);
+	Error += test_eulerAngles::test(glm::eulerAngleXYX<value>, X, Y, X);
+	Error += test_eulerAngles::test(glm::eulerAngleYXY<value>, Y, X, Y);
+	Error += test_eulerAngles::test(glm::eulerAngleYZY<value>, Y, Z, Y);
+	Error += test_eulerAngles::test(glm::eulerAngleZYZ<value>, Z, Y, Z);
+	Error += test_eulerAngles::test(glm::eulerAngleZXZ<value>, Z, X, Z);
+	Error += test_eulerAngles::test(glm::eulerAngleXZY<value>, X, Z, Y);
+	Error += test_eulerAngles::test(glm::eulerAngleYZX<value>, Y, Z, X);
+	Error += test_eulerAngles::test(glm::eulerAngleZYX<value>, Z, Y, X);
+	Error += test_eulerAngles::test(glm::eulerAngleZXY<value>, Z, X, Y);
+
+	Error += test_extractsEulerAngles::test(glm::eulerAngleYXZ<value>, glm::extractEulerAngleYXZ<value>);
+	Error += test_extractsEulerAngles::test(glm::eulerAngleXZX<value>, glm::extractEulerAngleXZX<value>);
+	Error += test_extractsEulerAngles::test(glm::eulerAngleXYX<value>, glm::extractEulerAngleXYX<value>);
+	Error += test_extractsEulerAngles::test(glm::eulerAngleYXY<value>, glm::extractEulerAngleYXY<value>);
+	Error += test_extractsEulerAngles::test(glm::eulerAngleYZY<value>, glm::extractEulerAngleYZY<value>);
+	Error += test_extractsEulerAngles::test(glm::eulerAngleZYZ<value>, glm::extractEulerAngleZYZ<value>);
+	Error += test_extractsEulerAngles::test(glm::eulerAngleZXZ<value>, glm::extractEulerAngleZXZ<value>);
+	Error += test_extractsEulerAngles::test(glm::eulerAngleXZY<value>, glm::extractEulerAngleXZY<value>);
+	Error += test_extractsEulerAngles::test(glm::eulerAngleYZX<value>, glm::extractEulerAngleYZX<value>);
+	Error += test_extractsEulerAngles::test(glm::eulerAngleZYX<value>, glm::extractEulerAngleZYX<value>);
+	Error += test_extractsEulerAngles::test(glm::eulerAngleZXY<value>, glm::extractEulerAngleZXY<value>);
 
 	return Error; 
 }


### PR DESCRIPTION
This PR adds the following:
- Creates the derived matrix from the rotation matrix about the X-, Y-, and Z-axis
- Creates the rotation matrix from the Euler angles (intrinsic rotations):
**_Proper Euler angles_** (z-x-z, x-y-x, y-z-y, z-y-z, x-z-x, y-x-y)
**_Tait–Bryan angles_** (y-z-x, z-x-y, x-z-y, z-y-x).
- Extracts the Euler angles from the rotation matrix (intrinsic rotations):
**_Proper Euler angles_** (z-x-z, x-y-x, y-z-y, z-y-z, x-z-x, y-x-y)
**_Tait–Bryan angles_** (y-z-x, z-x-y, x-z-y, z-y-x, y-x-z).
- Tests for these features