### PR TITLE
Add constexpr qualifier to non-simd vec const operator[]

### DIFF
--- a/glm/detail/type_vec1.inl
+++ b/glm/detail/type_vec1.inl
@@ -70,7 +70,7 @@ namespace glm
 	}
 
 	template<typename T, qualifier Q>
-	GLM_FUNC_QUALIFIER T const& vec<1, T, Q>::operator[](typename vec<1, T, Q>::length_type i) const
+	GLM_FUNC_QUALIFIER GLM_CONSTEXPR_CXX14 T const& vec<1, T, Q>::operator[](typename vec<1, T, Q>::length_type i) const
 	{
 		assert(i >= 0 && i < this->length());
 		return (&x)[i];

--- a/glm/detail/type_vec2.hpp
+++ b/glm/detail/type_vec2.hpp
@@ -82,7 +82,7 @@ namespace glm
 		GLM_FUNC_DECL static GLM_CONSTEXPR length_type length(){return 2;}
 
 		GLM_FUNC_DECL T& operator[](length_type i);
-		GLM_FUNC_DECL T const& operator[](length_type i) const;
+		GLM_FUNC_DECL GLM_CONSTEXPR_CXX14 T const& operator[](length_type i) const;
 
 		// -- Implicit basic constructors --
 

--- a/glm/detail/type_vec2.inl
+++ b/glm/detail/type_vec2.inl
@@ -88,7 +88,7 @@ namespace glm
 	}
 
 	template<typename T, qualifier Q>
-	GLM_FUNC_QUALIFIER T const& vec<2, T, Q>::operator[](typename vec<2, T, Q>::length_type i) const
+	GLM_FUNC_QUALIFIER GLM_CONSTEXPR_CXX14 T const& vec<2, T, Q>::operator[](typename vec<2, T, Q>::length_type i) const
 	{
 		assert(i >= 0 && i < this->length());
 		return (&x)[i];

--- a/glm/detail/type_vec3.hpp
+++ b/glm/detail/type_vec3.hpp
@@ -82,7 +82,7 @@ namespace glm
 		GLM_FUNC_DECL static GLM_CONSTEXPR length_type length(){return 3;}
 
 		GLM_FUNC_DECL T & operator[](length_type i);
-		GLM_FUNC_DECL T const& operator[](length_type i) const;
+		GLM_FUNC_DECL GLM_CONSTEXPR_CXX14 T const& operator[](length_type i) const;
 
 		// -- Implicit basic constructors --
 

--- a/glm/detail/type_vec3.inl
+++ b/glm/detail/type_vec3.inl
@@ -117,7 +117,7 @@ namespace glm
 	}
 
 	template<typename T, qualifier Q>
-	GLM_FUNC_QUALIFIER T const& vec<3, T, Q>::operator[](typename vec<3, T, Q>::length_type i) const
+	GLM_FUNC_QUALIFIER GLM_CONSTEXPR_CXX14 T const& vec<3, T, Q>::operator[](typename vec<3, T, Q>::length_type i) const
 	{
 		assert(i >= 0 && i < this->length());
 		return (&x)[i];

--- a/glm/detail/type_vec4.hpp
+++ b/glm/detail/type_vec4.hpp
@@ -85,7 +85,7 @@ namespace glm
 		GLM_FUNC_DECL static GLM_CONSTEXPR length_type length(){return 4;}
 
 		GLM_FUNC_DECL T & operator[](length_type i);
-		GLM_FUNC_DECL T const& operator[](length_type i) const;
+		GLM_FUNC_DECL GLM_CONSTEXPR_CXX14 T const& operator[](length_type i) const;
 
 		// -- Implicit basic constructors --
 

--- a/glm/detail/type_vec4.inl
+++ b/glm/detail/type_vec4.inl
@@ -332,7 +332,7 @@ namespace detail
 	}
 
 	template<typename T, qualifier Q>
-	GLM_FUNC_QUALIFIER T const& vec<4, T, Q>::operator[](typename vec<4, T, Q>::length_type i) const
+	GLM_FUNC_QUALIFIER GLM_CONSTEXPR_CXX14 T const& vec<4, T, Q>::operator[](typename vec<4, T, Q>::length_type i) const
 	{
 		assert(i >= 0 && i < this->length());
 		return (&x)[i];

--- a/glm/ext/vec1.hpp
+++ b/glm/ext/vec1.hpp
@@ -97,7 +97,7 @@ namespace glm
 		GLM_FUNC_DECL static GLM_CONSTEXPR length_type length(){return 1;}
 
 		GLM_FUNC_DECL T & operator[](length_type i);
-		GLM_FUNC_DECL T const& operator[](length_type i) const;
+		GLM_FUNC_DECL GLM_CONSTEXPR_CXX14 T const& operator[](length_type i) const;
 
 		// -- Implicit basic constructors --
 


### PR DESCRIPTION
With reference to #713 

We could consider this as a starting point for augmenting other functions/types (i.e. overloaded operators for non-simd vec's, and the same for mat types) with `constexpr`. 

There was a concern raised about code size possibly blowing up with the forced inlining caused by `constexpr`. From what I've read, it is very compiler/platform dependent, so it's hard to get a solid metric. Either way, I kept my changes minimal so there is an opportunity to run some tests, if desired.