### PR TITLE
Intermediate Function Is Improperly Done

### DIFF
--- a/glm/gtx/quaternion.inl
+++ b/glm/gtx/quaternion.inl
@@ -45,7 +45,7 @@ namespace glm
 	)
 	{
 		tquat<T, Q> invQuat = inverse(curr);
-		return exp((log(next + invQuat) + log(prev + invQuat)) / static_cast<T>(-4)) * curr;
+		return exp((log(next * invQuat) + log(prev * invQuat)) / static_cast<T>(-4)) * curr;
 	}
 
 	template<typename T, qualifier Q>


### PR DESCRIPTION
The formula for calculating the intermediate for a SQUAD interpolation is

exp((log(next * invQuat) + log(prev * invQuat)) / static_cast<T>(-4)) * curr;

The current code uses addition instead of multiplication (based on http://web.mit.edu/2.998/www/QuaternionReport1.pdf)