### PR TITLE
Make to_string(dualquat) actually work

### DIFF
--- a/glm/gtx/string_cast.inl
+++ b/glm/gtx/string_cast.inl
@@ -467,6 +467,7 @@ namespace detail
 			char const * LiteralStr = literal<T, std::numeric_limits<T>::is_iec559>::value();
 			std::string FormatStr(detail::format("%sdualquat((%s, {%s, %s, %s}), (%s, {%s, %s, %s}))",
 				PrefixStr,
+				LiteralStr, LiteralStr, LiteralStr, LiteralStr,
 				LiteralStr, LiteralStr, LiteralStr, LiteralStr));
 
 			return detail::format(FormatStr.c_str(),

--- a/test/gtx/gtx_string_cast.cpp
+++ b/test/gtx/gtx_string_cast.cpp
@@ -129,12 +129,24 @@ int test_string_cast_quaternion()
 
 }
 
+int test_string_cast_dual_quaternion()
+{
+	int Error = 0;
+
+	glm::dualquat Q0 = glm::dualquat({1.0f, 2.0f, 3.0f, 4.0f}, {5.0f, 6.0f, 7.0f, 8.0f});
+	std::string S0 = glm::to_string(Q0);
+	Error += S0 != std::string("dualquat((1.000000, {2.000000, 3.000000, 4.000000}), (5.000000, {6.000000, 7.000000, 8.000000}))") ? 1 : 0;
+
+	return Error;
+}
+
 int main()
 {
 	int Error = 0;
 	Error += test_string_cast_vector();
 	Error += test_string_cast_matrix();
 	Error += test_string_cast_quaternion();
+	Error += test_string_cast_dual_quaternion();
 
 	return Error;
 }

--- a/test/gtx/gtx_string_cast.cpp
+++ b/test/gtx/gtx_string_cast.cpp
@@ -133,7 +133,7 @@ int test_string_cast_dual_quaternion()
 {
 	int Error = 0;
 
-	glm::dualquat Q0 = glm::dualquat({1.0f, 2.0f, 3.0f, 4.0f}, {5.0f, 6.0f, 7.0f, 8.0f});
+	glm::dualquat Q0 = glm::dualquat(glm::quat(1.0f, 2.0f, 3.0f, 4.0f), glm::quat(5.0f, 6.0f, 7.0f, 8.0f));
 	std::string S0 = glm::to_string(Q0);
 	Error += S0 != std::string("dualquat((1.000000, {2.000000, 3.000000, 4.000000}), (5.000000, {6.000000, 7.000000, 8.000000}))") ? 1 : 0;
 


### PR DESCRIPTION
When implementing [GLM integration](http://doc.magnum.graphics/magnum/GlmIntegration_2Integration_8h.html) for the [Magnum graphics engine](http://magnum.graphics/) I discovered that `glm::to_string(glm::dualquat)` crashes due to a mismatch in `printf()` argument count. Looks like it was never used or tested since its initial implementation in bf30816e363b196805c99ef06c41ec1560005040 from 2015.

Added a test case there.