### PR TITLE
Suppressed VC warnings with /permissive-

### DIFF
--- a/glm/detail/type_vec2.hpp
+++ b/glm/detail/type_vec2.hpp
@@ -39,6 +39,10 @@ namespace glm
 #				pragma clang diagnostic ignored "-Wgnu-anonymous-struct"
 #				pragma clang diagnostic ignored "-Wnested-anon-types"
 #			endif
+#			if GLM_COMPILER & GLM_COMPILER_VC
+#				pragma warning(push)
+#				pragma warning(disable: 4201)  // nonstandard extension used : nameless struct/union
+#			endif
 
 			union
 			{
@@ -60,6 +64,9 @@ namespace glm
 
 			};
 
+#			if GLM_COMPILER & GLM_COMPILER_VC
+#				pragma warning(pop)
+#			endif
 #			if GLM_COMPILER & GLM_COMPILER_CLANG
 #				pragma clang diagnostic pop
 #			endif

--- a/glm/detail/type_vec3.hpp
+++ b/glm/detail/type_vec3.hpp
@@ -39,6 +39,10 @@ namespace glm
 #				pragma clang diagnostic ignored "-Wgnu-anonymous-struct"
 #				pragma clang diagnostic ignored "-Wnested-anon-types"
 #			endif
+#			if GLM_COMPILER & GLM_COMPILER_VC
+#				pragma warning(push)
+#				pragma warning(disable: 4201)  // nonstandard extension used : nameless struct/union
+#			endif
 
 			union
 			{
@@ -59,6 +63,9 @@ namespace glm
 #				endif//GLM_SWIZZLE
 			};
 
+#			if GLM_COMPILER & GLM_COMPILER_VC
+#				pragma warning(pop)
+#			endif
 #			if GLM_COMPILER & GLM_COMPILER_CLANG
 #				pragma clang diagnostic pop
 #			endif

--- a/glm/detail/type_vec4.hpp
+++ b/glm/detail/type_vec4.hpp
@@ -39,6 +39,10 @@ namespace glm
 #				pragma clang diagnostic ignored "-Wgnu-anonymous-struct"
 #				pragma clang diagnostic ignored "-Wnested-anon-types"
 #			endif
+#			if GLM_COMPILER & GLM_COMPILER_VC
+#				pragma warning(push)
+#				pragma warning(disable: 4201)  // nonstandard extension used : nameless struct/union
+#			endif
 
 			union
 			{
@@ -61,6 +65,9 @@ namespace glm
 #				endif//GLM_SWIZZLE
 			};
 
+#			if GLM_COMPILER & GLM_COMPILER_VC
+#				pragma warning(pop)
+#			endif
 #			if GLM_COMPILER & GLM_COMPILER_CLANG
 #				pragma clang diagnostic pop
 #			endif

--- a/glm/ext/vec1.hpp
+++ b/glm/ext/vec1.hpp
@@ -56,6 +56,10 @@ namespace glm
 #				pragma clang diagnostic ignored "-Wgnu-anonymous-struct"
 #				pragma clang diagnostic ignored "-Wnested-anon-types"
 #			endif
+#			if GLM_COMPILER & GLM_COMPILER_VC
+#				pragma warning(push)
+#				pragma warning(disable: 4201)  // nonstandard extension used : nameless struct/union
+#			endif
 
 			union
 			{
@@ -76,6 +80,9 @@ namespace glm
 #				endif//GLM_SWIZZLE*/
 			};
 
+#			if GLM_COMPILER & GLM_COMPILER_VC
+#				pragma warning(pop)
+#			endif
 #			if GLM_COMPILER & GLM_COMPILER_CLANG
 #				pragma clang diagnostic pop
 #			endif

--- a/glm/gtc/quaternion.hpp
+++ b/glm/gtc/quaternion.hpp
@@ -49,6 +49,10 @@ namespace glm
 #				pragma clang diagnostic ignored "-Wgnu-anonymous-struct"
 #				pragma clang diagnostic ignored "-Wnested-anon-types"
 #			endif
+#			if GLM_COMPILER & GLM_COMPILER_VC
+#				pragma warning(push)
+#				pragma warning(disable: 4201)  // nonstandard extension used : nameless struct/union
+#			endif
 
 			union
 			{
@@ -56,6 +60,9 @@ namespace glm
 				typename detail::storage<T, sizeof(T) * 4, detail::is_aligned<Q>::value>::type data;
 			};
 
+#			if GLM_COMPILER & GLM_COMPILER_VC
+#				pragma warning(pop)
+#			endif
 #			if GLM_COMPILER & GLM_COMPILER_CLANG
 #				pragma clang diagnostic pop
 #			endif


### PR DESCRIPTION
So we can keep warning-free headers, instead of [C4201](https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4201).