### PR TITLE
Modify glm::refract's behaviour

### DIFF
--- a/glm/detail/func_geometric.inl
+++ b/glm/detail/func_geometric.inl
@@ -114,11 +114,10 @@ namespace detail
 	{
 		GLM_FUNC_QUALIFIER static vec<L, T, Q> call(vec<L, T, Q> const& I, vec<L, T, Q> const& N, T eta)
 		{
-			assert(eta >= static_cast<T>(-1) && eta <= static_cast<T>(1));
-
 			T const dotValue(dot(N, I));
 			T const k(static_cast<T>(1) - eta * eta * (static_cast<T>(1) - dotValue * dotValue));
-			vec<L, T, Q> const Result = (eta * I - (eta * dotValue + std::sqrt(k)) * N) * static_cast<T>(k >= static_cast<T>(0));
+			vec<L, T, Q> const Result =
+                (k >= static_cast<T>(0)) ? (eta * I - (eta * dotValue + std::sqrt(k)) * N) : vec<L, T, Q>(0);
 			return Result;
 		}
 	};

--- a/glm/geometric.hpp
+++ b/glm/geometric.hpp
@@ -99,8 +99,6 @@ namespace glm
 	/// and the ratio of indices of refraction eta,
 	/// return the refraction vector.
 	///
-	/// @param eta Indice of refraction. Must be a value between -1 and 1 inclusively.
-	///
 	/// @tparam L An integer between 1 and 4 included that qualify the dimension of the vector.
 	/// @tparam T Floating-point scalar types.
 	///


### PR DESCRIPTION
Refer to issue #806.

No offence, I don't think the changes in 76580af80e0314c9a33284461b1c4fdd03aafe04 is appropriate. Actually, `eta`'s absolute value can be greater than 1.

When a bundle of light shoots from a denser medium (say, water whose refractive index equals 1.3325) to less dense medium (air, for instance), a [full internal reflection](https://en.wikipedia.org/wiki/Total_internal_reflection#/media/File:RefractionReflextion.svg) is possible to happen.

In this case, `eta` is 1.3325 / 1 = 1.3325. If we constrict `eta` into the range from -1 to 1, `glm` will never support this kind of phenomenon, which is quite significant in computer graphics.

By the way, negative `eta` may be redundant. 