### PR TITLE
Add missing include to vec1

### DIFF
--- a/glm/detail/func_common.inl
+++ b/glm/detail/func_common.inl
@@ -3,6 +3,7 @@
 
 #include "../vector_relational.hpp"
 #include "compute_common.hpp"
+#include "type_vec1.hpp"
 #include "type_vec2.hpp"
 #include "type_vec3.hpp"
 #include "type_vec4.hpp"


### PR DESCRIPTION
I suspect `func_common.inl` is missing an include to `vec1`.
For example, this class is required by the implementation of `genType fract(genType x)`, for which I got a compiler error with both the 0.9.9.3 release and the current master.