### PR TITLE
Don't disable constexpr on length() when simd is enabled.

### DIFF
--- a/glm/detail/setup.hpp
+++ b/glm/detail/setup.hpp
@@ -275,9 +275,7 @@
 
 // N2235 Generalized Constant Expressions http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2007/n2235.pdf
 // N3652 Extended Constant Expressions http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2013/n3652.html
-#if (GLM_ARCH & GLM_ARCH_SIMD_BIT) // Compiler SIMD intrinsics don't support constexpr...
-#	define GLM_HAS_CONSTEXPR 0
-#elif (GLM_COMPILER & GLM_COMPILER_CLANG)
+#if (GLM_COMPILER & GLM_COMPILER_CLANG)
 #	define GLM_HAS_CONSTEXPR __has_feature(cxx_relaxed_constexpr)
 #elif (GLM_LANG & GLM_LANG_CXX14_FLAG)
 #	define GLM_HAS_CONSTEXPR 1
@@ -289,9 +287,16 @@
 #endif
 
 #if GLM_HAS_CONSTEXPR
-#	define GLM_CONSTEXPR constexpr
+#	if (GLM_ARCH & GLM_ARCH_SIMD_BIT) // Compiler SIMD intrinsics don't support constexpr...
+#		define GLM_CONSTEXPR
+#	else
+#		define GLM_CONSTEXPR constexpr
+#	endif
+
+#	define GLM_NON_MATH_CONSTEXPR constexpr
 #else
 #	define GLM_CONSTEXPR
+#	define GLM_NON_MATH_CONSTEXPR
 #endif
 
 //

--- a/glm/detail/setup.hpp
+++ b/glm/detail/setup.hpp
@@ -286,19 +286,6 @@
 		((GLM_COMPILER & GLM_COMPILER_VC) && (GLM_COMPILER >= GLM_COMPILER_VC15))))
 #endif
 
-#if GLM_HAS_CONSTEXPR
-#	if (GLM_ARCH & GLM_ARCH_SIMD_BIT) // Compiler SIMD intrinsics don't support constexpr...
-#		define GLM_CONSTEXPR
-#	else
-#		define GLM_CONSTEXPR constexpr
-#	endif
-
-#	define GLM_NON_MATH_CONSTEXPR constexpr
-#else
-#	define GLM_CONSTEXPR
-#	define GLM_NON_MATH_CONSTEXPR
-#endif
-
 //
 #if GLM_LANG & GLM_LANG_CXX11_FLAG
 #	define GLM_HAS_ASSIGNABLE 1
@@ -542,7 +529,16 @@ namespace glm
 // constexpr
 
 #if GLM_HAS_CONSTEXPR
-#	define GLM_CONFIG_CONSTEXP GLM_ENABLE
+#	if (GLM_ARCH & GLM_ARCH_SIMD_BIT) // Compiler SIMD intrinsics don't support constexpr...
+#		define GLM_CONFIG_CONSTEXP GLM_DISABLE
+#		define GLM_CONSTEXPR
+#	else
+#		define GLM_CONFIG_CONSTEXP GLM_ENABLE
+#		define GLM_CONSTEXPR constexpr
+#	endif
+
+#	define GLM_CONFIG_NON_MATH_CONSTEXP GLM_ENABLE
+#	define GLM_NON_MATH_CONSTEXPR constexpr
 
 	namespace glm
 	{
@@ -555,10 +551,18 @@ namespace glm
 #	define GLM_COUNTOF(arr) glm::countof(arr)
 #elif defined(_MSC_VER)
 #	define GLM_CONFIG_CONSTEXP GLM_DISABLE
+#	define GLM_CONSTEXPR
+
+#	define GLM_CONFIG_NON_MATH_CONSTEXP GLM_DISABLE
+#	define GLM_NON_MATH_CONSTEXPR
 
 #	define GLM_COUNTOF(arr) _countof(arr)
 #else
 #	define GLM_CONFIG_CONSTEXP GLM_DISABLE
+#	define GLM_CONSTEXPR
+
+#	define GLM_CONFIG_NON_MATH_CONSTEXP GLM_DISABLE
+#	define GLM_NON_MATH_CONSTEXPR
 
 #	define GLM_COUNTOF(arr) sizeof(arr) / sizeof(arr[0])
 #endif

--- a/glm/detail/type_mat2x2.hpp
+++ b/glm/detail/type_mat2x2.hpp
@@ -25,7 +25,7 @@ namespace glm
 		// -- Accesses --
 
 		typedef length_t length_type;
-		GLM_FUNC_DECL static GLM_CONSTEXPR length_type length() { return 2; }
+		GLM_FUNC_DECL static GLM_NON_MATH_CONSTEXPR length_type length() { return 2; }
 
 		GLM_FUNC_DECL col_type & operator[](length_type i);
 		GLM_FUNC_DECL GLM_CONSTEXPR col_type const& operator[](length_type i) const;

--- a/glm/detail/type_mat2x3.hpp
+++ b/glm/detail/type_mat2x3.hpp
@@ -26,7 +26,7 @@ namespace glm
 		// -- Accesses --
 
 		typedef length_t length_type;
-		GLM_FUNC_DECL static GLM_CONSTEXPR length_type length() { return 2; }
+		GLM_FUNC_DECL static GLM_NON_MATH_CONSTEXPR length_type length() { return 2; }
 
 		GLM_FUNC_DECL col_type & operator[](length_type i);
 		GLM_FUNC_DECL GLM_CONSTEXPR col_type const& operator[](length_type i) const;

--- a/glm/detail/type_mat2x4.hpp
+++ b/glm/detail/type_mat2x4.hpp
@@ -26,7 +26,7 @@ namespace glm
 		// -- Accesses --
 
 		typedef length_t length_type;
-		GLM_FUNC_DECL static GLM_CONSTEXPR length_type length() { return 2; }
+		GLM_FUNC_DECL static GLM_NON_MATH_CONSTEXPR length_type length() { return 2; }
 
 		GLM_FUNC_DECL col_type & operator[](length_type i);
 		GLM_FUNC_DECL GLM_CONSTEXPR col_type const& operator[](length_type i) const;

--- a/glm/detail/type_mat3x2.hpp
+++ b/glm/detail/type_mat3x2.hpp
@@ -26,7 +26,7 @@ namespace glm
 		// -- Accesses --
 
 		typedef length_t length_type;
-		GLM_FUNC_DECL static GLM_CONSTEXPR length_type length() { return 3; }
+		GLM_FUNC_DECL static GLM_NON_MATH_CONSTEXPR length_type length() { return 3; }
 
 		GLM_FUNC_DECL col_type & operator[](length_type i);
 		GLM_FUNC_DECL GLM_CONSTEXPR col_type const& operator[](length_type i) const;

--- a/glm/detail/type_mat3x3.hpp
+++ b/glm/detail/type_mat3x3.hpp
@@ -25,7 +25,7 @@ namespace glm
 		// -- Accesses --
 
 		typedef length_t length_type;
-		GLM_FUNC_DECL static GLM_CONSTEXPR length_type length() { return 3; }
+		GLM_FUNC_DECL static GLM_NON_MATH_CONSTEXPR length_type length() { return 3; }
 
 		GLM_FUNC_DECL col_type & operator[](length_type i);
 		GLM_FUNC_DECL GLM_CONSTEXPR col_type const& operator[](length_type i) const;

--- a/glm/detail/type_mat3x4.hpp
+++ b/glm/detail/type_mat3x4.hpp
@@ -26,7 +26,7 @@ namespace glm
 		// -- Accesses --
 
 		typedef length_t length_type;
-		GLM_FUNC_DECL static GLM_CONSTEXPR length_type length() { return 3; }
+		GLM_FUNC_DECL static GLM_NON_MATH_CONSTEXPR length_type length() { return 3; }
 
 		GLM_FUNC_DECL col_type & operator[](length_type i);
 		GLM_FUNC_DECL GLM_CONSTEXPR col_type const& operator[](length_type i) const;

--- a/glm/detail/type_mat4x2.hpp
+++ b/glm/detail/type_mat4x2.hpp
@@ -26,7 +26,7 @@ namespace glm
 		// -- Accesses --
 
 		typedef length_t length_type;
-		GLM_FUNC_DECL static GLM_CONSTEXPR length_type length() { return 4; }
+		GLM_FUNC_DECL static GLM_NON_MATH_CONSTEXPR length_type length() { return 4; }
 
 		GLM_FUNC_DECL col_type & operator[](length_type i);
 		GLM_FUNC_DECL GLM_CONSTEXPR col_type const& operator[](length_type i) const;

--- a/glm/detail/type_mat4x3.hpp
+++ b/glm/detail/type_mat4x3.hpp
@@ -26,7 +26,7 @@ namespace glm
 		// -- Accesses --
 
 		typedef length_t length_type;
-		GLM_FUNC_DECL static GLM_CONSTEXPR length_type length() { return 4; }
+		GLM_FUNC_DECL static GLM_NON_MATH_CONSTEXPR length_type length() { return 4; }
 
 		GLM_FUNC_DECL col_type & operator[](length_type i);
 		GLM_FUNC_DECL GLM_CONSTEXPR col_type const& operator[](length_type i) const;

--- a/glm/detail/type_mat4x4.hpp
+++ b/glm/detail/type_mat4x4.hpp
@@ -25,7 +25,7 @@ namespace glm
 		// -- Accesses --
 
 		typedef length_t length_type;
-		GLM_FUNC_DECL static GLM_CONSTEXPR length_type length(){return 4;}
+		GLM_FUNC_DECL static GLM_NON_MATH_CONSTEXPR length_type length(){return 4;}
 
 		GLM_FUNC_DECL col_type & operator[](length_type i);
 		GLM_FUNC_DECL GLM_CONSTEXPR col_type const& operator[](length_type i) const;

--- a/glm/detail/type_quat.hpp
+++ b/glm/detail/type_quat.hpp
@@ -77,7 +77,7 @@ namespace glm
 
 		typedef length_t length_type;
 		/// Return the count of components of a quaternion
-		GLM_FUNC_DECL static GLM_CONSTEXPR length_type length(){return 4;}
+		GLM_FUNC_DECL static GLM_NON_MATH_CONSTEXPR length_type length(){return 4;}
 
 		GLM_FUNC_DECL GLM_CONSTEXPR T & operator[](length_type i);
 		GLM_FUNC_DECL GLM_CONSTEXPR T const& operator[](length_type i) const;

--- a/glm/detail/type_vec1.hpp
+++ b/glm/detail/type_vec1.hpp
@@ -85,7 +85,7 @@ namespace glm
 
 		/// Return the count of components of the vector
 		typedef length_t length_type;
-		GLM_FUNC_DECL static GLM_CONSTEXPR length_type length(){return 1;}
+		GLM_FUNC_DECL static GLM_NON_MATH_CONSTEXPR length_type length(){return 1;}
 
 		GLM_FUNC_DECL GLM_CONSTEXPR T & operator[](length_type i);
 		GLM_FUNC_DECL GLM_CONSTEXPR T const& operator[](length_type i) const;

--- a/glm/detail/type_vec2.hpp
+++ b/glm/detail/type_vec2.hpp
@@ -84,7 +84,7 @@ namespace glm
 
 		/// Return the count of components of the vector
 		typedef length_t length_type;
-		GLM_FUNC_DECL static GLM_CONSTEXPR length_type length(){return 2;}
+		GLM_FUNC_DECL static GLM_NON_MATH_CONSTEXPR length_type length(){return 2;}
 
 		GLM_FUNC_DECL GLM_CONSTEXPR T& operator[](length_type i);
 		GLM_FUNC_DECL GLM_CONSTEXPR T const& operator[](length_type i) const;

--- a/glm/detail/type_vec3.hpp
+++ b/glm/detail/type_vec3.hpp
@@ -88,7 +88,7 @@ namespace glm
 
 		/// Return the count of components of the vector
 		typedef length_t length_type;
-		GLM_FUNC_DECL static GLM_CONSTEXPR length_type length(){return 3;}
+		GLM_FUNC_DECL static GLM_NON_MATH_CONSTEXPR length_type length(){return 3;}
 
 		GLM_FUNC_DECL GLM_CONSTEXPR T & operator[](length_type i);
 		GLM_FUNC_DECL GLM_CONSTEXPR T const& operator[](length_type i) const;

--- a/glm/detail/type_vec4.hpp
+++ b/glm/detail/type_vec4.hpp
@@ -86,7 +86,7 @@ namespace glm
 
 		/// Return the count of components of the vector
 		typedef length_t length_type;
-		GLM_FUNC_DECL static GLM_CONSTEXPR length_type length(){return 4;}
+		GLM_FUNC_DECL static GLM_NON_MATH_CONSTEXPR length_type length(){return 4;}
 
 		GLM_FUNC_DECL GLM_CONSTEXPR T & operator[](length_type i);
 		GLM_FUNC_DECL GLM_CONSTEXPR T const& operator[](length_type i) const;

--- a/test/core/core_func_common.cpp
+++ b/test/core/core_func_common.cpp
@@ -1296,13 +1296,13 @@ namespace ldexp_
 
 static int test_constexpr()
 {
-#if GLM_HAS_CONSTEXPR
+#if GLM_CONFIG_CONSTEXP
 	static_assert(glm::abs(1.0f) > 0.0f, "GLM: Failed constexpr");
 	constexpr glm::vec1 const A = glm::abs(glm::vec1(1.0f));
 	constexpr glm::vec2 const B = glm::abs(glm::vec2(1.0f));
 	constexpr glm::vec3 const C = glm::abs(glm::vec3(1.0f));
 	constexpr glm::vec4 const D = glm::abs(glm::vec4(1.0f));
-#endif // GLM_HAS_CONSTEXPR
+#endif // GLM_CONFIG_CONSTEXP
 
 	return 0;
 }

--- a/test/core/core_type_mat2x2.cpp
+++ b/test/core/core_type_mat2x2.cpp
@@ -155,7 +155,7 @@ int test_size()
 
 int test_constexpr()
 {
-#if GLM_HAS_CONSTEXPR
+#if GLM_CONFIG_NON_MATH_CONSTEXP
 	static_assert(glm::mat2x2::length() == 2, "GLM: Failed constexpr");
 #endif
 

--- a/test/core/core_type_mat2x3.cpp
+++ b/test/core/core_type_mat2x3.cpp
@@ -121,7 +121,7 @@ int test_size()
 
 int test_constexpr()
 {
-#if GLM_HAS_CONSTEXPR
+#if GLM_CONFIG_NON_MATH_CONSTEXP
 	static_assert(glm::mat2x3::length() == 2, "GLM: Failed constexpr");
 #endif
 

--- a/test/core/core_type_mat2x4.cpp
+++ b/test/core/core_type_mat2x4.cpp
@@ -123,7 +123,7 @@ static int test_size()
 
 static int test_constexpr()
 {
-#if GLM_HAS_CONSTEXPR
+#if GLM_CONFIG_NON_MATH_CONSTEXP
 	static_assert(glm::mat2x4::length() == 2, "GLM: Failed constexpr");
 #endif
 

--- a/test/core/core_type_mat3x2.cpp
+++ b/test/core/core_type_mat3x2.cpp
@@ -125,7 +125,7 @@ static int test_size()
 
 static int test_constexpr()
 {
-#if GLM_HAS_CONSTEXPR
+#if GLM_CONFIG_NON_MATH_CONSTEXP
 	static_assert(glm::mat3x2::length() == 3, "GLM: Failed constexpr");
 #endif
 

--- a/test/core/core_type_mat3x3.cpp
+++ b/test/core/core_type_mat3x3.cpp
@@ -171,9 +171,11 @@ static int test_size()
 
 static int test_constexpr()
 {
-#if GLM_HAS_CONSTEXPR
+#ifdef GLM_NON_MATH_CONSTEXPR
 	static_assert(glm::mat3x3::length() == 3, "GLM: Failed constexpr");
+#endif
 
+#ifdef GLM_CONSTEXPR
 	constexpr glm::mat3x3 const Z(0.0f);
 #endif
 

--- a/test/core/core_type_mat3x3.cpp
+++ b/test/core/core_type_mat3x3.cpp
@@ -171,11 +171,11 @@ static int test_size()
 
 static int test_constexpr()
 {
-#ifdef GLM_NON_MATH_CONSTEXPR
+#if GLM_CONFIG_NON_MATH_CONSTEXP
 	static_assert(glm::mat3x3::length() == 3, "GLM: Failed constexpr");
 #endif
 
-#ifdef GLM_CONSTEXPR
+#if GLM_CONFIG_CONSTEXP
 	constexpr glm::mat3x3 const Z(0.0f);
 #endif
 

--- a/test/core/core_type_mat3x4.cpp
+++ b/test/core/core_type_mat3x4.cpp
@@ -127,7 +127,7 @@ static int test_size()
 
 static int test_constexpr()
 {
-#if GLM_HAS_CONSTEXPR
+#if GLM_CONFIG_NON_MATH_CONSTEXP
 	static_assert(glm::mat3x4::length() == 3, "GLM: Failed constexpr");
 #endif
 

--- a/test/core/core_type_mat4x2.cpp
+++ b/test/core/core_type_mat4x2.cpp
@@ -129,7 +129,7 @@ static int test_size()
 
 static int test_constexpr()
 {
-#if GLM_HAS_CONSTEXPR
+#if GLM_CONFIG_NON_MATH_CONSTEXP
 	static_assert(glm::mat4x2::length() == 4, "GLM: Failed constexpr");
 #endif
 

--- a/test/core/core_type_mat4x3.cpp
+++ b/test/core/core_type_mat4x3.cpp
@@ -129,7 +129,7 @@ static int test_size()
 
 static int test_constexpr()
 {
-#if GLM_HAS_CONSTEXPR
+#if GLM_CONFIG_NON_MATH_CONSTEXP
 	static_assert(glm::mat4x3::length() == 4, "GLM: Failed constexpr");
 #endif
 

--- a/test/core/core_type_mat4x4.cpp
+++ b/test/core/core_type_mat4x4.cpp
@@ -173,11 +173,11 @@ static int test_size()
 
 static int test_constexpr()
 {
-#ifdef GLM_NON_MATH_CONSTEXPR
+#if GLM_CONFIG_NON_MATH_CONSTEXP
 	static_assert(glm::mat4::length() == 4, "GLM: Failed constexpr");
 #endif
 
-#ifdef GLM_CONSTEXPR
+#if GLM_CONFIG_CONSTEXP
 	constexpr glm::mat4 A(1.f);
 	constexpr glm::mat4 B(1.f);
 	constexpr glm::bvec4 C = glm::equal(A, B, 0.01f);

--- a/test/core/core_type_mat4x4.cpp
+++ b/test/core/core_type_mat4x4.cpp
@@ -173,8 +173,11 @@ static int test_size()
 
 static int test_constexpr()
 {
-#if GLM_HAS_CONSTEXPR
+#ifdef GLM_NON_MATH_CONSTEXPR
 	static_assert(glm::mat4::length() == 4, "GLM: Failed constexpr");
+#endif
+
+#ifdef GLM_CONSTEXPR
 	constexpr glm::mat4 A(1.f);
 	constexpr glm::mat4 B(1.f);
 	constexpr glm::bvec4 C = glm::equal(A, B, 0.01f);

--- a/test/core/core_type_vec1.cpp
+++ b/test/core/core_type_vec1.cpp
@@ -146,8 +146,11 @@ static int test_swizzle()
 
 static int test_constexpr()
 {
-#if GLM_HAS_CONSTEXPR
+#ifdef GLM_NON_MATH_CONSTEXPR
 	static_assert(glm::vec1::length() == 1, "GLM: Failed constexpr");
+#endif
+
+#ifdef GLM_CONSTEXPR
 	static_assert(glm::vec1(1.0f).x > 0.0f, "GLM: Failed constexpr");
 #endif
 

--- a/test/core/core_type_vec1.cpp
+++ b/test/core/core_type_vec1.cpp
@@ -146,11 +146,11 @@ static int test_swizzle()
 
 static int test_constexpr()
 {
-#ifdef GLM_NON_MATH_CONSTEXPR
+#if GLM_CONFIG_NON_MATH_CONSTEXP
 	static_assert(glm::vec1::length() == 1, "GLM: Failed constexpr");
 #endif
 
-#ifdef GLM_CONSTEXPR
+#if GLM_CONFIG_CONSTEXP
 	static_assert(glm::vec1(1.0f).x > 0.0f, "GLM: Failed constexpr");
 #endif
 

--- a/test/core/core_type_vec2.cpp
+++ b/test/core/core_type_vec2.cpp
@@ -336,8 +336,11 @@ static int test_operator_increment()
 
 static int test_constexpr()
 {
-#if GLM_HAS_CONSTEXPR
+#ifdef GLM_NON_MATH_CONSTEXPR
 	static_assert(glm::vec2::length() == 2, "GLM: Failed constexpr");
+#endif
+
+#ifdef GLM_CONSTEXPR
 	static_assert(glm::vec2(1.0f).x > 0.0f, "GLM: Failed constexpr");
 	static_assert(glm::vec2(1.0f, -1.0f).x > 0.0f, "GLM: Failed constexpr");
 	static_assert(glm::vec2(1.0f, -1.0f).y < 0.0f, "GLM: Failed constexpr");

--- a/test/core/core_type_vec2.cpp
+++ b/test/core/core_type_vec2.cpp
@@ -301,7 +301,7 @@ static int test_size()
 	Error += glm::vec2::length() == 2 ? 0 : 1;
 	Error += glm::dvec2::length() == 2 ? 0 : 1;
 
-	GLM_CONSTEXPR std::size_t Length = glm::vec2::length();
+	GLM_NON_MATH_CONSTEXPR std::size_t Length = glm::vec2::length();
 	Error += Length == 2 ? 0 : 1;
 
 	return Error;
@@ -336,11 +336,11 @@ static int test_operator_increment()
 
 static int test_constexpr()
 {
-#ifdef GLM_NON_MATH_CONSTEXPR
+#if GLM_CONFIG_NON_MATH_CONSTEXP
 	static_assert(glm::vec2::length() == 2, "GLM: Failed constexpr");
 #endif
 
-#ifdef GLM_CONSTEXPR
+#if GLM_CONFIG_CONSTEXP
 	static_assert(glm::vec2(1.0f).x > 0.0f, "GLM: Failed constexpr");
 	static_assert(glm::vec2(1.0f, -1.0f).x > 0.0f, "GLM: Failed constexpr");
 	static_assert(glm::vec2(1.0f, -1.0f).y < 0.0f, "GLM: Failed constexpr");

--- a/test/core/core_type_vec3.cpp
+++ b/test/core/core_type_vec3.cpp
@@ -596,8 +596,11 @@ static int test_swizzle()
 
 static int test_constexpr()
 {
-#if GLM_HAS_CONSTEXPR
+#ifdef GLM_NON_MATH_CONSTEXPR
 	static_assert(glm::vec3::length() == 3, "GLM: Failed constexpr");
+#endif
+
+#ifdef GLM_CONSTEXPR
 	static_assert(glm::vec3(1.0f).x > 0.0f, "GLM: Failed constexpr");
 	static_assert(glm::vec3(1.0f, -1.0f, -1.0f).x > 0.0f, "GLM: Failed constexpr");
 	static_assert(glm::vec3(1.0f, -1.0f, -1.0f).y < 0.0f, "GLM: Failed constexpr");

--- a/test/core/core_type_vec3.cpp
+++ b/test/core/core_type_vec3.cpp
@@ -308,7 +308,7 @@ int test_vec3_size()
 	Error += glm::vec3::length() == 3 ? 0 : 1;
 	Error += glm::dvec3::length() == 3 ? 0 : 1;
 
-	GLM_CONSTEXPR std::size_t Length = glm::vec3::length();
+	GLM_NON_MATH_CONSTEXPR std::size_t Length = glm::vec3::length();
 	Error += Length == 3 ? 0 : 1;
 
 	return Error;
@@ -596,11 +596,11 @@ static int test_swizzle()
 
 static int test_constexpr()
 {
-#ifdef GLM_NON_MATH_CONSTEXPR
+#if GLM_CONFIG_NON_MATH_CONSTEXP
 	static_assert(glm::vec3::length() == 3, "GLM: Failed constexpr");
 #endif
 
-#ifdef GLM_CONSTEXPR
+#if GLM_CONFIG_CONSTEXP
 	static_assert(glm::vec3(1.0f).x > 0.0f, "GLM: Failed constexpr");
 	static_assert(glm::vec3(1.0f, -1.0f, -1.0f).x > 0.0f, "GLM: Failed constexpr");
 	static_assert(glm::vec3(1.0f, -1.0f, -1.0f).y < 0.0f, "GLM: Failed constexpr");

--- a/test/core/core_type_vec4.cpp
+++ b/test/core/core_type_vec4.cpp
@@ -750,8 +750,11 @@ static int test_inheritance()
 
 static int test_constexpr()
 {
-#if GLM_HAS_CONSTEXPR
+#ifdef GLM_NON_MATH_CONSTEXPR
 	static_assert(glm::vec4::length() == 4, "GLM: Failed constexpr");
+#endif
+
+#ifdef GLM_CONSTEXPR
 	static_assert(glm::vec4(1.0f).x > 0.0f, "GLM: Failed constexpr");
 	static_assert(glm::vec4(1.0f, -1.0f, -1.0f, -1.0f).x > 0.0f, "GLM: Failed constexpr");
 	static_assert(glm::vec4(1.0f, -1.0f, -1.0f, -1.0f).y < 0.0f, "GLM: Failed constexpr");

--- a/test/core/core_type_vec4.cpp
+++ b/test/core/core_type_vec4.cpp
@@ -750,11 +750,11 @@ static int test_inheritance()
 
 static int test_constexpr()
 {
-#ifdef GLM_NON_MATH_CONSTEXPR
+#if GLM_CONFIG_NON_MATH_CONSTEXP
 	static_assert(glm::vec4::length() == 4, "GLM: Failed constexpr");
 #endif
 
-#ifdef GLM_CONSTEXPR
+#if GLM_CONFIG_CONSTEXP
 	static_assert(glm::vec4(1.0f).x > 0.0f, "GLM: Failed constexpr");
 	static_assert(glm::vec4(1.0f, -1.0f, -1.0f, -1.0f).x > 0.0f, "GLM: Failed constexpr");
 	static_assert(glm::vec4(1.0f, -1.0f, -1.0f, -1.0f).y < 0.0f, "GLM: Failed constexpr");

--- a/test/ext/ext_quaternion_type.cpp
+++ b/test/ext/ext_quaternion_type.cpp
@@ -91,8 +91,11 @@ static int test_precision()
 
 static int test_constexpr()
 {
-#if GLM_HAS_CONSTEXPR
+#if GLM_CONFIG_NON_MATH_CONSTEXP
 	static_assert(glm::quat::length() == 4, "GLM: Failed constexpr");
+#endif
+
+#if GLM_CONFIG_CONSTEXP
 	static_assert(glm::quat(1.0f, glm::vec3(0.0f)).w > 0.0f, "GLM: Failed constexpr");
 #endif
 

--- a/test/ext/ext_vec1.cpp
+++ b/test/ext/ext_vec1.cpp
@@ -76,7 +76,7 @@ static int test_vec1_size()
 	Error += glm::vec1::length() == 1 ? 0 : 1;
 	Error += glm::dvec1::length() == 1 ? 0 : 1;
 
-	GLM_CONSTEXPR std::size_t Length = glm::vec1::length();
+	GLM_NON_MATH_CONSTEXPR std::size_t Length = glm::vec1::length();
 	Error += Length == 1 ? 0 : 1;
 
 	return Error;
@@ -134,8 +134,11 @@ static int test_bvec1_ctor()
 
 static int test_constexpr()
 {
-#if GLM_HAS_CONSTEXPR
+#if GLM_CONFIG_NON_MATH_CONSTEXP
 	static_assert(glm::vec1::length() == 1, "GLM: Failed constexpr");
+#endif
+
+#if GLM_CONFIG_CONSTEXP
 	static_assert(glm::vec1(1.0f).x > 0.0f, "GLM: Failed constexpr");
 #endif
 

--- a/test/ext/ext_vector_bool1.cpp
+++ b/test/ext/ext_vector_bool1.cpp
@@ -64,7 +64,7 @@ static int test_relational()
 template <typename genType>
 static int test_constexpr()
 {
-#	if GLM_HAS_CONSTEXPR
+#	if GLM_CONFIG_NON_MATH_CONSTEXP
 		static_assert(genType::length() == 1, "GLM: Failed constexpr");
 #	endif
 

--- a/test/gtc/gtc_type_aligned.cpp
+++ b/test/gtc/gtc_type_aligned.cpp
@@ -96,7 +96,7 @@ static int test_ctor()
 {
 	int Error = 0;
 
-#	if GLM_HAS_CONSTEXPR
+#	if GLM_CONFIG_CONSTEXP
 	{
 		constexpr glm::aligned_ivec4 v(1);
 
@@ -123,7 +123,7 @@ static int test_ctor()
 		Error += v.z == 1 ? 0 : 1;
 		Error += v.w == 1 ? 0 : 1;
 	}
-#	endif//GLM_HAS_CONSTEXPR
+#	endif//GLM_CONFIG_CONSTEXP
 
 	return Error;
 }


### PR DESCRIPTION
This fixes #860.