### PR TITLE
Fixing 'GLM_ENABLE_EXPERIMENTAL macro redefined' warning

### DIFF
--- a/glm/detail/glm.cpp
+++ b/glm/detail/glm.cpp
@@ -1,7 +1,9 @@
 /// @ref core
 /// @file glm/glm.cpp
 
+#ifndef GLM_ENABLE_EXPERIMENTAL
 #define GLM_ENABLE_EXPERIMENTAL
+#endif
 #include <glm/gtx/dual_quaternion.hpp>
 #include <glm/gtc/vec1.hpp>
 #include <glm/gtc/quaternion.hpp>


### PR DESCRIPTION
If I've already defined GLM_ENABLE_EXPERIMENTAL for my project, `glm/detail/glm.cpp` defines it again for cpp file without check if this macro is already defined.
This leads to
```
glm/detail/glm.cpp:4:9: warning: 'GLM_ENABLE_EXPERIMENTAL' macro redefined [-Wmacro-redefined]
#define GLM_ENABLE_EXPERIMENTAL
        ^
<command line>:2:9: note: previous definition is here
#define GLM_ENABLE_EXPERIMENTAL 1
        ^
1 warning generated.
```