### PR TITLE
Add const to quaternion conversion operators

### DIFF
--- a/glm/detail/type_quat.hpp
+++ b/glm/detail/type_quat.hpp
@@ -101,8 +101,8 @@ namespace glm
 
 		/// Explicit conversion operators
 #		if GLM_HAS_EXPLICIT_CONVERSION_OPERATORS
-			GLM_FUNC_DECL explicit operator mat<3, 3, T, Q>();
-			GLM_FUNC_DECL explicit operator mat<4, 4, T, Q>();
+			GLM_FUNC_DECL explicit operator mat<3, 3, T, Q>() const;
+			GLM_FUNC_DECL explicit operator mat<4, 4, T, Q>() const;
 #		endif
 
 		/// Create a quaternion from two normalized axis

--- a/glm/detail/type_quat.inl
+++ b/glm/detail/type_quat.inl
@@ -197,13 +197,13 @@ namespace detail
 
 #	if GLM_HAS_EXPLICIT_CONVERSION_OPERATORS
 	template<typename T, qualifier Q>
-	GLM_FUNC_QUALIFIER qua<T, Q>::operator mat<3, 3, T, Q>()
+	GLM_FUNC_QUALIFIER qua<T, Q>::operator mat<3, 3, T, Q>() const
 	{
 		return mat3_cast(*this);
 	}
 
 	template<typename T, qualifier Q>
-	GLM_FUNC_QUALIFIER qua<T, Q>::operator mat<4, 4, T, Q>()
+	GLM_FUNC_QUALIFIER qua<T, Q>::operator mat<4, 4, T, Q>() const
 	{
 		return mat4_cast(*this);
 	}


### PR DESCRIPTION
The explicit conversion operators from `qua<T, Q>` to `mat<3, 3, T, Q>` and `mat<4, 4, T, Q>` can be `const`, because they do not modify the quaternion. Without this change, the following code does not compile:
```C++
const glm::quat q(0.0f, 0.0f, 0.0f, 0.0f);
const glm::mat3 R(q);
```