### PR TITLE
Fixed typos

### DIFF
--- a/glm/ext/vector_double1.hpp
+++ b/glm/ext/vector_double1.hpp
@@ -16,7 +16,7 @@
 #include "../detail/type_vec1.hpp"
 
 #if GLM_MESSAGES == GLM_ENABLE && !defined(GLM_EXT_INCLUDED)
-#	pragma message("GLM: GLM_EXT_vector_dvec1 extension included")
+#	pragma message("GLM: GLM_EXT_vector_double1 extension included")
 #endif
 
 namespace glm

--- a/glm/gtc/round.hpp
+++ b/glm/gtc/round.hpp
@@ -22,7 +22,7 @@
 #include <limits>
 
 #if GLM_MESSAGES == GLM_ENABLE && !defined(GLM_EXT_INCLUDED)
-#	pragma message("GLM: GLM_GTC_integer extension included")
+#	pragma message("GLM: GLM_GTC_round extension included")
 #endif
 
 namespace glm


### PR DESCRIPTION
In ext/vector_double1.hpp:
The name of the extension is incorrectly displayed as "vector_dvec1".
It should be "vector_double1".

In gtc/round.hpp:
The name of the extension is incorrectly displayed as "integer".
It should be "round".