### PR TITLE
Silence C4244 warning

### DIFF
--- a/glm/gtc/random.inl
+++ b/glm/gtc/random.inl
@@ -228,7 +228,7 @@ namespace detail
 			w = x1 * x1 + x2 * x2;
 		} while(w > genType(1));
 
-		return x2 * Deviation * Deviation * sqrt((genType(-2) * log(w)) / w) + Mean;
+		return (genType)(x2 * Deviation * Deviation * sqrt((genType(-2) * log(w)) / w) + Mean);
 	}
 
 	template<length_t L, typename T, qualifier Q>

--- a/glm/gtc/random.inl
+++ b/glm/gtc/random.inl
@@ -228,7 +228,7 @@ namespace detail
 			w = x1 * x1 + x2 * x2;
 		} while(w > genType(1));
 
-		return (genType)(x2 * Deviation * Deviation * sqrt((genType(-2) * log(w)) / w) + Mean);
+		return static_cast<genType>(x2 * Deviation * Deviation * sqrt((genType(-2) * log(w)) / w) + Mean);
 	}
 
 	template<length_t L, typename T, qualifier Q>


### PR DESCRIPTION
In gtc/random.inl:
gaussRand issues a [C4244](https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-levels-3-and-4-c4244?view=vs-2019) compiler warning in MSVC.

Since this warning is unwarrented, a ~~C-type cast~~ static_cast is used to silence it.