### PR TITLE
SYCL support

### DIFF
--- a/glm/detail/setup.hpp
+++ b/glm/detail/setup.hpp
@@ -410,7 +410,6 @@
 #if GLM_COMPILER & GLM_COMPILER_CUDA
 #	define GLM_CUDA_FUNC_DEF __device__ __host__
 #	define GLM_CUDA_FUNC_DECL __device__ __host__
-#error "oops cuda shit"
 #else
 #	define GLM_CUDA_FUNC_DEF
 #	define GLM_CUDA_FUNC_DECL

--- a/glm/detail/setup.hpp
+++ b/glm/detail/setup.hpp
@@ -410,6 +410,7 @@
 #if GLM_COMPILER & GLM_COMPILER_CUDA
 #	define GLM_CUDA_FUNC_DEF __device__ __host__
 #	define GLM_CUDA_FUNC_DECL __device__ __host__
+#error "oops cuda shit"
 #else
 #	define GLM_CUDA_FUNC_DEF
 #	define GLM_CUDA_FUNC_DECL
@@ -528,6 +529,48 @@
 #else
 #	define GLM_EXPLICIT
 #endif
+
+///////////////////////////////////////////////////////////////////////////////////
+// SYCL
+
+#if GLM_COMPILER==GLM_COMPILER_SYCL
+
+#include <CL/sycl.hpp>
+#include <limits>
+
+namespace glm {
+namespace std {
+    // import sycl function into the namespace glm::std to force their usages.
+    // It's important to use the builtin intrinsics (sin, exp, ...)
+    // of sycl instead the std ones.
+    using namespace cl::sycl;
+
+    ///////////////////////////////////////////////////////////////////////////////
+    // Import some "harmless" std's stuffs used by glm into
+    // the new glm::std namespace.
+    template<typename T>
+    using numeric_limits = ::std::numeric_limits<T>;
+
+    using ::std::size_t;
+
+    using ::std::uint8_t;
+    using ::std::uint16_t;
+    using ::std::uint32_t;
+    using ::std::uint64_t;
+
+    using ::std::int8_t;
+    using ::std::int16_t;
+    using ::std::int32_t;
+    using ::std::int64_t;
+
+    using ::std::make_unsigned;
+    ///////////////////////////////////////////////////////////////////////////////
+} //namespace std
+} //namespace glm
+
+#endif
+
+///////////////////////////////////////////////////////////////////////////////////
 
 ///////////////////////////////////////////////////////////////////////////////////
 // Length type: all length functions returns a length_t type.

--- a/glm/detail/setup.hpp
+++ b/glm/detail/setup.hpp
@@ -539,31 +539,31 @@
 
 namespace glm {
 namespace std {
-    // import sycl function into the namespace glm::std to force their usages.
-    // It's important to use the builtin intrinsics (sin, exp, ...)
-    // of sycl instead the std ones.
-    using namespace cl::sycl;
+	// Import SYCL's functions into the namespace glm::std to force their usages.
+	// It's important to use the math built-in function (sin, exp, ...)
+	// of SYCL instead the std ones.
+	using namespace cl::sycl;
 
-    ///////////////////////////////////////////////////////////////////////////////
-    // Import some "harmless" std's stuffs used by glm into
-    // the new glm::std namespace.
-    template<typename T>
-    using numeric_limits = ::std::numeric_limits<T>;
+	///////////////////////////////////////////////////////////////////////////////
+	// Import some "harmless" std's stuffs used by glm into
+	// the new glm::std namespace.
+	template<typename T>
+	using numeric_limits = ::std::numeric_limits<T>;
 
-    using ::std::size_t;
+	using ::std::size_t;
 
-    using ::std::uint8_t;
-    using ::std::uint16_t;
-    using ::std::uint32_t;
-    using ::std::uint64_t;
+	using ::std::uint8_t;
+	using ::std::uint16_t;
+	using ::std::uint32_t;
+	using ::std::uint64_t;
 
-    using ::std::int8_t;
-    using ::std::int16_t;
-    using ::std::int32_t;
-    using ::std::int64_t;
+	using ::std::int8_t;
+	using ::std::int16_t;
+	using ::std::int32_t;
+	using ::std::int64_t;
 
-    using ::std::make_unsigned;
-    ///////////////////////////////////////////////////////////////////////////////
+	using ::std::make_unsigned;
+	///////////////////////////////////////////////////////////////////////////////
 } //namespace std
 } //namespace glm
 

--- a/glm/simd/platform.h
+++ b/glm/simd/platform.h
@@ -81,6 +81,9 @@
 #define GLM_COMPILER_CUDA75			0x100000B0
 #define GLM_COMPILER_CUDA80			0x100000C0
 
+// SYCL
+#define GLM_COMPILER_SYCL			0x00300000
+
 // Clang
 #define GLM_COMPILER_CLANG			0x20000000
 #define GLM_COMPILER_CLANG34		0x20000050
@@ -128,6 +131,10 @@
 #	elif CUDA_VERSION < 7000
 #		error "GLM requires CUDA 7.0 or higher"
 #	endif
+
+// SYCL
+#elif defined(__SYCL_DEVICE_ONLY__)
+#	define GLM_COMPILER GLM_COMPILER_SYCL
 
 // Clang
 #elif defined(__clang__)

--- a/readme.md
+++ b/readme.md
@@ -15,7 +15,7 @@ This library works perfectly with *[OpenGL](https://www.opengl.org)* but it also
 - [LLVM](http://llvm.org/) 3.4 and higher
 - [Visual C++](http://www.visualstudio.com/) 2013 and higher
 - [CUDA](https://developer.nvidia.com/about-cuda) 7.0 and higher (experimental)
-- [SYCL](https://www.khronos.org/sycl/) 1.2.1 and higher (experimental: only [ComputeCpp](https://codeplay.com/products/computesuite/computecpp) has been tested).
+- [SYCL](https://www.khronos.org/sycl/) (experimental: only [ComputeCpp](https://codeplay.com/products/computesuite/computecpp) implementation has been tested).
 - Any C++11 compiler
 
 For more information about *GLM*, please have a look at the [manual](manual.md) and the [API reference documentation](http://glm.g-truc.net/0.9.8/api/index.html).

--- a/readme.md
+++ b/readme.md
@@ -15,6 +15,7 @@ This library works perfectly with *[OpenGL](https://www.opengl.org)* but it also
 - [LLVM](http://llvm.org/) 3.4 and higher
 - [Visual C++](http://www.visualstudio.com/) 2013 and higher
 - [CUDA](https://developer.nvidia.com/about-cuda) 7.0 and higher (experimental)
+- [SYCL](https://www.khronos.org/sycl/) 1.2.1 and higher (experimental: only [ComputeCpp](https://codeplay.com/products/computesuite/computecpp) has been tested).
 - Any C++11 compiler
 
 For more information about *GLM*, please have a look at the [manual](manual.md) and the [API reference documentation](http://glm.g-truc.net/0.9.8/api/index.html).


### PR DESCRIPTION
I added some modifications to be able to use glm inside SYCL's kernel.

[https://www.khronos.org/sycl/](https://www.khronos.org/sycl/):
> SYCL (pronounced ‘sickle’) is a royalty-free, cross-platform abstraction layer that builds on the underlying concepts, portability and efficiency of OpenCL that enables code for heterogeneous processors to be written in a “single-source” style using completely standard C++

The core and ext functions should work out-of-box as long as they don't use the SYCL kernel's limitations (RTTI, dynamic allocation, recursion, function pointer).
