### PR TITLE
Fix gcc if constexpr error

### DIFF
--- a/glm/detail/setup.hpp
+++ b/glm/detail/setup.hpp
@@ -298,7 +298,7 @@
 # if (GLM_COMPILER & GLM_COMPILER_CLANG)
 #	define GLM_HAS_IF_CONSTEXPR __has_feature(cxx_if_constexpr)
 # elif (GLM_COMPILER & GLM_COMPILER_GCC) 
-#	define GLM_HAS_IF_CONSTEXPR GLM_COMPILER >= GLM_COMPILER_GCC7
+#	define GLM_HAS_IF_CONSTEXPR (__cplusplus >= 201703L)
 # elif (GLM_LANG & GLM_LANG_CXX17_FLAG)
 # 	define GLM_HAS_IF_CONSTEXPR 1
 # else


### PR DESCRIPTION
Check against __cplusplus version instead of compiler version. This fixes compilation errors when using an older cpp standard version with a newer gcc compiler. This flag requires GCC 4.7 or greater.