### PR TITLE
Fix lx norm

### DIFF
--- a/glm/gtx/norm.inl
+++ b/glm/gtx/norm.inl
@@ -71,13 +71,13 @@ namespace detail
 	template<typename T, qualifier Q>
 	GLM_FUNC_QUALIFIER T lxNorm(vec<3, T, Q> const& x, vec<3, T, Q> const& y, unsigned int Depth)
 	{
-		return pow(pow(y.x - x.x, T(Depth)) + pow(y.y - x.y, T(Depth)) + pow(y.z - x.z, T(Depth)), T(1) / T(Depth));
+		return pow(pow(abs(y.x - x.x), T(Depth)) + pow(abs(y.y - x.y), T(Depth)) + pow(abs(y.z - x.z), T(Depth)), T(1) / T(Depth));
 	}
 
 	template<typename T, qualifier Q>
 	GLM_FUNC_QUALIFIER T lxNorm(vec<3, T, Q> const& v, unsigned int Depth)
 	{
-		return pow(pow(v.x, T(Depth)) + pow(v.y, T(Depth)) + pow(v.z, T(Depth)), T(1) / T(Depth));
+		return pow(pow(abs(v.x), T(Depth)) + pow(abs(v.y), T(Depth)) + pow(abs(v.z), T(Depth)), T(1) / T(Depth));
 	}
 
 }//namespace glm

--- a/test/gtx/gtx_norm.cpp
+++ b/test/gtx/gtx_norm.cpp
@@ -1,9 +1,63 @@
 #define GLM_ENABLE_EXPERIMENTAL
 #include <glm/gtx/norm.hpp>
 
+int test_lxNorm()
+{
+	int Error(0);
+
+	{
+		unsigned int depth_1 = 1;
+		float normA = glm::lxNorm(glm::vec3(2, 3, 1), depth_1);
+		float normB = glm::l1Norm(glm::vec3(2, 3, 1));
+		Error += glm::epsilonEqual(normA, normB, 0.00001f) ? 0 : 1;
+		Error += glm::epsilonEqual(normA, 6.f, 0.00001f) ? 0 : 1;
+	}
+
+	{
+		unsigned int depth_1 = 1;
+		float normA = glm::lxNorm(glm::vec3(-1, -2, -3), depth_1);
+		float normB = glm::l1Norm(glm::vec3(-1, -2, -3));
+		Error += glm::epsilonEqual(normA, normB, 0.00001f) ? 0 : 1;
+		Error += glm::epsilonEqual(normA, 6.f, 0.00001f) ? 0 : 1;
+	}
+
+	{
+		unsigned int depth_2 = 2;
+		float normA = glm::lxNorm(glm::vec3(2, 3, 1), depth_2);
+		float normB = glm::l2Norm(glm::vec3(2, 3, 1));
+		Error += glm::epsilonEqual(normA, normB, 0.00001f) ? 0 : 1;
+		Error += glm::epsilonEqual(normA, 3.741657387f, 0.00001f) ? 0 : 1;
+	}
+
+	{
+		unsigned int depth_2 = 2;
+		float normA = glm::lxNorm(glm::vec3(-1, -2, -3), depth_2);
+		float normB = glm::l2Norm(glm::vec3(-1, -2, -3));
+		Error += glm::epsilonEqual(normA, normB, 0.00001f) ? 0 : 1;
+		Error += glm::epsilonEqual(normA, 3.741657387f, 0.00001f) ? 0 : 1;
+	}
+
+	{
+		unsigned int oddDepth = 3;
+		float norm = glm::lxNorm(glm::vec3(2, 3, 1), oddDepth);
+		Error += glm::epsilonEqual(norm, 3.301927249f, 0.00001f) ? 0 : 1;
+	}
+
+	{
+		unsigned int oddDepth = 3;
+		float norm = glm::lxNorm(glm::vec3(-1, -2, -3), oddDepth);
+		Error += glm::epsilonEqual(norm, 3.301927249f, 0.00001f) ? 0 : 1;
+	}
+
+
+	return Error;
+}
+
 int main()
 {
 	int Error(0);
+
+	Error += test_lxNorm();
 
 	return Error;
 }


### PR DESCRIPTION
This is a proposed fix for `lxNorm` wrt the issue I raised (https://github.com/g-truc/glm/issues/784).

This fix simply takes the absolute value of each component of a vector before computing the exponent and then the root. This means that using lxNorm with an odd number `depth` on a vector with negative components will now return a positive value.

I have also added unit tests that shows that this fails without that fix and particularly showing the discrepancy with  l1Norm. 