### PR TITLE
Fix compilation under xcode 6.4

### DIFF
--- a/glm/detail/type_quat.hpp
+++ b/glm/detail/type_quat.hpp
@@ -47,7 +47,7 @@ namespace glm
 				typename detail::storage<4, T, detail::is_aligned<Q>::value>::type data;
 			};
 #		else
-			T x, y, z, w;
+			T w, x, y, z;
 #		endif
 
 #		if GLM_SILENT_WARNINGS == GLM_ENABLE


### PR DESCRIPTION
This PR fix the ordering of quaternions fiels causing Compilation to fail under xcode6.4