### PR TITLE
correct compilation error on macOS with LLVM 9.0

### DIFF
--- a/glm/detail/setup.hpp
+++ b/glm/detail/setup.hpp
@@ -710,6 +710,12 @@ namespace detail
 		typedef unsigned char type;
 	};
 
+    template<>
+    struct make_unsigned<signed char>
+    {
+        typedef unsigned char type;
+    };
+
 	template<>
 	struct make_unsigned<short>
 	{

--- a/glm/detail/type_quat.inl
+++ b/glm/detail/type_quat.inl
@@ -90,32 +90,32 @@ namespace detail
 		template<typename T, qualifier Q>
 		GLM_FUNC_QUALIFIER GLM_CONSTEXPR qua<T, Q>::qua()
 #			if GLM_CONFIG_CTOR_INIT != GLM_CTOR_INIT_DISABLE
-			: w(1), x(0), y(0), z(0)
+			: x(0), y(0), z(0), w(1)
 #			endif
 		{}
 
 		template<typename T, qualifier Q>
 		GLM_FUNC_QUALIFIER GLM_CONSTEXPR qua<T, Q>::qua(qua<T, Q> const& q)
-			: w(q.w), x(q.x), y(q.y), z(q.z)
+			: x(q.x), y(q.y), z(q.z), w(q.w)
 		{}
 #	endif
 
 	template<typename T, qualifier Q>
 	template<qualifier P>
 	GLM_FUNC_QUALIFIER GLM_CONSTEXPR qua<T, Q>::qua(qua<T, P> const& q)
-		: w(q.w), x(q.x), y(q.y), z(q.z)
+		: x(q.x), y(q.y), z(q.z), w(q.w)
 	{}
 
 	// -- Explicit basic constructors --
 
 	template<typename T, qualifier Q>
 	GLM_FUNC_QUALIFIER GLM_CONSTEXPR qua<T, Q>::qua(T s, vec<3, T, Q> const& v)
-		: w(s), x(v.x), y(v.y), z(v.z)
+		: x(v.x), y(v.y), z(v.z), w(s)
 	{}
 
 	template <typename T, qualifier Q>
 	GLM_FUNC_QUALIFIER GLM_CONSTEXPR qua<T, Q>::qua(T _w, T _x, T _y, T _z)
-		: w(_w), x(_x), y(_y), z(_z)
+		: x(_x), y(_y), z(_z), w(_w)
 	{}
 
 	// -- Conversion constructors --

--- a/glm/ext/scalar_integer.hpp
+++ b/glm/ext/scalar_integer.hpp
@@ -57,7 +57,7 @@ namespace glm
 
 	/// Higher multiple number of Source.
 	///
-	/// @tparam genType Floating-point or integer scalar or vector types.
+	/// @tparam genIUType Floating-point or integer scalar or vector types.
 	///
 	/// @param v Source value to which is applied the function
 	/// @param Multiple Must be a null or positive value
@@ -68,7 +68,7 @@ namespace glm
 
 	/// Lower multiple number of Source.
 	///
-	/// @tparam genType Floating-point or integer scalar or vector types.
+	/// @tparam genIUType Floating-point or integer scalar or vector types.
 	///
 	/// @param v Source value to which is applied the function
 	/// @param Multiple Must be a null or positive value

--- a/glm/ext/scalar_integer.inl
+++ b/glm/ext/scalar_integer.inl
@@ -178,7 +178,7 @@ namespace detail
 	{
 		GLM_STATIC_ASSERT(std::numeric_limits<genIUType>::is_integer, "'prevPowerOfTwo' only accept integer inputs");
 
-		return isPowerOfTwo(value) ? value : static_cast<genIUType>(1) << findMSB(value);
+		return isPowerOfTwo(value) ? value : static_cast<genIUType>(1 << findMSB(value));
 	}
 
 	template<typename genIUType>


### PR DESCRIPTION
-Werror -Weverything prevent test code from compiling with Xcode 9.2, LLVM 90 on macOS

