### PR TITLE
Add missing '@' in the documentation

### DIFF
--- a/doc/api/a00769.html
+++ b/doc/api/a00769.html
@@ -413,7 +413,13 @@ Functions</h2></td></tr>
 </div><div class="memdoc">
 
 <p>Compute the rotation between two vectors. </p>
-<p>param orig vector, needs to be normalized param dest vector, needs to be normalized</p>
+<dl class="params"><dt>Parameters</dt><dd>
+  <table class="params">
+    <tr><td class="paramname">orig</td><td>vector, needs to be normalized </td></tr>
+    <tr><td class="paramname">dest</td><td>vector, needs to be normalized</td></tr>
+  </table>
+  </dd>
+</dl>
 <dl class="section see"><dt>See also</dt><dd><a class="el" href="a00769.html" title="Include &lt;glm/gtx/quaternion.hpp&gt; to use the features of this extension. ">GLM_GTX_quaternion</a> </dd></dl>
 
 </div>

--- a/glm/gtx/quaternion.hpp
+++ b/glm/gtx/quaternion.hpp
@@ -153,8 +153,8 @@ namespace glm
 		T const& a);
 
 	/// Compute the rotation between two vectors.
-	/// param orig vector, needs to be normalized
-	/// param dest vector, needs to be normalized
+	/// @param orig vector, needs to be normalized
+	/// @param dest vector, needs to be normalized
 	///
 	/// @see gtx_quaternion
 	template<typename T, qualifier Q>


### PR DESCRIPTION
"param" was not being recognised as a keyword, messing up the layout of
`glm::rotation()`'s parameter description.