### PR TITLE
Fix loss of precision on small angles in qua's pow

### DIFF
--- a/glm/ext/quaternion_trigonometric.inl
+++ b/glm/ext/quaternion_trigonometric.inl
@@ -1,8 +1,15 @@
+#include "scalar_constants.hpp"
+
 namespace glm
 {
 	template<typename T, qualifier Q>
 	GLM_FUNC_QUALIFIER T angle(qua<T, Q> const& x)
 	{
+		if (abs(x.w) > cos_one_over_two<T>())
+		{
+			return asin(sqrt(x.x * x.x + x.y * x.y + x.z * x.z)) * static_cast<T>(2);
+		}
+
 		return acos(x.w) * static_cast<T>(2);
 	}
 

--- a/glm/ext/scalar_constants.hpp
+++ b/glm/ext/scalar_constants.hpp
@@ -30,6 +30,10 @@ namespace glm
 	template<typename genType>
 	GLM_FUNC_DECL GLM_CONSTEXPR genType pi();
 
+	/// Return the value of cos(1 / 2) for floating point types.
+	template<typename genType>
+	GLM_FUNC_DECL GLM_CONSTEXPR genType cos_one_over_two();
+
 	/// @}
 } //namespace glm
 

--- a/glm/ext/scalar_constants.inl
+++ b/glm/ext/scalar_constants.inl
@@ -15,4 +15,10 @@ namespace glm
 		GLM_STATIC_ASSERT(std::numeric_limits<genType>::is_iec559, "'pi' only accepts floating-point inputs");
 		return static_cast<genType>(3.14159265358979323846264338327950288);
 	}
+
+	template<typename genType>
+	GLM_FUNC_QUALIFIER GLM_CONSTEXPR genType cos_one_over_two()
+	{
+		return genType(0.877582561890372716130286068203503191);
+	}
 } //namespace glm

--- a/glm/gtc/constants.inl
+++ b/glm/gtc/constants.inl
@@ -163,4 +163,5 @@ namespace glm
 	{
 		return genType(1.61803398874989484820458683436563811);
 	}
+
 } //namespace glm


### PR DESCRIPTION
I encountered loss of precision when using quaternions with very small angles with the function `pow()`. This is because it determines the angle in the quaternion by applying `acos()` to the scale component `w`, which is equal to `1.` because of dramatic cancellation.

However, it is still possible to recover an accurate angle by looking at the non-scale components (which are then very close to, but different than, `0.`) and using `asin()`. I have written a fix to verify that this was possible, and it might be useful to merge it into the project.

I have tried to take non-normalized quaternions into account, but I may have missed something. Any feedback is welcome.

**Edit:** I have included a similar fix for qua's `angle()` function