### PR TITLE
Request to update licence.

### DIFF
--- a/copying.txt
+++ b/copying.txt
@@ -1,7 +1,7 @@
 ================================================================================
 OpenGL Mathematics (GLM)
 --------------------------------------------------------------------------------
-GLM is licensed under The Happy Bunny License and MIT License
+GLM is licensed under The Happy Bunny License or MIT License
 
 ================================================================================
 The Happy Bunny License (Modified MIT License)


### PR DESCRIPTION
It is not clear if the software is licensed by either MIT or Happy Bunny or BOTH by MIT and Happy Bunny.

In the official website ( https://glm.g-truc.net/0.9.9/index.html ) I notice "OR":
"The source code and the documentation, including this manual, are licensed under the Happy Bunny License (Modified MIT) or the MIT License."
Also, there is "OR" in the readme.md ( https://github.com/g-truc/glm )
"The source code and the documentation are licensed under both the Happy Bunny License (Modified MIT) or the MIT License."