### PR TITLE
Fix Arm 64bit detection

### DIFF
--- a/glm/detail/setup.hpp
+++ b/glm/detail/setup.hpp
@@ -35,12 +35,12 @@
 ///////////////////////////////////////////////////////////////////////////////////
 // Build model
 
-#if defined(__arch64__) || defined(__LP64__) || defined(_M_X64) || defined(__ppc64__) || defined(__x86_64__)
+#if defined(__LP64__)
 #	define GLM_MODEL	GLM_MODEL_64
-#elif defined(__i386__) || defined(__ppc__)
+#elif defined(__ILP32__)
 #	define GLM_MODEL	GLM_MODEL_32
 #else
-#	define GLM_MODEL	GLM_MODEL_32
+#	error "Architecture must be either 32 or 64-bits"
 #endif//
 
 #if !defined(GLM_MODEL) && GLM_COMPILER != 0


### PR DESCRIPTION
__arch64__ is probably meant for __aarch64__, but forgets __arm64__ which is the iOS way.
But this needs simplification: __LP64__ is 64 bits, __ILP32__ is 32 bits. Checking for the target architecture is not the way to go and leads to mistaks like this.
Not a bug, just a simplification of something already messy.

Quickly tested using:

$CXX nova/external/glm/glm/detail/setup.hpp -dM -E  | grep GLM_MODEL
$CXX -m32 nova/external/glm/glm/detail/setup.hpp -dM -E  | grep GLM_MODEL
$CXX -mx32 nova/external/glm/glm/detail/setup.hpp -dM -E  | grep GLM_MODEL
$CXX --target=armv7a nova/external/glm/glm/detail/setup.hpp -dM -E  | grep GLM_MODEL
$CXX --target=aarch64 nova/external/glm/glm/detail/setup.hpp -dM -E  | grep GLM_MODEL
