### PR TITLE
More simd/Neon functions

### DIFF
--- a/glm/detail/func_geometric_simd.inl
+++ b/glm/detail/func_geometric_simd.inl
@@ -96,4 +96,71 @@ namespace detail
 }//namespace detail
 }//namespace glm
 
+#elif GLM_ARCH & GLM_ARCH_NEON_BIT
+namespace glm{
+namespace detail
+{
+	template<qualifier Q>
+	struct compute_length<4, float, Q, true>
+	{
+		GLM_FUNC_QUALIFIER static float call(vec<4, float, Q> const& v)
+		{
+			return compute_dot<vec<4, float, Q>, float, true>::call(v, v);
+		}
+	};
+
+	template<qualifier Q>
+	struct compute_distance<4, float, Q, true>
+	{
+		GLM_FUNC_QUALIFIER static float call(vec<4, float, Q> const& p0, vec<4, float, Q> const& p1)
+		{
+			return compute_length<4, float, Q, true>::call(p1 - p0);
+		}
+	};
+
+
+	template<qualifier Q>
+	struct compute_dot<vec<4, float, Q>, float, true>
+	{
+		GLM_FUNC_QUALIFIER static float call(vec<4, float, Q> const& x, vec<4, float, Q> const& y)
+		{
+#if GLM_ARCH & GLM_ARCH_ARMV8_BIT
+			float32x4_t v = vmulq_f32(x.data, y.data);
+			v = vpaddq_f32(v, v);
+			v = vpaddq_f32(v, v);
+			return vgetq_lane_f32(v, 0);
+#else  // Armv7a with Neon
+			float32x4_t p = vmulq_f32(x.data, y.data);
+			float32x2_t v = vpadd_f32(vget_low_f32(p), vget_high_f32(p));
+			v = vpadd_f32(v, v);
+			return vget_lane_f32(v, 0);
+#endif
+		}
+	};
+
+	template<qualifier Q>
+	struct compute_normalize<4, float, Q, true>
+	{
+		GLM_FUNC_QUALIFIER static vec<4, float, Q> call(vec<4, float, Q> const& v)
+		{
+			float32x4_t p = vmulq_f32(v.data, v.data);
+#if GLM_ARCH & GLM_ARCH_ARMV8_BIT
+			p = vpaddq_f32(p, p);
+			p = vpaddq_f32(p, p);
+#else
+			float32x2_t t = vpadd_f32(vget_low_f32(p), vget_high_f32(p));
+			t = vpadd_f32(t, t);
+			p = vcombine_f32(t, t);
+#endif
+
+			float32x4_t vd = vrsqrteq_f32(p);
+			vec<4, float, Q> Result;
+			Result.data = vmulq_f32(v, vd);
+			return Result;
+		}
+	};
+
+}//namespace detail
+}//namespace glm
+
 #endif//GLM_ARCH & GLM_ARCH_SSE2_BIT

--- a/glm/detail/func_geometric_simd.inl
+++ b/glm/detail/func_geometric_simd.inl
@@ -159,7 +159,6 @@ namespace detail
 			return Result;
 		}
 	};
-
 }//namespace detail
 }//namespace glm
 

--- a/glm/detail/setup.hpp
+++ b/glm/detail/setup.hpp
@@ -35,9 +35,9 @@
 ///////////////////////////////////////////////////////////////////////////////////
 // Build model
 
-#if defined(__arch64__) || defined(__LP64__) || defined(_M_X64) || defined(__ppc64__) || defined(__x86_64__)
+#if defined(_M_ARM64) || defined(__LP64__) || defined(_M_X64) || defined(__ppc64__) || defined(__x86_64__)
 #	define GLM_MODEL	GLM_MODEL_64
-#elif defined(__i386__) || defined(__ppc__)
+#elif defined(__i386__) || defined(__ppc__) || defined(__ILP32__) || defined(_M_ARM)
 #	define GLM_MODEL	GLM_MODEL_32
 #else
 #	define GLM_MODEL	GLM_MODEL_32

--- a/test/gtx/gtx_fast_square_root.cpp
+++ b/test/gtx/gtx_fast_square_root.cpp
@@ -14,7 +14,7 @@ int test_fastInverseSqrt()
 	Error += glm::all(glm::epsilonEqual(glm::fastInverseSqrt(glm::dvec3(1.0)), glm::dvec3(1.0), 0.01)) ? 0 : 1;
 	Error += glm::all(glm::epsilonEqual(glm::fastInverseSqrt(glm::dvec4(1.0)), glm::dvec4(1.0), 0.01)) ? 0 : 1;
 
-	return 0;
+	return Error;
 }
 
 int test_fastDistance()


### PR DESCRIPTION
Continuing on the Neon support. Simple geometric functions that Neon can help make faster.
Not expecting a lot of performance improvement from that PR, but keeps going from scalar to vector all the time for simple arithmetic functions helps the overall performance of glm on Arm cores.