### PR TITLE
Modernize cmake files 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -232,8 +232,6 @@ elseif(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
 	add_definitions(-D_CRT_SECURE_NO_WARNINGS)
 endif()
 
-include_directories("${PROJECT_SOURCE_DIR}")
-
 add_subdirectory(glm)
 add_subdirectory(test)
 

--- a/glm/CMakeLists.txt
+++ b/glm/CMakeLists.txt
@@ -42,25 +42,29 @@ source_group("SIMD Files" FILES ${SIMD_SOURCE})
 source_group("SIMD Files" FILES ${SIMD_INLINE})
 source_group("SIMD Files" FILES ${SIMD_HEADER})
 
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/..)
-
 if(BUILD_STATIC_LIBS)
-add_library(glm_static STATIC ${ROOT_TEXT} ${ROOT_MD} ${ROOT_NAT}
-	${ROOT_SOURCE}    ${ROOT_INLINE}    ${ROOT_HEADER}
-	${CORE_SOURCE}    ${CORE_INLINE}    ${CORE_HEADER}
-	${EXT_SOURCE}     ${EXT_INLINE}     ${EXT_HEADER}
-	${GTC_SOURCE}     ${GTC_INLINE}     ${GTC_HEADER}
-	${GTX_SOURCE}     ${GTX_INLINE}     ${GTX_HEADER}
-	${SIMD_SOURCE}    ${SIMD_INLINE}    ${SIMD_HEADER})
+	add_library(glm_static STATIC ${ROOT_TEXT} ${ROOT_MD} ${ROOT_NAT}
+		${ROOT_SOURCE}    ${ROOT_INLINE}    ${ROOT_HEADER}
+		${CORE_SOURCE}    ${CORE_INLINE}    ${CORE_HEADER}
+		${EXT_SOURCE}     ${EXT_INLINE}     ${EXT_HEADER}
+		${GTC_SOURCE}     ${GTC_INLINE}     ${GTC_HEADER}
+		${GTX_SOURCE}     ${GTX_INLINE}     ${GTX_HEADER}
+		${SIMD_SOURCE}    ${SIMD_INLINE}    ${SIMD_HEADER})
+	target_include_directories(glm_static PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/..)
+	# Add alias target
+	add_library(glm::glm_static ALIAS glm_static)
 endif()
 
 if(BUILD_SHARED_LIBS)
-add_library(glm_shared SHARED ${ROOT_TEXT} ${ROOT_MD} ${ROOT_NAT}
-	${ROOT_SOURCE}    ${ROOT_INLINE}    ${ROOT_HEADER}
-	${CORE_SOURCE}    ${CORE_INLINE}    ${CORE_HEADER}
-	${EXT_SOURCE}     ${EXT_INLINE}     ${EXT_HEADER}
-	${GTC_SOURCE}     ${GTC_INLINE}     ${GTC_HEADER}
-	${GTX_SOURCE}     ${GTX_INLINE}     ${GTX_HEADER}
-	${SIMD_SOURCE}    ${SIMD_INLINE}    ${SIMD_HEADER})
+	add_library(glm_shared SHARED ${ROOT_TEXT} ${ROOT_MD} ${ROOT_NAT}
+		${ROOT_SOURCE}    ${ROOT_INLINE}    ${ROOT_HEADER}
+		${CORE_SOURCE}    ${CORE_INLINE}    ${CORE_HEADER}
+		${EXT_SOURCE}     ${EXT_INLINE}     ${EXT_HEADER}
+		${GTC_SOURCE}     ${GTC_INLINE}     ${GTC_HEADER}
+		${GTX_SOURCE}     ${GTX_INLINE}     ${GTX_HEADER}
+		${SIMD_SOURCE}    ${SIMD_INLINE}    ${SIMD_HEADER})
+	target_include_directories(glm_shared PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/..)
+	# Add alias target
+	add_library(glm::glm_shared ALIAS glm_shared)
 endif()
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -5,6 +5,8 @@ function(glmCreateTestGTC NAME)
 	add_test(
 		NAME ${SAMPLE_NAME}
 		COMMAND $<TARGET_FILE:${SAMPLE_NAME}> )
+		
+	target_link_libraries(${SAMPLE_NAME} PRIVATE glm::glm_static)
 endfunction()
 
 if(GLM_TEST_ENABLE)


### PR DESCRIPTION
I've replaced the legacy `include_directories` with `target_include_directories`. The problem was that include_directories would not work if you added glm via `add_subdirectory`.
The other thing I added as an alias target for `glm_static` and `glm_shared`. The advantage of these alias targets is that your going to get an CMake build error when trying to use `taget_link_libraries` instead of an compiler error. Which, at least in theory, should make it easier to find the problem if you miss typed the target name.

References:
https://cmake.org/cmake/help/latest/command/target_include_directories.html
https://stackoverflow.com/questions/31969547/what-is-the-difference-between-include-directories-and-target-include-directorie