### PR TITLE
bugfix for intersection ray/plane, added related tests

### DIFF
--- a/glm/gtx/intersect.inl
+++ b/glm/gtx/intersect.inl
@@ -13,10 +13,13 @@ namespace glm
 		typename genType::value_type d = glm::dot(dir, planeNormal);
 		typename genType::value_type Epsilon = std::numeric_limits<typename genType::value_type>::epsilon();
 
-		if(d < -Epsilon)
+		if(glm::abs(d) > Epsilon)  // if dir and planeNormal are not perpendicular
 		{
-			intersectionDistance = glm::dot(planeOrig - orig, planeNormal) / d;
-			return true;
+			typename genType::value_type const tmp_intersectionDistance = 	glm::dot(planeOrig - orig, planeNormal) / d;
+			if (tmp_intersectionDistance > static_cast<typename genType::value_type>(0)) { // allow only intersections
+				intersectionDistance = tmp_intersectionDistance;
+				return true;
+			}
 		}
 
 		return false;

--- a/test/gtx/gtx_intersect.cpp
+++ b/test/gtx/gtx_intersect.cpp
@@ -3,6 +3,39 @@
 #include <glm/gtc/epsilon.hpp>
 #include <glm/gtx/intersect.hpp>
 
+int test_intersectRayPlane()
+{
+	int Error = 0;
+	glm::vec3 const PlaneOrigin(0, 0, 1);
+	glm::vec3 const PlaneNormal(0, 0, -1);
+	glm::vec3 const RayOrigin(0, 0, 0);
+	glm::vec3 const RayDir(0, 0, 1);
+
+	// check that inversion of the plane normal has no effect
+	{
+		float Distance = 0;
+		bool const Result = glm::intersectRayPlane(RayOrigin, RayDir, PlaneOrigin, PlaneNormal, Distance);
+		Error += glm::abs(Distance - 1.f) <= std::numeric_limits<float>::epsilon() ? 0 : 1;
+		Error += Result ? 0 : 1;
+	}
+	{
+		float Distance = 0;
+		bool const Result = glm::intersectRayPlane(RayOrigin, RayDir, PlaneOrigin, -1.f * PlaneNormal, Distance);
+		Error += glm::abs(Distance - 1.f) <= std::numeric_limits<float>::epsilon() ? 0 : 1;
+		Error += Result ? 0 : 1;
+	}
+
+	// check if plane is before of behind the ray origin
+	{
+		float Distance = 9.9999f; // value should not be changed
+		bool const Result = glm::intersectRayPlane(RayOrigin, RayDir, -1.f * PlaneOrigin, PlaneNormal, Distance);
+		Error += glm::abs(Distance - 9.9999f) <= std::numeric_limits<float>::epsilon() ? 0 : 1;
+		Error += Result ? 1 : 0; // there is no intersection in front of the ray origin, only behind
+	}
+
+	return Error;
+}
+
 int test_intersectRayTriangle()
 {
 	int Error = 0;
@@ -47,6 +80,7 @@ int main()
 {
 	int Error = 0;
 
+	Error += test_intersectRayPlane();
 	Error += test_intersectRayTriangle();
 	Error += test_intersectLineTriangle();
 


### PR DESCRIPTION
If a ray has an intersection with a plane, inverting the plane normal should have no effect on the result. Additionally, it might be a difference, if the plane is in front of the ray-origin (positive intersection distance) or behind (negative intersection distance). The current code doesn't handle all these cases correct.