### PR TITLE
Fix Wimplicit-int-float-conversion warnings with clang 10+

### DIFF
--- a/glm/gtx/scalar_multiplication.hpp
+++ b/glm/gtx/scalar_multiplication.hpp
@@ -54,7 +54,7 @@ namespace glm
 	template<typename T> \
 	return_type_scalar_multiplication<T, Vec> \
 	operator/(Vec lh, T const& s){ \
-		return lh *= 1.0f / s; \
+		return lh *= 1.0f / static_cast<float>(s); \
 	}
 
 GLM_IMPLEMENT_SCAL_MULT(vec2)

--- a/test/gtx/gtx_fast_trigonometry.cpp
+++ b/test/gtx/gtx_fast_trigonometry.cpp
@@ -239,12 +239,12 @@ namespace taylorCos
 		std::vector<glm::vec4> Results;
 		Results.resize(Samples);
 
-		float Steps = (End - Begin) / Samples;
+		float Steps = (End - Begin) / float(Samples);
 
 		std::clock_t const TimeStampBegin = std::clock();
 
 		for(std::size_t i = 0; i < Samples; ++i)
-			Results[i] = fastCosNew(AngleShift + glm::vec4(Begin + Steps * i));
+			Results[i] = fastCosNew(AngleShift + glm::vec4(Begin + Steps * float(i)));
 
 		std::clock_t const TimeStampEnd = std::clock();
 
@@ -280,12 +280,12 @@ namespace taylorCos
 		std::vector<glm::vec4> Results;
 		Results.resize(Samples);
 
-		float Steps = (End - Begin) / Samples;
+		float Steps = (End - Begin) / float(Samples);
 
 		std::clock_t const TimeStampBegin = std::clock();
 
 		for(std::size_t i = 0; i < Samples; ++i)
-			Results[i] = taylorCos::fastCosDeterminisctic(AngleShift + glm::vec4(Begin + Steps * i));
+			Results[i] = taylorCos::fastCosDeterminisctic(AngleShift + glm::vec4(Begin + Steps * float(i)));
 
 		std::clock_t const TimeStampEnd = std::clock();
 
@@ -327,12 +327,12 @@ namespace taylorCos
 		std::vector<glm::vec4> Results;
 		Results.resize(Samples);
 
-		float Steps = (End - Begin) / Samples;
+		float Steps = (End - Begin) / float(Samples);
 
 		std::clock_t const TimeStampBegin = std::clock();
 
 		for(std::size_t i = 0; i < Samples; ++i)
-			Results[i] = taylorCos::fastRefCos(AngleShift + glm::vec4(Begin + Steps * i));
+			Results[i] = taylorCos::fastRefCos(AngleShift + glm::vec4(Begin + Steps * float(i)));
 
 		std::clock_t const TimeStampEnd = std::clock();
 
@@ -349,12 +349,12 @@ namespace taylorCos
 		std::vector<glm::vec4> Results;
 		Results.resize(Samples);
 
-		float Steps = (End - Begin) / Samples;
+		float Steps = (End - Begin) / float(Samples);
 
 		std::clock_t const TimeStampBegin = std::clock();
 
 		for(std::size_t i = 0; i < Samples; ++i)
-			Results[i] = glm::fastCos(AngleShift + glm::vec4(Begin + Steps * i));
+			Results[i] = glm::fastCos(AngleShift + glm::vec4(Begin + Steps * float(i)));
 
 		std::clock_t const TimeStampEnd = std::clock();
 
@@ -371,12 +371,12 @@ namespace taylorCos
 		std::vector<glm::vec4> Results;
 		Results.resize(Samples);
 
-		float Steps = (End - Begin) / Samples;
+		float Steps = (End - Begin) / float(Samples);
 
 		std::clock_t const TimeStampBegin = std::clock();
 
 		for(std::size_t i = 0; i < Samples; ++i)
-			Results[i] = glm::cos(AngleShift + glm::vec4(Begin + Steps * i));
+			Results[i] = glm::cos(AngleShift + glm::vec4(Begin + Steps * float(i)));
 
 		std::clock_t const TimeStampEnd = std::clock();
 
@@ -466,12 +466,12 @@ namespace taylor2
 		std::vector<float> Results;
 		Results.resize(Samples);
 
-		float Steps = (End - Begin) / Samples;
+		float Steps = (End - Begin) / float(Samples);
 
 		std::clock_t const TimeStampBegin = std::clock();
 
 		for(std::size_t i = 0; i < Samples; ++i)
-			Results[i] = taylorCosA(AngleShift.x + Begin + Steps * i);
+			Results[i] = taylorCosA(AngleShift.x + Begin + Steps * float(i));
 
 		std::clock_t const TimeStampEnd = std::clock();
 
@@ -488,12 +488,12 @@ namespace taylor2
 		std::vector<float> Results;
 		Results.resize(Samples);
 
-		float Steps = (End - Begin) / Samples;
+		float Steps = (End - Begin) / float(Samples);
 
 		std::clock_t const TimeStampBegin = std::clock();
 
 		for(std::size_t i = 0; i < Samples; ++i)
-			Results[i] = taylorCosB(AngleShift.x + Begin + Steps * i);
+			Results[i] = taylorCosB(AngleShift.x + Begin + Steps * float(i));
 
 		std::clock_t const TimeStampEnd = std::clock();
 
@@ -510,12 +510,12 @@ namespace taylor2
 		std::vector<float> Results;
 		Results.resize(Samples);
 
-		float Steps = (End - Begin) / Samples;
+		float Steps = (End - Begin) / float(Samples);
 
 		std::clock_t const TimeStampBegin = std::clock();
 
 		for(std::size_t i = 0; i < Samples; ++i)
-			Results[i] = taylorCosC(AngleShift.x + Begin + Steps * i);
+			Results[i] = taylorCosC(AngleShift.x + Begin + Steps * float(i));
 
 		std::clock_t const TimeStampEnd = std::clock();
 


### PR DESCRIPTION
This is a new warning in clang which will be available in clang 10
onwards

Fixes
error: implicit conversion from 'const int' to 'float' may lose precision [-Werror,-Wimplicit-int-float-conversion]