### PR TITLE
Fix the readme example to successfully include `glm::pi`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -29,7 +29,7 @@ Thanks for contributing to the project by [submitting issues](https://github.com
 #include <glm/mat4x4.hpp> // glm::mat4
 #include <glm/ext/matrix_transform.hpp> // glm::translate, glm::rotate, glm::scale
 #include <glm/ext/matrix_clip_space.hpp> // glm::perspective
-#include <glm/ext/constants.hpp> // glm::pi
+#include <glm/ext/scalar_constants.hpp> // glm::pi
 
 glm::mat4 camera(float Translate, glm::vec2 const& Rotate)
 {


### PR DESCRIPTION
I was just trying to build the latest release inside of my project using the starter code that had been provided in the readme. Upon building, `<glm/ext/constants.hpp>` failed to be included and changing the include to `#include <glm/ext/scalar_constants.hpp>` fixed the issue and resulted int a successful build.