### PR TITLE
Fixed warning when compiling with MSVS in SIMD mode

### DIFF
--- a/glm/ext/matrix_transform.inl
+++ b/glm/ext/matrix_transform.inl
@@ -144,9 +144,10 @@ namespace glm
 	template<typename T, qualifier Q>
 	GLM_FUNC_QUALIFIER mat<4, 4, T, Q> lookAt(vec<3, T, Q> const& eye, vec<3, T, Q> const& center, vec<3, T, Q> const& up)
 	{
-		GLM_IF_CONSTEXPR(GLM_CONFIG_CLIP_CONTROL & GLM_CLIP_CONTROL_LH_BIT)
-			return lookAtLH(eye, center, up);
-		else
-			return lookAtRH(eye, center, up);
+#       if (GLM_CONFIG_CLIP_CONTROL & GLM_CLIP_CONTROL_LH_BIT)
+            return lookAtLH(eye, center, up);
+#       else
+            return lookAtRH(eye, center, up);
+#       endif
 	}
 }//namespace glm


### PR DESCRIPTION
When compiling GLM with SIMD on MSVC compiler it detects that if constexpr can be used but this feature is exclusive with SIMD and warning is emitted (warning C4127: conditional expression is constant).