### PR TITLE
Fix quaternion orientation in `glm::decompose`

### DIFF
--- a/glm/gtx/matrix_decompose.inl
+++ b/glm/gtx/matrix_decompose.inl
@@ -159,9 +159,9 @@ namespace detail
 			root = sqrt(trace + static_cast<T>(1.0));
 			Orientation.w = static_cast<T>(0.5) * root;
 			root = static_cast<T>(0.5) / root;
-			Orientation.x = root * (Row[1].z - Row[2].y);
-			Orientation.y = root * (Row[2].x - Row[0].z);
-			Orientation.z = root * (Row[0].y - Row[1].x);
+			Orientation.x = root * (Row[2].y - Row[1].z);
+			Orientation.y = root * (Row[0].z - Row[2].x);
+			Orientation.z = root * (Row[1].x - Row[0].y);
 		} // End if > 0
 		else
 		{


### PR DESCRIPTION
Between 0.9.8 and 0.9.9 a change to the implementation of `decompose` caused the conjugate of the rotation quaternion to be returned. This has also been noted in [this Stack Overflow question](https://stackoverflow.com/questions/17918033/glm-decompose-mat4-into-translation-and-rotation), in particular [this comment](https://stackoverflow.com/a/56587367). This seems like a regression that ought to be fixed to avoid having to conjugate the result of `decompose` in the future. 