### PR TITLE
Fixed typo in documentation

### DIFF
--- a/glm/trigonometric.hpp
+++ b/glm/trigonometric.hpp
@@ -96,7 +96,7 @@ namespace glm
 	template<length_t L, typename T, qualifier Q>
 	GLM_FUNC_DECL vec<L, T, Q> asin(vec<L, T, Q> const& x);
 
-	/// Arc cosine. Returns an angle whose sine is x.
+	/// Arc cosine. Returns an angle whose cosine is x.
 	/// The range of values returned by this function is [0, PI].
 	/// Results are undefined if |x| > 1.
 	///


### PR DESCRIPTION
A typo in acos function description is changed.