### PR TITLE
Incorrect mat3 value_ptr behavior with SIMD

### DIFF
--- a/glm/gtc/type_ptr.inl
+++ b/glm/gtc/type_ptr.inl
@@ -61,6 +61,10 @@ namespace glm
 		return &(m[0].x);
 	}
 
+	// BUG:
+	// Incorrect behavior when defined GLM_FORCE_DEFAULT_ALIGNED_GENTYPES
+	// mat3 pointer contains aligment bytes
+
 	template<typename T, qualifier Q>
 	GLM_FUNC_QUALIFIER T* value_ptr(mat<3, 3, T, Q>& m)
 	{


### PR DESCRIPTION
Returned pointer contains alignment bytes.