### PR TITLE
Support clang in C++1z mode

### DIFF
--- a/glm/detail/setup.hpp
+++ b/glm/detail/setup.hpp
@@ -119,7 +119,7 @@
 #		define GLM_LANG (GLM_LANG_CXX2A | GLM_LANG_EXT)
 #	elif __cplusplus == 201703L || GLM_LANG_PLATFORM == 201703L
 #		define GLM_LANG (GLM_LANG_CXX17 | GLM_LANG_EXT)
-#	elif __cplusplus == 201402L || __cplusplus == 201500L || GLM_LANG_PLATFORM == 201402L
+#	elif __cplusplus == 201402L || __cplusplus == 201406L || __cplusplus == 201500L || GLM_LANG_PLATFORM == 201402L
 #		define GLM_LANG (GLM_LANG_CXX14 | GLM_LANG_EXT)
 #	elif __cplusplus == 201103L || GLM_LANG_PLATFORM == 201103L
 #		define GLM_LANG (GLM_LANG_CXX11 | GLM_LANG_EXT)


### PR DESCRIPTION
Certain older clang versions signal C++1z mode by defining
__cplusplus as 201406L. Support this as if it were C++14.

https://github.com/llvm/llvm-project/blob/llvmorg-3.6.2/clang/lib/Frontend/InitPreprocessor.cpp#L374
