### PR TITLE
Fix handling of small magnitude quaternions

### DIFF
--- a/glm/ext/quaternion_exponential.inl
+++ b/glm/ext/quaternion_exponential.inl
@@ -56,7 +56,11 @@ namespace glm
 
 			//Prevent a division by 0 error later on
 			T VectorMagnitude = x.x * x.x + x.y * x.y + x.z * x.z;
-			if (glm::abs(VectorMagnitude - static_cast<T>(0)) < glm::epsilon<T>()) {
+			//Despite the compiler might say, we actually want to compare
+			//VectorMagnitude to 0. here; we could use denorm_int() compiling a
+			//project with unsafe maths optimizations might make the comparison
+			//always false, even when VectorMagnitude is 0.
+			if (VectorMagnitude < std::numeric_limits<T>::min()) {
 				//Equivalent to raising a real number to a power
 				return qua<T, Q>(pow(x.w, y), 0, 0, 0);
 			}


### PR DESCRIPTION
Hello again! I contributed to the project last year in https://github.com/g-truc/glm/pull/946. I have finally updated the version of glm in my project, and I noticed that there is still actually something afoul with small-angle quaternions.

The special case handling in `glm::qua::pow` is specifically intended for the case when the magnitude is null. Even for magnitudes smaller than epsilon, the common formula should be used. Because comparing a floating-point value by equality triggers a warning through the `-Weveverything` setting of clang, it must be selectively disabled for the condition.

I initially did so in https://github.com/g-truc/glm/commit/a921b517819a54f75ec631ad25c377c980266747 but, as you can see, the pipeline failed because of `-Wfloat-equal`, and I fixed it too quickly by using a comparison to epsilon like in other parts of the project.

In passing, `glm::epsilon` is defined in `ext/scalar_constants.inl` as `std::numeric_limits<T>::epsilon`. [According to cppreference.com](https://en.cppreference.com/w/cpp/types/numeric_limits), it “returns the difference between 1.0 and the next representable value of the given floating-point type”. But, for small values of `x`, there are many floating-point values between `x` and `x + epsilon`. [Dawson's series on floating-point numbers seems to agree with me](https://randomascii.wordpress.com/2012/02/25/comparing-floating-point-numbers-2012-edition/). Also, for values of `x` larger than 2.0, comparing to epsilon is the same as simple equality. So it is possible that other floating-point discrepancies have crept up somewhere else due to comparing to epsilon.

Tell me if this fix is acceptable (for information, I am actually using the version with ~~`if (VectorMagnitude == 0) {`~~ `if (< std::numeric_limits<T>::min()) {` in my project, and it works perfectly).