### PR TITLE
Fix compiler warnings

### DIFF
--- a/glm/detail/type_half.inl
+++ b/glm/detail/type_half.inl
@@ -6,7 +6,7 @@ namespace detail
 		volatile float f = 1e10;
 
 		for(int i = 0; i < 10; ++i)
-			f *= f; // this will overflow before the for loop terminates
+			f = f * f; // this will overflow before the for loop terminates
 		return f;
 	}
 


### PR DESCRIPTION
I ran into two compiler warnings when using g++ 10.1.0 and c++20:

`
[build] _deps/glm-src/glm/../glm/gtx/../detail/type_half.inl:9:6: error: compound assignment with ‘volatile’-qualified left operand is deprecated [-Werror=volatile]
[build]     9 |    f *= f; // this will overflow before the for loop terminates
[build]       |    ~~^~~~
`

and


`
[build] _deps/glm-src/glm/../glm/gtx/../detail/func_integer.inl:197:3: error: this condition has identical branches [-Werror=duplicated-branches]
[build]   197 |   if(y >= x)
[build]       |   ^~
`

EDIT: Only managed to fix the first one in a seemingly acceptable way so far.