### PR TITLE
fix: matrix axisAngle

### DIFF
--- a/glm/gtx/matrix_interpolation.inl
+++ b/glm/gtx/matrix_interpolation.inl
@@ -78,7 +78,7 @@ namespace glm
 		if (glm::abs(s) < T(0.001))
 			s = static_cast<T>(1);
 		T const angleCos = (m[0][0] + m[1][1] + m[2][2] - static_cast<T>(1)) * static_cast<T>(0.5);
-		if(angleCos - static_cast<T>(1) < epsilon)
+		if(abs(angleCos - static_cast<T>(1)) < epsilon)
 			angle = pi<T>() * static_cast<T>(0.25);
 		else
 			angle = acos(angleCos);


### PR DESCRIPTION
Following commit corresponded to a missing ``glm::abs(`` rather than an intentionally stray parenthesis: https://github.com/g-truc/glm/commit/0ca6a444541f3faf993c384e1d25f04c185d4eec#diff-69f446be3cb86e02d2289a5d04595584