### PR TITLE
fix: missing type_quat header

### DIFF
--- a/glm/detail/type_quat.inl
+++ b/glm/detail/type_quat.inl
@@ -1,5 +1,6 @@
 #include "../trigonometric.hpp"
 #include "../exponential.hpp"
+#include "../ext/quaternion_common.hpp"
 #include "../ext/quaternion_geometric.hpp"
 #include <limits>
 


### PR DESCRIPTION
``operator*(vec<3, T, Q> const& v, qua<T, Q> const& q)`` depends upon ``glm::inverse(qua<T, Q>)``, however, that 
function isn't (directly) accessible to type_quat.inl.