### PR TITLE
Silence warnings wrongly emitted by MSVC about uninitialized variables

### DIFF
--- a/glm/detail/func_common.inl
+++ b/glm/detail/func_common.inl
@@ -68,6 +68,12 @@ namespace glm
 namespace glm{
 namespace detail
 {
+#	if GLM_SILENT_WARNINGS == GLM_ENABLE
+#		if GLM_COMPILER & GLM_COMPILER_VC
+#			pragma warning(push)
+#			pragma warning(disable: 4701) // msvc erroneously warns about usage of uninitialized variables
+#		endif
+#	endif
 	template<length_t L, typename T, qualifier Q, bool Aligned>
 	struct compute_abs_vector
 	{
@@ -785,6 +791,12 @@ namespace detail
 			Result[l] = std::ldexp(v[l], exp[l]);
 		return Result;
 	}
+
+#	if GLM_SILENT_WARNINGS == GLM_ENABLE
+#		if GLM_COMPILER & GLM_COMPILER_VC
+#			pragma warning(pop)
+#		endif
+#	endif
 }//namespace glm
 
 #if GLM_CONFIG_SIMD == GLM_ENABLE

--- a/glm/detail/func_matrix.inl
+++ b/glm/detail/func_matrix.inl
@@ -4,6 +4,12 @@
 namespace glm{
 namespace detail
 {
+#	if GLM_SILENT_WARNINGS == GLM_ENABLE
+#		if GLM_COMPILER & GLM_COMPILER_VC
+#			pragma warning(push)
+#			pragma warning(disable: 4701) // msvc erroneously warns about usage of uninitialized variables
+#		endif
+#	endif
 	template<length_t C, length_t R, typename T, qualifier Q, bool Aligned>
 	struct compute_matrixCompMult
 	{
@@ -390,6 +396,11 @@ namespace detail
 		GLM_STATIC_ASSERT(std::numeric_limits<T>::is_iec559 || GLM_CONFIG_UNRESTRICTED_GENTYPE, "'inverse' only accept floating-point inputs");
 		return detail::compute_inverse<C, R, T, Q, detail::is_aligned<Q>::value>::call(m);
 	}
+#	if GLM_SILENT_WARNINGS == GLM_ENABLE
+#		if GLM_COMPILER & GLM_COMPILER_VC
+#			pragma warning(pop)
+#		endif
+#	endif
 }//namespace glm
 
 #if GLM_CONFIG_SIMD == GLM_ENABLE


### PR DESCRIPTION
We are having these warnings emitted only in Debug configuration, despite using `/W4` for all configurations in our project. Since MSVC still has no system header support, we must address this here instead..

It would be awesome if a release could come out of this as well, so we can start using it ASAP! Thanks!