### PR TITLE
fix: fastNormalize ambiguity

### DIFF
--- a/glm/gtx/fast_square_root.hpp
+++ b/glm/gtx/fast_square_root.hpp
@@ -84,7 +84,13 @@ namespace glm
 	///
 	/// @see gtx_fast_square_root extension.
 	template<typename genType>
-	GLM_FUNC_DECL genType fastNormalize(genType const& x);
+	GLM_FUNC_DECL genType fastNormalize(genType x);
+
+	/// Faster than the common normalize function but less accurate.
+	///
+	/// @see gtx_fast_square_root extension.
+	template<length_t L, typename T, qualifier Q>
+	GLM_FUNC_DECL vec<L, T, Q> fastNormalize(vec<L, T, Q> const& x);
 
 	/// @}
 }// namespace glm


### PR DESCRIPTION
Declarations in fast_square_root.hpp do not match qualifiers fast_square_root.inl; can/will generate: "call to 'fastNormalize' is ambiguous" errors.