### PR TITLE
fix: isMultiple

### DIFF
--- a/glm/ext/vector_integer.inl
+++ b/glm/ext/vector_integer.inl
@@ -32,7 +32,7 @@ namespace glm
 	{
 		GLM_STATIC_ASSERT(std::numeric_limits<T>::is_integer, "'isMultiple' only accept integer inputs");
 
-		return (Value % Multiple) == vec<L, T, Q>(0);
+		return equal(Value % Multiple, vec<L, T, Q>(0));
 	}
 
 	template<length_t L, typename T, qualifier Q>
@@ -40,7 +40,7 @@ namespace glm
 	{
 		GLM_STATIC_ASSERT(std::numeric_limits<T>::is_integer, "'isMultiple' only accept integer inputs");
 
-		return (Value % Multiple) == vec<L, T, Q>(0);
+		return equal(Value % Multiple, vec<L, T, Q>(0));
 	}
 
 	template<length_t L, typename T, qualifier Q>


### PR DESCRIPTION
Function declaration has it returning ``vec<L, bool, Q>``, however, the function uses the equality operator (which only returns a bool). Usage of the function will generate "no viable conversion ..." compilation errors.