### PR TITLE
Fixed unpackUnorm

### DIFF
--- a/glm/gtc/packing.inl
+++ b/glm/gtc/packing.inl
@@ -683,7 +683,7 @@ namespace detail
 		GLM_STATIC_ASSERT(std::numeric_limits<uintType>::is_integer, "uintType must be an integer type");
 		GLM_STATIC_ASSERT(std::numeric_limits<floatType>::is_iec559, "floatType must be a floating point type");
 
-		return vec<L, float, Q>(v) * (static_cast<floatType>(1) / static_cast<floatType>(std::numeric_limits<uintType>::max()));
+		return vec<L, floatType, Q>(v) * (static_cast<floatType>(1) / static_cast<floatType>(std::numeric_limits<uintType>::max()));
 	}
 
 	template<typename intType, length_t L, typename floatType, qualifier Q>


### PR DESCRIPTION
Should use the same float type as defined in the template.