### PR TITLE
Add WORKSPACE and BUILD to root directory

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -51,8 +51,8 @@ matrix:
 
 before_build:
   - ps: |
-      mkdir build
-      cd build
+      mkdir build_appveyor
+      cd build_appveyor
 
       if ("$env:APPVEYOR_JOB_NAME" -match "Image: Visual Studio 2013") {
           $env:generator="Visual Studio 12 2013"

--- a/BUILD
+++ b/BUILD
@@ -1,0 +1,13 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+cc_library(
+    name = "glm",
+    srcs = glob(["glm/**/*.cpp"]),
+    hdrs = glob([
+        "glm/**/*.hpp",
+        "glm/**/*.h",
+        "glm/**/*.inl",
+    ]),
+    includes = ["."],
+    visibility = ["//visibility:public"],
+)


### PR DESCRIPTION
Add support to bazel build system.
Can be easily intergrated into other projects depend on bazel by adding some lines to the WORKSPACE:

```
load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
git_repository(
    name = "glm",
    remote = "https://github.com/g-truc/glm.git",
    branch = "master",
)
```

and a `deps = ["@glm"]` is sufficient for using glm.