### PR TITLE
fix: glm::angle() discards the sign of result for angles in range (2*pi-1, 2*pi)

### DIFF
--- a/glm/ext/quaternion_trigonometric.inl
+++ b/glm/ext/quaternion_trigonometric.inl
@@ -7,7 +7,10 @@ namespace glm
 	{
 		if (abs(x.w) > cos_one_over_two<T>())
 		{
-			return asin(sqrt(x.x * x.x + x.y * x.y + x.z * x.z)) * static_cast<T>(2);
+			T const a = asin(sqrt(x.x * x.x + x.y * x.y + x.z * x.z)) * static_cast<T>(2);
+			if(x.w < static_cast<T>(0))
+				return two_pi<T>() - a;
+			return a;
 		}
 
 		return acos(x.w) * static_cast<T>(2);

--- a/glm/ext/quaternion_trigonometric.inl
+++ b/glm/ext/quaternion_trigonometric.inl
@@ -9,7 +9,7 @@ namespace glm
 		{
 			T const a = asin(sqrt(x.x * x.x + x.y * x.y + x.z * x.z)) * static_cast<T>(2);
 			if(x.w < static_cast<T>(0))
-				return two_pi<T>() - a;
+				return pi<T>() * static_cast<T>(2) - a;
 			return a;
 		}
 

--- a/test/ext/ext_quaternion_trigonometric.cpp
+++ b/test/ext/ext_quaternion_trigonometric.cpp
@@ -21,6 +21,12 @@ static int test_angle()
 		Error += glm::equal(A, 90.0f, Epsilon) ? 0 : 1;
 	}
 
+	{
+		glm::quat const Q = glm::angleAxis(glm::two_pi<float>() - 1.0f, glm::vec3(1, 0, 0));
+		float const A = glm::angle(Q);
+		Error += glm::equal(A, 1.0f, Epsilon) ? 1 : 0;
+	}
+
 	return Error;
 }
 


### PR DESCRIPTION
While #946 fixes precision loss on small angles in various functions, the way patch is implemented for `glm::angle()` introduces a mathematical error.

https://github.com/g-truc/glm/pull/946/files#diff-e2a0bd93372fb1306bb3caaf8fb8ed34089fca0ebd5356d4e6306eac0244fa31R10

For angles in range `(-1, 1)` (in radians), `glm::angle()` use `asin()` on non-scale components to prevent precision loss. However, the way it extracts `sin(theta/2)` from the non-scale components - `sqrt(x*x+y*y+z*z)` - effectively takes the absloute value, thus the sign of result is lost.

This error affects angles in range `(2*pi-1, 2*pi)`. Proof of concept (included in this PR):
```cpp
glm::vec3 my_axis(0.0f, 1.0f, 0.0f);

glm::quat q1 = glm::angleAxis(1.0f, my_axis);
std::cout << q1.x << ", " << q1.y << ", " << q1.z << ", " << q1.w << std::endl; // 0, 0.479425, 0, -0.877583
std::cout << glm::angle(q1)  << std::endl; // 1 (correct)

glm::quat q2 = glm::angleAxis(glm::two_pi<float>() - 1.0f, my_axis);
std::cout << q2.x << ", " << q2.y << ", " << q2.z << ", " << q2.w << std::endl; // 0, 0.479426, 0, 0.877583
std::cout << glm::angle(q2)  << std::endl; // 1 (WRONG; should be 5.28319 or -1)
```

~~A simple fix will be take the sign of `w` into consideration, i.e. `sign(w) * sqrt(x*x+y*y+z*z)`, but it will break continuity in angle calculations by introducing negative angles (`glm::angleAxis(0.3f, my_axis) * glm::angleAxis(5.28f, my_axis) == glm::angleAxis(-0.973186f, my_axis)`, albeit equivalent in terms of rotations). Working on a better fix.~~