### PR TITLE
Adding constexpr qualifiers for dot and cross product

### DIFF
--- a/glm/detail/func_geometric.inl
+++ b/glm/detail/func_geometric.inl
@@ -67,7 +67,7 @@ namespace detail
 	template<typename T, qualifier Q, bool Aligned>
 	struct compute_cross
 	{
-		GLM_FUNC_QUALIFIER static vec<3, T, Q> call(vec<3, T, Q> const& x, vec<3, T, Q> const& y)
+		GLM_FUNC_QUALIFIER GLM_CONSTEXPR static vec<3, T, Q> call(vec<3, T, Q> const& x, vec<3, T, Q> const& y)
 		{
 			GLM_STATIC_ASSERT(std::numeric_limits<T>::is_iec559, "'cross' accepts only floating-point inputs");
 
@@ -172,7 +172,7 @@ namespace detail
 
 	// cross
 	template<typename T, qualifier Q>
-	GLM_FUNC_QUALIFIER vec<3, T, Q> cross(vec<3, T, Q> const& x, vec<3, T, Q> const& y)
+	GLM_FUNC_QUALIFIER GLM_CONSTEXPR vec<3, T, Q> cross(vec<3, T, Q> const& x, vec<3, T, Q> const& y)
 	{
 		return detail::compute_cross<T, Q, detail::is_aligned<Q>::value>::call(x, y);
 	}

--- a/glm/detail/func_geometric.inl
+++ b/glm/detail/func_geometric.inl
@@ -28,7 +28,7 @@ namespace detail
 	template<typename T, qualifier Q, bool Aligned>
 	struct compute_dot<vec<1, T, Q>, T, Aligned>
 	{
-		GLM_FUNC_QUALIFIER static T call(vec<1, T, Q> const& a, vec<1, T, Q> const& b)
+		GLM_FUNC_QUALIFIER GLM_CONSTEXPR static T call(vec<1, T, Q> const& a, vec<1, T, Q> const& b)
 		{
 			return a.x * b.x;
 		}
@@ -37,7 +37,7 @@ namespace detail
 	template<typename T, qualifier Q, bool Aligned>
 	struct compute_dot<vec<2, T, Q>, T, Aligned>
 	{
-		GLM_FUNC_QUALIFIER static T call(vec<2, T, Q> const& a, vec<2, T, Q> const& b)
+		GLM_FUNC_QUALIFIER GLM_CONSTEXPR static T call(vec<2, T, Q> const& a, vec<2, T, Q> const& b)
 		{
 			vec<2, T, Q> tmp(a * b);
 			return tmp.x + tmp.y;
@@ -47,7 +47,7 @@ namespace detail
 	template<typename T, qualifier Q, bool Aligned>
 	struct compute_dot<vec<3, T, Q>, T, Aligned>
 	{
-		GLM_FUNC_QUALIFIER static T call(vec<3, T, Q> const& a, vec<3, T, Q> const& b)
+		GLM_FUNC_QUALIFIER GLM_CONSTEXPR static T call(vec<3, T, Q> const& a, vec<3, T, Q> const& b)
 		{
 			vec<3, T, Q> tmp(a * b);
 			return tmp.x + tmp.y + tmp.z;
@@ -57,7 +57,7 @@ namespace detail
 	template<typename T, qualifier Q, bool Aligned>
 	struct compute_dot<vec<4, T, Q>, T, Aligned>
 	{
-		GLM_FUNC_QUALIFIER static T call(vec<4, T, Q> const& a, vec<4, T, Q> const& b)
+		GLM_FUNC_QUALIFIER GLM_CONSTEXPR static T call(vec<4, T, Q> const& a, vec<4, T, Q> const& b)
 		{
 			vec<4, T, Q> tmp(a * b);
 			return (tmp.x + tmp.y) + (tmp.z + tmp.w);
@@ -157,14 +157,14 @@ namespace detail
 
 	// dot
 	template<typename T>
-	GLM_FUNC_QUALIFIER T dot(T x, T y)
+	GLM_FUNC_QUALIFIER GLM_CONSTEXPR T dot(T x, T y)
 	{
 		GLM_STATIC_ASSERT(std::numeric_limits<T>::is_iec559, "'dot' accepts only floating-point inputs");
 		return x * y;
 	}
 
 	template<length_t L, typename T, qualifier Q>
-	GLM_FUNC_QUALIFIER T dot(vec<L, T, Q> const& x, vec<L, T, Q> const& y)
+	GLM_FUNC_QUALIFIER GLM_CONSTEXPR T dot(vec<L, T, Q> const& x, vec<L, T, Q> const& y)
 	{
 		GLM_STATIC_ASSERT(std::numeric_limits<T>::is_iec559, "'dot' accepts only floating-point inputs");
 		return detail::compute_dot<vec<L, T, Q>, T, detail::is_aligned<Q>::value>::call(x, y);

--- a/glm/geometric.hpp
+++ b/glm/geometric.hpp
@@ -56,7 +56,7 @@ namespace glm
 	/// @see <a href="http://www.opengl.org/sdk/docs/manglsl/xhtml/cross.xml">GLSL cross man page</a>
 	/// @see <a href="http://www.opengl.org/registry/doc/GLSLangSpec.4.20.8.pdf">GLSL 4.20.8 specification, section 8.5 Geometric Functions</a>
 	template<typename T, qualifier Q>
-	GLM_FUNC_DECL vec<3, T, Q> cross(vec<3, T, Q> const& x, vec<3, T, Q> const& y);
+	GLM_FUNC_DECL GLM_CONSTEXPR vec<3, T, Q> cross(vec<3, T, Q> const& x, vec<3, T, Q> const& y);
 
 	/// Returns a vector in the same direction as x but with length of 1.
 	/// According to issue 10 GLSL 1.10 specification, if length(x) == 0 then result is undefined and generate an error.

--- a/glm/geometric.hpp
+++ b/glm/geometric.hpp
@@ -47,7 +47,7 @@ namespace glm
 	/// @see <a href="http://www.opengl.org/sdk/docs/manglsl/xhtml/dot.xml">GLSL dot man page</a>
 	/// @see <a href="http://www.opengl.org/registry/doc/GLSLangSpec.4.20.8.pdf">GLSL 4.20.8 specification, section 8.5 Geometric Functions</a>
 	template<length_t L, typename T, qualifier Q>
-	GLM_FUNC_DECL T dot(vec<L, T, Q> const& x, vec<L, T, Q> const& y);
+	GLM_FUNC_DECL GLM_CONSTEXPR T dot(vec<L, T, Q> const& x, vec<L, T, Q> const& y);
 
 	/// Returns the cross product of x and y.
 	///


### PR DESCRIPTION
There is no technical reason to not allow dot and cross product evaluate in compile time.  Both operations uses only arithmetic multiplication and subtraction.