### PR TITLE
Remove ban on using string_cast with CUDA host code

### DIFF
--- a/glm/gtx/string_cast.hpp
+++ b/glm/gtx/string_cast.hpp
@@ -11,8 +11,6 @@
 /// Include <glm/gtx/string_cast.hpp> to use the features of this extension.
 ///
 /// Setup strings for GLM type values
-///
-/// This extension is not supported with CUDA
 
 #pragma once
 
@@ -30,10 +28,6 @@
 #	else
 #		pragma message("GLM: GLM_GTX_string_cast extension included")
 #	endif
-#endif
-
-#if(GLM_COMPILER & GLM_COMPILER_CUDA)
-#	error "GLM_GTX_string_cast is not supported on CUDA compiler"
 #endif
 
 namespace glm


### PR DESCRIPTION
string_cast.hpp merely detects whether the current compiler is NVCC (originally based on `if defined(__CUDACC__)` in glm/simd/platform.h) and throws an error if it is. This means string_cast.hpp cannot be included in any header which might ever be used in a CUDA project.

Of course, `glm::to_string` can't be used in device (GPU) code. However, the current approach to stop this is both incorrect and unnecessary. `__CUDACC__` will be defined in both host and device code compilation, and `glm::to_string` can obviously be used in host code. The correct define is `__CUDA_ARCH__` (will be defined only if compiling device code). However, there's no problem if `glm::to_string` is defined (the header is included) while compiling device code, as long as it's not actually used in the device code. So, throwing an error if `__CUDA_ARCH__` is defined would still prevent string_cast.hpp from being included in CUDA projects.

There's actually no need for any manual check to see if `glm::to_string` is being used in device code, because the compiler will already check for that. It returns a std::string, which itself can't be used in device code, so it's unlikely a developer would try. And if they did, there would be errors that both `glm::to_string` and all the needed std::string constructors, stream operators, etc. are host-only functions.