### PR TITLE
Remove transpose type constraint

### DIFF
--- a/glm/detail/func_matrix.inl
+++ b/glm/detail/func_matrix.inl
@@ -373,7 +373,6 @@ namespace detail
 	template<length_t C, length_t R, typename T, qualifier Q>
 	GLM_FUNC_QUALIFIER typename mat<C, R, T, Q>::transpose_type transpose(mat<C, R, T, Q> const& m)
 	{
-		GLM_STATIC_ASSERT(std::numeric_limits<T>::is_iec559 || GLM_CONFIG_UNRESTRICTED_GENTYPE, "'transpose' only accept floating-point inputs");
 		return detail::compute_transpose<C, R, T, Q, detail::is_aligned<Q>::value>::call(m);
 	}
 


### PR DESCRIPTION
There's no reason for transpose to work on floating-point matrices only.