### PR TITLE
matrix decompose(): fix bug

### DIFF
--- a/glm/gtx/matrix_decompose.inl
+++ b/glm/gtx/matrix_decompose.inl
@@ -174,10 +174,10 @@ namespace detail
 
 			root = sqrt(Row[i][i] - Row[j][j] - Row[k][k] + static_cast<T>(1.0));
 
-			Orientation[i] = static_cast<T>(0.5) * root;
+			Orientation[i + 1] = static_cast<T>(0.5) * root;
 			root = static_cast<T>(0.5) / root;
-			Orientation[j] = root * (Row[i][j] + Row[j][i]);
-			Orientation[k] = root * (Row[i][k] + Row[k][i]);
+			Orientation[j + 1] = root * (Row[i][j] + Row[j][i]);
+			Orientation[k + 1] = root * (Row[i][k] + Row[k][i]);
 			Orientation.w = root * (Row[j][k] - Row[k][j]);
 		} // End if <= 0
 


### PR DESCRIPTION
Here is a test case (in Python, sorry) that proves that glm.decompose() has a bug.
It builds a simple transformation that contains a rotation built from a known quaternion, and prints the output quaternion: it's wrong.
If I use quat_cast instead, I get the right result.
```python
# Here is a proof that glm's decompose has a bug.
import numpy as np
import glm
rotation = np.random.random((4,))
rotation /= np.linalg.norm(rotation)
rotation = glm.quat(rotation)
print(f'rotation               ={rotation} len={np.linalg.norm(rotation)}') # glm bug: outputs a non-normalized rotation
rotmat = glm.mat3_cast(rotation)
transformation = np.eye(4)
transformation[:3,:3] = np.array(rotmat)
transformation = glm.mat4(transformation)
rotation_out = glm.quat()
glm.decompose(transformation, scale, rotation_out, translation, skew, perspective)
print(f'rotation_from_decompose={rotation_out} len={np.linalg.norm(rotation_out)}') # glm bug: outputs a non-normalized rotation
print(f'rotation_from_quat_cast={glm.quat_cast(rotmat)} len={np.linalg.norm(glm.quat_cast(rotmat))}') # glm bug: outputs a non-normalized rotation
```
sample output:
```
rotation               =quat(     0.433091,     0.745813,    0.0454693,     0.504111 ) len=1.0
rotation_from_decompose=quat(     0.433091,    0.0454692,     0.504111,            0 ) len=0.6661555171012878
rotation_from_quat_cast=quat(     0.433091,     0.745813,    0.0454692,     0.504111 ) len=1.0
```

Looking at the source code, it seems to take inspiration from several sources:
- original is http://www.opensource.apple.com/source/WebCore/WebCore-514/platform/graphics/transforms/TransformationMatrix.cpp
- but the final rotation to quaternion seems to be from https://github.com/jpkinney/meshmorph/blob/master/Wm4Quaternion.inl#L357

Except that when the code was copied: the following trick was ommited:
```
Real* apfQuat[3] = { &m_afTuple[1], &m_afTuple[2], &m_afTuple[3] };
```
so that index 0 in apfQuat is actually index 1 in m_afTuple. In the code, i j and k refer to some ordering of x,y and z, which have indices 1 2 and 3 in the quaternion.

A simple fix is to add 1 to i, j and k:
```
			Orientation[i + 1] = static_cast<T>(0.5) * root;
			root = static_cast<T>(0.5) / root;
			Orientation[j + 1] = root * (Row[i][j] + Row[j][i]);
			Orientation[k + 1] = root * (Row[i][k] + Row[k][i]);
```

A better fix would be to replace this duplicated functionality with a call to quad_cast which does the job without a bug.