### PR TITLE
fix: isIdentity for non-symmetric matrices

### DIFF
--- a/glm/gtx/matrix_query.inl
+++ b/glm/gtx/matrix_query.inl
@@ -33,13 +33,13 @@ namespace glm
 	GLM_FUNC_QUALIFIER bool isIdentity(mat<C, R, T, Q> const& m, T const& epsilon)
 	{
 		bool result = true;
-		for(length_t i = 0; result && i < m[0].length() ; ++i)
+		for(length_t i = 0; result && i < m.length(); ++i)
 		{
-			for(length_t j = 0; result && j < i ; ++j)
+			for(length_t j = 0; result && j < glm::min(i, m[0].length()); ++j)
 				result = abs(m[i][j]) <= epsilon;
-			if(result)
+			if(result && i < m[0].length())
 				result = abs(m[i][i] - 1) <= epsilon;
-			for(length_t j = i + 1; result && j < m.length(); ++j)
+			for(length_t j = i + 1; result && j < m[0].length(); ++j)
 				result = abs(m[i][j]) <= epsilon;
 		}
 		return result;


### PR DESCRIPTION
isIdentity incorrectly indexes the matrix; here is a simple repro:
```cpp
#include <iostream>

#include <glm/glm.hpp>
#include <glm/gtx/matrix_query.hpp>
#include <glm/ext/matrix_transform.hpp>

int main() {
    std::cout << glm::isIdentity(glm::identity<glm::mat4x3>(), glm::epsilon<glm::f32>()) << std::endl;
    return 0;
}
```

That will generate assertion errors:

```bash
{GLM_DIR}/glm/glm/./ext/../detail/type_vec3.inl:188: constexpr const T& glm::vec<3, T, Q>::operator[](glm::vec<3, T, Q>::length_type) const [with T = float; glm::qualifier Q = glm::packed_highp; glm::vec<3, T, Q>::length_type = int]: Assertion `i >= 0 && i < this->length()' failed.
```

Edit: It'd probably be better if the function was rewritten to have less branching than what I've PR'd.