### PR TITLE
fix: variadic arguments and GLM_FORCE_INLINE

### DIFF
--- a/glm/gtx/string_cast.inl
+++ b/glm/gtx/string_cast.inl
@@ -18,7 +18,7 @@ namespace detail
 		typedef double value_type;
 	};
 
-	GLM_FUNC_QUALIFIER std::string format(const char* msg, ...)
+	GLM_CUDA_FUNC_DECL static std::string format(const char* msg, ...)
 	{
 		std::size_t const STRING_BUFFER(4096);
 		char text[STRING_BUFFER];


### PR DESCRIPTION
This is less of a PR and more of a bug-report: gcc/g++, unlike MSVC & clang which simply ignore the attribute, explicitly forbids using `__always_inline__`  on functions that have variadic arguments, e.g.,

```cpp
#include <iostream>

#include <glm/glm.hpp>
#include <glm/gtx/string_cast.hpp>

int main() {
    glm::vec3 v3 = glm::vec3( 0.0 );
    std::cout << glm::to_string(v3) << std::endl;
    return 0;
}
```

will generate (and this holds for many g++ versions prior to 10.2):

```bash
└> g++ --version
g++ (Ubuntu 10.2.0-5ubuntu1~20.04) 10.2.0

└> g++ -DGLM_FORCE_INLINE -I${GLM_DIR} example.cpp
In file included from {GLM_DIR}/glm/glm/gtx/string_cast.hpp:46,
                 from example.cpp:4:
{GLM_DIR}/glm/glm/gtx/string_cast.inl: In function ‘std::string glm::detail::format(const char*, ...)’:
{GLM_DIR}/glm/glm/gtx/string_cast.inl:21:33: error: function ‘std::string glm::detail::format(const char*, ...)’ can never be inlined because it uses variable argument lists
   21 |  GLM_FUNC_QUALIFIER std::string format(const char* msg, ...)
```

My included changes is just a minimal number of changes to make `GLM_FORCE_INLINE` completely compatible with g++. There are likely better solutions, so your opinion on this would be appreciated.