### PR TITLE
Proper handling of boundary cases in matrix interpolation

### DIFF
--- a/glm/gtx/matrix_interpolation.inl
+++ b/glm/gtx/matrix_interpolation.inl
@@ -79,7 +79,9 @@ namespace glm
 			s = static_cast<T>(1);
 		T const angleCos = (m[0][0] + m[1][1] + m[2][2] - static_cast<T>(1)) * static_cast<T>(0.5);
 		if(abs(angleCos - static_cast<T>(1)) < epsilon)
-			angle = pi<T>() * static_cast<T>(0.25);
+			angle = static_cast<T>(0.0);
+		else if(abs(angleCos + static_cast<T>(1)) < epsilon)
+			angle = pi<T>();
 		else
 			angle = acos(angleCos);
 		axis.x = (m[1][2] - m[2][1]) / s;


### PR DESCRIPTION
Maybe I misunderstand something but from my point of view the boundary cases angleCos ~= 1.0 and angleCos ~= -1.0 are currently wrongly mapped to pi/4 in the axisAngle() function used by matrix interpolation. Mathematically arccos(+1.0) = 0.0 and arccos(-1.0) = pi:
https://en.wikipedia.org/wiki/Inverse_trigonometric_functions#/media/File:Arcsine_Arccosine.svg

I discovered this problem when interpolating the model matrix of a rotating object that suddenly jumped to an angle of pi/4 in a slow animation.

