### PR TITLE
Missing transposition step in adjugate() for mat2 and mat4

### DIFF
--- a/glm/gtx/matrix_operation.inl
+++ b/glm/gtx/matrix_operation.inl
@@ -119,8 +119,8 @@ namespace glm
 	GLM_FUNC_QUALIFIER mat<2, 2, T, Q> adjugate(mat<2, 2, T, Q> const& m)
 	{
 		return mat<2, 2, T, Q>(
-			+m[1][1], -m[1][0],
-			-m[0][1], +m[0][0]);
+			+m[1][1], -m[0][1],
+			-m[1][0], +m[0][0]);
 	}
 
 	template<typename T, qualifier Q>
@@ -168,9 +168,9 @@ namespace glm
 		T const m33 = determinant(mat<3, 3, T, Q>(m[0][0], m[0][1], m[0][2], m[1][0], m[1][1], m[1][2], m[2][0], m[2][1], m[2][2]));
 
 		return mat<4, 4, T, Q>(
-			+m00, -m01, +m02, -m03,
-			-m10, +m11, -m12, +m13,
-			+m20, -m21, +m22, -m23,
-			-m30, +m31, -m32, +m33);
+			+m00, -m10, +m20, -m30,
+			-m01, +m11, -m21, +m31,
+			+m02, -m12, +m22, -m32,
+			-m03, +m13, -m23, +m33);
 	}
 }//namespace glm

--- a/test/gtx/gtx_matrix_operation.cpp
+++ b/test/gtx/gtx_matrix_operation.cpp
@@ -1,9 +1,86 @@
 #define GLM_ENABLE_EXPERIMENTAL
+#include <glm/glm.hpp>
+#include <glm/gtc/epsilon.hpp>
 #include <glm/gtx/matrix_operation.hpp>
+#include <limits>
+
+int test_adjugate()
+{
+	int Error = 0;
+
+	const float epsilon = std::numeric_limits<float>::epsilon();
+
+	// mat2
+	const glm::mat2 m2 {
+		2, 3,
+		1, 5
+	};
+
+	const glm::mat2 eam2 {
+		5, -3,
+		-1, 2
+	};
+
+	const glm::mat2 am2 = glm::adjugate(m2);
+
+	Error += glm::all(glm::bvec2 {
+		glm::all(glm::epsilonEqual(am2[0], eam2[0], epsilon)),
+		glm::all(glm::epsilonEqual(am2[1], eam2[1], epsilon))
+	}) ? 0 : 1;
+
+	// mat3
+	const glm::mat3 m3 {
+		2, 3, 3,
+		1, 5, 4,
+		4, 6, 8
+	};
+
+	const glm::mat3 eam3 {
+		16, -6, -3,
+		8, 4, -5,
+		-14, 0, 7
+	};
+
+	const glm::mat3 am3 = glm::adjugate(m3);
+
+	Error += glm::all(glm::bvec3 {
+		glm::all(glm::epsilonEqual(am3[0], eam3[0], epsilon)),
+		glm::all(glm::epsilonEqual(am3[1], eam3[1], epsilon)),
+		glm::all(glm::epsilonEqual(am3[2], eam3[2], epsilon))
+	}) ? 0 : 1;
+
+	// mat4
+	const glm::mat4 m4 {
+		2, 3, 3, 1,
+		1, 5, 4, 3,
+		4, 6, 8, 5,
+		-2, -3, -3, 4
+	};
+
+	const glm::mat4 eam4 {
+		97, -30, -15, 17,
+		45, 20, -25, 5,
+		-91, 0, 35, -21,
+		14, 0, 0, 14
+	};
+
+	const glm::mat4 am4 = glm::adjugate(m4);
+
+	Error += glm::all(glm::bvec4 {
+		glm::all(glm::epsilonEqual(am4[0], eam4[0], epsilon)),
+		glm::all(glm::epsilonEqual(am4[1], eam4[1], epsilon)),
+		glm::all(glm::epsilonEqual(am4[2], eam4[2], epsilon)),
+		glm::all(glm::epsilonEqual(am4[3], eam4[3], epsilon)),
+	}) ? 0 : 1;
+
+	return Error;
+}
 
 int main()
 {
-	int Error(0);
+	int Error = 0;
+
+	Error += test_adjugate();
 
 	return Error;
 }

--- a/test/gtx/gtx_matrix_operation.cpp
+++ b/test/gtx/gtx_matrix_operation.cpp
@@ -11,67 +11,67 @@ int test_adjugate()
 	const float epsilon = std::numeric_limits<float>::epsilon();
 
 	// mat2
-	const glm::mat2 m2 {
+	const glm::mat2 m2(
 		2, 3,
 		1, 5
-	};
+	);
 
-	const glm::mat2 eam2 {
+	const glm::mat2 eam2(
 		5, -3,
 		-1, 2
-	};
+	);
 
 	const glm::mat2 am2 = glm::adjugate(m2);
 
-	Error += glm::all(glm::bvec2 {
+	Error += glm::all(glm::bvec2(
 		glm::all(glm::epsilonEqual(am2[0], eam2[0], epsilon)),
 		glm::all(glm::epsilonEqual(am2[1], eam2[1], epsilon))
-	}) ? 0 : 1;
+	)) ? 0 : 1;
 
 	// mat3
-	const glm::mat3 m3 {
+	const glm::mat3 m3(
 		2, 3, 3,
 		1, 5, 4,
 		4, 6, 8
-	};
+	);
 
-	const glm::mat3 eam3 {
+	const glm::mat3 eam3(
 		16, -6, -3,
 		8, 4, -5,
 		-14, 0, 7
-	};
+	);
 
 	const glm::mat3 am3 = glm::adjugate(m3);
 
-	Error += glm::all(glm::bvec3 {
+	Error += glm::all(glm::bvec3(
 		glm::all(glm::epsilonEqual(am3[0], eam3[0], epsilon)),
 		glm::all(glm::epsilonEqual(am3[1], eam3[1], epsilon)),
 		glm::all(glm::epsilonEqual(am3[2], eam3[2], epsilon))
-	}) ? 0 : 1;
+	)) ? 0 : 1;
 
 	// mat4
-	const glm::mat4 m4 {
+	const glm::mat4 m4(
 		2, 3, 3, 1,
 		1, 5, 4, 3,
 		4, 6, 8, 5,
 		-2, -3, -3, 4
-	};
+	);
 
-	const glm::mat4 eam4 {
+	const glm::mat4 eam4(
 		97, -30, -15, 17,
 		45, 20, -25, 5,
 		-91, 0, 35, -21,
 		14, 0, 0, 14
-	};
+	);
 
 	const glm::mat4 am4 = glm::adjugate(m4);
 
-	Error += glm::all(glm::bvec4 {
+	Error += glm::all(glm::bvec4(
 		glm::all(glm::epsilonEqual(am4[0], eam4[0], epsilon)),
 		glm::all(glm::epsilonEqual(am4[1], eam4[1], epsilon)),
 		glm::all(glm::epsilonEqual(am4[2], eam4[2], epsilon)),
-		glm::all(glm::epsilonEqual(am4[3], eam4[3], epsilon)),
-	}) ? 0 : 1;
+		glm::all(glm::epsilonEqual(am4[3], eam4[3], epsilon))
+	)) ? 0 : 1;
 
 	return Error;
 }


### PR DESCRIPTION
### Problem
It seems that `adjugate(mat2)` and `adjugate(mat4)` don't transpose the cofactor matrix correctly.

### Example
Test run in [WolframAlpha](https://www.wolframalpha.com/):
```
adjugate {{2,3,3,1},{1,5,4,3},{4,6,8,5},{-2,-3,-3,4}}
```
![adjugate](https://user-images.githubusercontent.com/64333006/107875396-e1246600-6ebf-11eb-9e8a-59425605bd7b.png)

Test with GLM:
```cpp
#include <iostream>
#include <glm/glm.hpp>
#include <glm/gtx/matrix_operation.hpp>
#include <glm/gtx/string_cast.hpp>


int main()
{
  glm::mat4 m {
    2,3,3,1,
    1,5,4,3,
    4,6,8,5,
    -2,-3,-3,4
  };

  auto a = glm::adjugate(m);

  std::cout << "m:\n" << to_string(m) << "\n\n";
  std::cout << "adjugate(m):\n" << to_string(a);
}
```
Output:
```
m:
mat4x4((2.000000, 3.000000, 3.000000, 1.000000), (1.000000, 5.000000, 4.000000, 3.000000), (4.000000, 6.000000, 8.000000, 5.000000), (-2.000000, -3.000000, -3.000000, 4.000000))

adjugate(m):
mat4x4((97.000000, 45.000000, -91.000000, 14.000000), (-30.000000, 20.000000, -0.000000, 0.000000), (-15.000000, -25.000000, 35.000000, -0.000000), (17.000000, 5.000000, -21.000000, 14.000000))
```
According to WolframAlpha the expected output should be:
```
adjugate(m):
mat4x4((97.000000, -30.000000, -15.000000, 17.000000), (45.000000, 20.000000, -25.000000, 5.000000), (-91.000000, -0.000000, 35.000000, -21.000000), (14.000000, 0.000000, -0.000000, 14.000000))
```
It seems that the result matrix needs to be transposed to match the result from WolframAlpha.

The same happens for `adjugate(mat2)`. `adjugate(mat3)` seems to work fine.

### Unit tests
Unit tests were prepared with the help of WolframAlpha using the following queries:
```
adjugate {{2,3},{1,5}}
adjugate {{2,3,3},{1,5,4},{4,6,8}}
adjugate {{2,3,3,1},{1,5,4,3},{4,6,8,5},{-2,-3,-3,4}}
```