### PR TITLE
Add targets make install and make uninstall

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,3 +26,12 @@ if(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_CURRENT_SOURCE_DIR})
 add_subdirectory(test)
 
 endif(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_CURRENT_SOURCE_DIR})
+
+if (NOT TARGET uninstall)
+configure_file(cmake/glm/cmake_uninstall.cmake.in
+               cmake_uninstall.cmake IMMEDIATE @ONLY)
+
+add_custom_target(uninstall
+                  "${CMAKE_COMMAND}" -P
+                  "${CMAKE_BINARY_DIR}/cmake_uninstall.cmake")
+endif()

--- a/cmake/glm/cmake_uninstall.cmake.in
+++ b/cmake/glm/cmake_uninstall.cmake.in
@@ -1,0 +1,21 @@
+if(NOT EXISTS "@CMAKE_BINARY_DIR@/install_manifest.txt")
+  message(FATAL_ERROR "Cannot find install manifest: @CMAKE_BINARY_DIR@/install_manifest.txt")
+endif()
+
+file(READ "@CMAKE_BINARY_DIR@/install_manifest.txt" files)
+string(REGEX REPLACE "\n" ";" files "${files}")
+foreach(file ${files})
+  message(STATUS "Uninstalling $ENV{DESTDIR}${file}")
+  if(IS_SYMLINK "$ENV{DESTDIR}${file}" OR EXISTS "$ENV{DESTDIR}${file}")
+    exec_program(
+      "@CMAKE_COMMAND@" ARGS "-E remove \"$ENV{DESTDIR}${file}\""
+      OUTPUT_VARIABLE rm_out
+      RETURN_VALUE rm_retval
+      )
+    if(NOT "${rm_retval}" STREQUAL 0)
+      message(FATAL_ERROR "Problem when removing $ENV{DESTDIR}${file}")
+    endif()
+  else(IS_SYMLINK "$ENV{DESTDIR}${file}" OR EXISTS "$ENV{DESTDIR}${file}")
+    message(STATUS "File $ENV{DESTDIR}${file} does not exist.")
+  endif()
+endforeach()

--- a/glm/CMakeLists.txt
+++ b/glm/CMakeLists.txt
@@ -44,6 +44,13 @@ source_group("SIMD Files" FILES ${SIMD_HEADER})
 
 add_library(glm INTERFACE)
 target_include_directories(glm INTERFACE ../)
+install(DIRECTORY ${PROJECT_SOURCE_DIR}/glm 
+		DESTINATION include/glm
+		PATTERN "*.hpp"
+		PATTERN "*.h"
+		PATTERN "*.inl"
+)
+
 
 if(BUILD_STATIC_LIBS)
 add_library(glm_static STATIC ${ROOT_TEXT} ${ROOT_MD} ${ROOT_NAT}
@@ -55,6 +62,7 @@ add_library(glm_static STATIC ${ROOT_TEXT} ${ROOT_MD} ${ROOT_NAT}
 	${SIMD_SOURCE}    ${SIMD_INLINE}    ${SIMD_HEADER})
 	target_link_libraries(glm_static PUBLIC glm)
 	add_library(glm::glm_static ALIAS glm_static)
+	install(TARGETS glm_static DESTINATION lib)
 endif()
 
 if(BUILD_SHARED_LIBS)
@@ -67,4 +75,5 @@ add_library(glm_shared SHARED ${ROOT_TEXT} ${ROOT_MD} ${ROOT_NAT}
 	${SIMD_SOURCE}    ${SIMD_INLINE}    ${SIMD_HEADER})
 	target_link_libraries(glm_shared PUBLIC glm)
 	add_library(glm::glm_shared ALIAS glm_shared)
+	install(TARGETS glm_shared DESTINATION lib)
 endif()


### PR DESCRIPTION
Add install and uninstall targets in cmake to ease installation process.

I have added the uninstall target and related files and I have set the install rules for glm's header only lib, static and shared libs.