### PR TITLE
Fixed the SIMD (SSE) implementation of compute_vec4_equal for floats

### DIFF
--- a/glm/detail/type_vec4_simd.inl
+++ b/glm/detail/type_vec4_simd.inl
@@ -304,7 +304,7 @@ namespace detail
 	{
 		static bool call(vec<4, float, Q> const& v1, vec<4, float, Q> const& v2)
 		{
-			return _mm_movemask_ps(_mm_cmpeq_ps(v1.data, v2.data)) != 0;
+			return _mm_movemask_ps(_mm_cmpneq_ps(v1.data, v2.data)) == 0;
 		}
 	};
 


### PR DESCRIPTION
The current SIMD implementation of the `==` operator of `vec4` is returning `true` if any of the components of two vectors are equal instead of checking all of them.

To maybe explain the logic problem in a bit more detail:

`_mm_cmpeq_ps` compares two four-component float vectors and for each component stores `0xffffffff` if the values are equal and `0` if they are not equal.
`_mm_movemask_ps` returns a bitmask with the most significant bits of a four-component float vector. 

Chaining the two operations together means that the only way that `_mm_movemask_ps` would return `0` is if all four components of the comparison result are `0`, which is only the case if none of the components are equal. However, if at least one of the component pairs is equal, `_mm_movemask_ps` would set a bit in the result and the old implementation of `compute_vec4_equal` would return true (after comparing the result with `!= 0`).

Example: 
```
a = {1, 0, 0, 1}
b = {1, 1, 1, 1}

_mm_cmpeq_ps(a, b) = {0xffffffff, 0, 0, 0xffffffff}
_mm_movemask_ps(_mm_cmpeq_ps(a, b)) = 00000000000000000000000000001001 != 0
```

The fixed version compares using not equal (`_mm_cmpneq_ps`), meaning that now the only way that the movemask operation produces 0 is if all vector components are equal.