### PR TITLE
Revert "Fix quaternion orientation in `glm::decompose`"

### DIFF
--- a/glm/gtx/matrix_decompose.inl
+++ b/glm/gtx/matrix_decompose.inl
@@ -159,9 +159,9 @@ namespace detail
 			root = sqrt(trace + static_cast<T>(1.0));
 			Orientation.w = static_cast<T>(0.5) * root;
 			root = static_cast<T>(0.5) / root;
-			Orientation.x = root * (Row[2].y - Row[1].z);
-			Orientation.y = root * (Row[0].z - Row[2].x);
-			Orientation.z = root * (Row[1].x - Row[0].y);
+			Orientation.x = root * (Row[1].z - Row[2].y);
+			Orientation.y = root * (Row[2].x - Row[0].z);
+			Orientation.z = root * (Row[0].y - Row[1].x);
 		} // End if > 0
 		else
 		{


### PR DESCRIPTION
Reverts g-truc/glm#1012