### PR TITLE
Use the parent of $CMAKE_CURRENT_SOURCE_DIR as include directory

### DIFF
--- a/glm/CMakeLists.txt
+++ b/glm/CMakeLists.txt
@@ -47,7 +47,7 @@ add_library(glm INTERFACE)
 include(GNUInstallDirs)
 
 target_include_directories(glm INTERFACE
-	$<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}>
+	$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/..>
 	$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 


### PR DESCRIPTION
`$CMAKE_SOURCE_DIR` will not work if glm is used as a subdirectory, since it refers to the project _using_ glm, and not glm itself.