### PR TITLE
fix clang CUDA compile

### DIFF
--- a/glm/gtc/type_ptr.inl
+++ b/glm/gtc/type_ptr.inl
@@ -164,97 +164,97 @@ namespace glm
 	}
 
 	template <typename T, qualifier Q>
-	inline vec<1, T, Q> make_vec1(vec<1, T, Q> const& v)
+	GLM_FUNC_DECL vec<1, T, Q> make_vec1(vec<1, T, Q> const& v)
 	{
 		return v;
 	}
 
 	template <typename T, qualifier Q>
-	inline vec<1, T, Q> make_vec1(vec<2, T, Q> const& v)
+	GLM_FUNC_DECL vec<1, T, Q> make_vec1(vec<2, T, Q> const& v)
 	{
 		return vec<1, T, Q>(v);
 	}
 
 	template <typename T, qualifier Q>
-	inline vec<1, T, Q> make_vec1(vec<3, T, Q> const& v)
+	GLM_FUNC_DECL vec<1, T, Q> make_vec1(vec<3, T, Q> const& v)
 	{
 		return vec<1, T, Q>(v);
 	}
 
 	template <typename T, qualifier Q>
-	inline vec<1, T, Q> make_vec1(vec<4, T, Q> const& v)
+	GLM_FUNC_DECL vec<1, T, Q> make_vec1(vec<4, T, Q> const& v)
 	{
 		return vec<1, T, Q>(v);
 	}
 
 	template <typename T, qualifier Q>
-	inline vec<2, T, Q> make_vec2(vec<1, T, Q> const& v)
+	GLM_FUNC_DECL vec<2, T, Q> make_vec2(vec<1, T, Q> const& v)
 	{
 		return vec<2, T, Q>(v.x, static_cast<T>(0));
 	}
 
 	template <typename T, qualifier Q>
-	inline vec<2, T, Q> make_vec2(vec<2, T, Q> const& v)
+	GLM_FUNC_DECL vec<2, T, Q> make_vec2(vec<2, T, Q> const& v)
 	{
 		return v;
 	}
 
 	template <typename T, qualifier Q>
-	inline vec<2, T, Q> make_vec2(vec<3, T, Q> const& v)
+	GLM_FUNC_DECL vec<2, T, Q> make_vec2(vec<3, T, Q> const& v)
 	{
 		return vec<2, T, Q>(v);
 	}
 
 	template <typename T, qualifier Q>
-	inline vec<2, T, Q> make_vec2(vec<4, T, Q> const& v)
+	GLM_FUNC_DECL vec<2, T, Q> make_vec2(vec<4, T, Q> const& v)
 	{
 		return vec<2, T, Q>(v);
 	}
 
 	template <typename T, qualifier Q>
-	inline vec<3, T, Q> make_vec3(vec<1, T, Q> const& v)
+	GLM_FUNC_DECL vec<3, T, Q> make_vec3(vec<1, T, Q> const& v)
 	{
 		return vec<3, T, Q>(v.x, static_cast<T>(0), static_cast<T>(0));
 	}
 
 	template <typename T, qualifier Q>
-	inline vec<3, T, Q> make_vec3(vec<2, T, Q> const& v)
+	GLM_FUNC_DECL vec<3, T, Q> make_vec3(vec<2, T, Q> const& v)
 	{
 		return vec<3, T, Q>(v.x, v.y, static_cast<T>(0));
 	}
 
 	template <typename T, qualifier Q>
-	inline vec<3, T, Q> make_vec3(vec<3, T, Q> const& v)
+	GLM_FUNC_DECL vec<3, T, Q> make_vec3(vec<3, T, Q> const& v)
 	{
 		return v;
 	}
 
 	template <typename T, qualifier Q>
-	inline vec<3, T, Q> make_vec3(vec<4, T, Q> const& v)
+	GLM_FUNC_DECL vec<3, T, Q> make_vec3(vec<4, T, Q> const& v)
 	{
 		return vec<3, T, Q>(v);
 	}
 
 	template <typename T, qualifier Q>
-	inline vec<4, T, Q> make_vec4(vec<1, T, Q> const& v)
+	GLM_FUNC_DECL vec<4, T, Q> make_vec4(vec<1, T, Q> const& v)
 	{
 		return vec<4, T, Q>(v.x, static_cast<T>(0), static_cast<T>(0), static_cast<T>(1));
 	}
 
 	template <typename T, qualifier Q>
-	inline vec<4, T, Q> make_vec4(vec<2, T, Q> const& v)
+	GLM_FUNC_DECL vec<4, T, Q> make_vec4(vec<2, T, Q> const& v)
 	{
 		return vec<4, T, Q>(v.x, v.y, static_cast<T>(0), static_cast<T>(1));
 	}
 
 	template <typename T, qualifier Q>
-	inline vec<4, T, Q> make_vec4(vec<3, T, Q> const& v)
+	GLM_FUNC_DECL vec<4, T, Q> make_vec4(vec<3, T, Q> const& v)
 	{
 		return vec<4, T, Q>(v.x, v.y, v.z, static_cast<T>(1));
 	}
 
 	template <typename T, qualifier Q>
-	inline vec<4, T, Q> make_vec4(vec<4, T, Q> const& v)
+	GLM_FUNC_DECL vec<4, T, Q> make_vec4(vec<4, T, Q> const& v)
 	{
 		return v;
 	}


### PR DESCRIPTION
Fix CUDA compile issue when using clang.

```
glm/gtc/type_ptr.inl:257:22: error: __host__ function 'make_vec4' cannot overload __host__ __device__ function 'make_vec4'
6946        inline vec<4, T, Q> make_vec4(vec<4, T, Q> const& v)
```

This issue was found during tests with [PIConGPU](https://github.com/ComputationalRadiationPhysics/picongpu): see https://gitlab.com/hzdr/crp/picongpu/-/jobs/1142313251#L6946