### PR TITLE
Remove type restriction in length2 and distance2

### DIFF
--- a/glm/gtx/norm.inl
+++ b/glm/gtx/norm.inl
@@ -18,28 +18,24 @@ namespace detail
 	template<typename genType>
 	GLM_FUNC_QUALIFIER genType length2(genType x)
 	{
-		GLM_STATIC_ASSERT(std::numeric_limits<genType>::is_iec559, "'length2' accepts only floating-point inputs");
 		return x * x;
 	}
 
 	template<length_t L, typename T, qualifier Q>
 	GLM_FUNC_QUALIFIER T length2(vec<L, T, Q> const& v)
 	{
-		GLM_STATIC_ASSERT(std::numeric_limits<T>::is_iec559, "'length2' accepts only floating-point inputs");
 		return detail::compute_length2<L, T, Q, detail::is_aligned<Q>::value>::call(v);
 	}
 
 	template<typename T>
 	GLM_FUNC_QUALIFIER T distance2(T p0, T p1)
 	{
-		GLM_STATIC_ASSERT(std::numeric_limits<T>::is_iec559, "'distance2' accepts only floating-point inputs");
 		return length2(p1 - p0);
 	}
 
 	template<length_t L, typename T, qualifier Q>
 	GLM_FUNC_QUALIFIER T distance2(vec<L, T, Q> const& p0, vec<L, T, Q> const& p1)
 	{
-		GLM_STATIC_ASSERT(std::numeric_limits<T>::is_iec559, "'distance2' accepts only floating-point inputs");
 		return length2(p1 - p0);
 	}
 


### PR DESCRIPTION
There is no reason for these operations to be restricted to float-point input types only.