### PR TITLE
fix intrinsic compilation errors

### DIFF
--- a/glm/detail/func_matrix_simd.inl
+++ b/glm/detail/func_matrix_simd.inl
@@ -17,10 +17,7 @@ namespace detail
 		GLM_FUNC_QUALIFIER static mat<4, 4, float, Q> call(mat<4, 4, float, Q> const& x, mat<4, 4, float, Q> const& y)
 		{
 			mat<4, 4, float, Q> Result;
-			glm_mat4_matrixCompMult(
-				*static_cast<glm_vec4 const (*)[4]>(&x[0].data),
-				*static_cast<glm_vec4 const (*)[4]>(&y[0].data),
-				*static_cast<glm_vec4(*)[4]>(&Result[0].data));
+			glm_mat4_matrixCompMult(&x[0].data, &y[0].data, &Result[0].data);
 			return Result;
 		}
 	};

--- a/glm/detail/type_quat_simd.inl
+++ b/glm/detail/type_quat_simd.inl
@@ -89,7 +89,7 @@ namespace detail
 	{
 		static qua<float, Q> call(qua<float, Q> const& q, qua<float, Q> const& p)
 		{
-			vec<4, float, Q> Result;
+			qua<float, Q> Result;
 			Result.data = _mm_sub_ps(q.data, p.data);
 			return Result;
 		}
@@ -177,7 +177,7 @@ namespace detail
 			uuv = _mm_mul_ps(uuv, two);
 
 			vec<4, float, Q> Result;
-			Result.data = _mm_add_ps(v.Data, _mm_add_ps(uv, uuv));
+			Result.data = _mm_add_ps(v.data, _mm_add_ps(uv, uuv));
 			return Result;
 		}
 	};


### PR DESCRIPTION
This commit cleans up a few lingering simd compilation errors. They are quite generic: typos or copy-and-paste gone wrong, so I didn't feel the need to include additional tests in the commit.

Repro:
```cpp
// g++ -DGLM_FORCE_INTRINSICS -DGLM_FORCE_DEFAULT_ALIGNED_GENTYPES -I${GLM_PATH} example.cpp

#include <glm/glm.hpp>
#include <glm/detail/type_quat.hpp>

using namespace glm;
int main() {
    qua<float> q3 = qua<float>(1.f, 0.f, 0.f, 0.f) - qua<float>(1.f, 0.f, 0.f, 0.f);
    mat<4,4,float> m3 = matrixCompMult(mat<4,4,float>(1.f), mat<4,4,float>(1.f));
    return 0;
}
```

Output:
```
${GLM_PATH}/glm/glm/detail/type_quat_simd.inl:94:11: error: could not convert ‘Result’ from ‘glm::vec<4, float, glm::aligned_highp>’ to ‘glm::qua<float, glm::aligned_highp>’
   94 |    return Result;
      |           ^~~~~~

...

${GLM_PATH}/glm/glm/./ext/../detail/../detail/func_matrix_simd.inl:21:6: error: invalid ‘static_cast’ from type ‘const type*’ {aka ‘const __m128*’} to type ‘const glm_vec4 (*)[4]’ {aka ‘const __m128 (*)[4]’}
   21 |     *static_cast<glm_vec4 const (*)[4]>(&x[0].data),
      |      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
${GLM_PATH}/glm/glm/./ext/../detail/../detail/func_matrix_simd.inl:22:6: error: invalid ‘static_cast’ from type ‘const type*’ {aka ‘const __m128*’} to type ‘const glm_vec4 (*)[4]’ {aka ‘const __m128 (*)[4]’}
   22 |     *static_cast<glm_vec4 const (*)[4]>(&y[0].data),
      |      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
${GLM_PATH}/glm/glm/./ext/../detail/../detail/func_matrix_simd.inl:23:6: error: invalid ‘static_cast’ from type ‘glm::detail::storage<4, float, true>::type*’ {aka ‘__m128*’} to type ‘glm_vec4 (*)[4]’ {aka ‘__m128 (*)[4]’}
   23 |     *static_cast<glm_vec4(*)[4]>(&Result[0].data));
```