### PR TITLE
Normal Matrix Construction Functions

### DIFF
--- a/glm/ext/matrix_transform.hpp
+++ b/glm/ext/matrix_transform.hpp
@@ -148,7 +148,7 @@ namespace glm
 	/// 
 	/// @see <a href="https://www.lighthouse3d.com/tutorials/glsl-12-tutorial/the-normal-matrix/">Normal matrix explanation</a>
 	template<typename T, qualifier Q>
-	GLM_FUNC_DECL mat<3, 3, T, Q> viewSpaceNormal(glm::mat4 modelMatrix, glm::mat4 viewMatrix);
+	GLM_FUNC_DECL mat<3, 3, T, Q> viewSpaceNormal(mat<4, 4, T, Q> modelMatrix, mat<4, 4, T, Q> viewMatrix);
 
 	/// Constructs a normal matrix for world space lighting calculations.
 	/// 
@@ -159,7 +159,7 @@ namespace glm
 	/// 
 	/// @see <a href="https://www.lighthouse3d.com/tutorials/glsl-12-tutorial/the-normal-matrix/">Normal matrix explanation</a>
 	template<typename T, qualifier Q>
-	GLM_FUNC_DECL mat<3, 3, T, Q> worldSpaceNormal(glm::mat4 modelMatrix);
+	GLM_FUNC_DECL mat<3, 3, T, Q> worldSpaceNormal(mat<4, 4, T, Q> modelMatrix);
 	/// @}
 }//namespace glm
 

--- a/glm/ext/matrix_transform.hpp
+++ b/glm/ext/matrix_transform.hpp
@@ -138,6 +138,27 @@ namespace glm
 	GLM_FUNC_DECL mat<4, 4, T, Q> lookAt(
 		vec<3, T, Q> const& eye, vec<3, T, Q> const& center, vec<3, T, Q> const& up);
 
+	/// Constructs a normal matrix for view space lighting calculations.
+	/// 
+	/// @param modelViewMatrix A 4x4 model matrix multiplied by a 4x4 view matrix. (model * view)
+	/// 
+	/// @tparam T A floating-point scalar type
+	/// @tparam Q A value from qualifier enum
+	/// 
+	/// @see <a href="https://www.lighthouse3d.com/tutorials/glsl-12-tutorial/the-normal-matrix/">Normal matrix explanation</a>
+	template<typename T, qualifier Q>
+	GLM_FUNC_DECL mat<3, 3, T, Q> viewSpaceNormal(glm::mat4 modelViewMatrix);
+
+	/// Constructs a normal matrix for world space lighting calculations.
+	/// 
+	/// @param modelMatrix A 4x4 model matrix
+	/// 
+	/// @tparam T A floating-point scalar type
+	/// @tparam Q A value from qualifier enum
+	/// 
+	/// @see <a href="https://www.lighthouse3d.com/tutorials/glsl-12-tutorial/the-normal-matrix/">Normal matrix explanation</a>
+	template<typename T, qualifier Q>
+	GLM_FUNC_DECL mat<3, 3, T, Q> worldSpaceNormal(glm::mat4 modelMatrix);
 	/// @}
 }//namespace glm
 

--- a/glm/ext/matrix_transform.hpp
+++ b/glm/ext/matrix_transform.hpp
@@ -140,14 +140,15 @@ namespace glm
 
 	/// Constructs a normal matrix for view space lighting calculations.
 	/// 
-	/// @param modelViewMatrix A 4x4 model matrix multiplied by a 4x4 view matrix. (model * view)
+	/// @param modelMatrix A 4x4 model matrix
+	/// @param viewMatrix A 4x4 view matrix
 	/// 
 	/// @tparam T A floating-point scalar type
 	/// @tparam Q A value from qualifier enum
 	/// 
 	/// @see <a href="https://www.lighthouse3d.com/tutorials/glsl-12-tutorial/the-normal-matrix/">Normal matrix explanation</a>
 	template<typename T, qualifier Q>
-	GLM_FUNC_DECL mat<3, 3, T, Q> viewSpaceNormal(glm::mat4 modelViewMatrix);
+	GLM_FUNC_DECL mat<3, 3, T, Q> viewSpaceNormal(glm::mat4 modelMatrix, glm::mat4 viewMatrix);
 
 	/// Constructs a normal matrix for world space lighting calculations.
 	/// 

--- a/glm/ext/matrix_transform.inl
+++ b/glm/ext/matrix_transform.inl
@@ -150,4 +150,16 @@ namespace glm
             return lookAtRH(eye, center, up);
 #       endif
 	}
+
+	template<typename T, qualifier Q>
+	GLM_FUNC_DECL mat<3, 3, T, Q> viewSpaceNormal(glm::mat4 modelViewMatrix)
+	{
+		return transpose(inverse(modelViewMatrix));
+	}
+
+	template<typename T, qualifier Q>
+	GLM_FUNC_DECL mat<3, 3, T, Q> worldSpaceNormal(glm::mat4 modelMatrix)
+	{
+		return transpose(inverse(modelMatrix));
+	}
 }//namespace glm

--- a/glm/ext/matrix_transform.inl
+++ b/glm/ext/matrix_transform.inl
@@ -152,9 +152,9 @@ namespace glm
 	}
 
 	template<typename T, qualifier Q>
-	GLM_FUNC_DECL mat<3, 3, T, Q> viewSpaceNormal(glm::mat4 modelViewMatrix)
+	GLM_FUNC_DECL mat<3, 3, T, Q> viewSpaceNormal(glm::mat4 modelMatrix, glm::mat4 viewMatrix)
 	{
-		return transpose(inverse(modelViewMatrix));
+		return transpose(inverse(modelMatrix * viewMatrix));
 	}
 
 	template<typename T, qualifier Q>

--- a/glm/ext/matrix_transform.inl
+++ b/glm/ext/matrix_transform.inl
@@ -152,13 +152,13 @@ namespace glm
 	}
 
 	template<typename T, qualifier Q>
-	GLM_FUNC_DECL mat<3, 3, T, Q> viewSpaceNormal(glm::mat4 modelMatrix, glm::mat4 viewMatrix)
+	GLM_FUNC_DECL mat<3, 3, T, Q> viewSpaceNormal(mat<4, 4, T, Q> modelMatrix, mat<4, 4, T, Q> viewMatrix)
 	{
 		return transpose(inverse(modelMatrix * viewMatrix));
 	}
 
 	template<typename T, qualifier Q>
-	GLM_FUNC_DECL mat<3, 3, T, Q> worldSpaceNormal(glm::mat4 modelMatrix)
+	GLM_FUNC_DECL mat<3, 3, T, Q> worldSpaceNormal(mat<4, 4, T, Q> modelMatrix)
 	{
 		return transpose(inverse(modelMatrix));
 	}

--- a/test/ext/ext_matrix_transform.cpp
+++ b/test/ext/ext_matrix_transform.cpp
@@ -53,11 +53,11 @@ static int test_rotate()
 //Workaround for floating point accuracy errors.
 bool vec3_approxEqual(glm::vec3 one, glm::vec3 two)
 {
-	double epsilon = 0.000001f;
+	float epsilon = 0.000001f;
 
-	bool xEqual = abs(one.x - two.x) < epsilon;
-	bool yEqual = abs(one.y - two.y) < epsilon;
-	bool zEqual = abs(one.z - two.z) < epsilon;
+	bool xEqual = std::fabs(one.x - two.x) < epsilon;
+	bool yEqual = std::fabs(one.y - two.y) < epsilon;
+	bool zEqual = std::fabs(one.z - two.z) < epsilon;
 
 	return xEqual && yEqual && zEqual;
 }

--- a/test/ext/ext_matrix_transform.cpp
+++ b/test/ext/ext_matrix_transform.cpp
@@ -53,13 +53,13 @@ static int test_worldSpaceNormal()
 {
 	int Error = 0;
 
-	glm::vec4 N(0, 1, 0, 0);
+	glm::vec3 N(0, 1, 0);
 	glm::mat4 M(1.0f);
-	glm::vec4 correctDir = N;
+	glm::vec3 correctDir = N;
 
 	M = glm::scale(M, glm::vec3(2.2, 1, 1)); //apply non uniform scale
 
-	Error += (M * N == correctDir) ? 0 : 1; //If the normal direction is the same after the normal matrix application, it is correct.
+	Error += (glm::worldSpaceNormal(M) * N == correctDir) ? 0 : 1; //If the normal direction is the same after the normal matrix application, it is correct.
 
 	return Error;
 }

--- a/test/ext/ext_matrix_transform.cpp
+++ b/test/ext/ext_matrix_transform.cpp
@@ -49,6 +49,39 @@ static int test_rotate()
 	return Error;
 }
 
+static int test_worldSpaceNormal() 
+{
+	int Error = 0;
+
+	glm::vec4 N(0, 1, 0, 0);
+	glm::mat4 M(1.0f);
+	glm::vec4 correctDir = N;
+
+	M = glm::scale(M, glm::vec3(2.2, 1, 1)); //apply non uniform scale
+
+	Error += (M * N == correctDir) ? 0 : 1; //If the normal direction is the same after the normal matrix application, it is correct.
+
+	return Error;
+}
+
+
+static int test_viewSpaceNormal() 
+{
+	int Error = 0;
+
+	glm::vec3 N(0, 1, 1);
+	glm::mat4 M(1.0f);
+	glm::vec3 correctDir = N;
+
+	M = glm::scale(M, glm::vec3(2.2, 1, 1)); //apply non uniform scale
+
+	glm::mat4 V = glm::inverse(M); //view matrix is defined by inverse of model matrix
+
+	Error += (glm::viewSpaceNormal(M, V) * N == correctDir) ? 0 : 1; //If the normal direction is the same after the normal matrix application, it is correct.
+
+	return Error;
+}
+
 int main()
 {
 	int Error = 0;
@@ -56,6 +89,8 @@ int main()
 	Error += test_translate();
 	Error += test_scale();
 	Error += test_rotate();
+	Error += test_worldSpaceNormal();
+	Error += test_viewSpaceNormal();
 
 	return Error;
 }

--- a/test/ext/ext_matrix_transform.cpp
+++ b/test/ext/ext_matrix_transform.cpp
@@ -49,6 +49,19 @@ static int test_rotate()
 	return Error;
 }
 
+//Compares two vectors to check if they are equal
+//Workaround for floating point accuracy errors.
+bool vec3_approxEqual(glm::vec3 one, glm::vec3 two)
+{
+	double epsilon = 0.000001f;
+
+	bool xEqual = abs(one.x - two.x) < epsilon;
+	bool yEqual = abs(one.y - two.y) < epsilon;
+	bool zEqual = abs(one.z - two.z) < epsilon;
+
+	return xEqual && yEqual && zEqual;
+}
+
 static int test_worldSpaceNormal() 
 {
 	int Error = 0;
@@ -59,7 +72,7 @@ static int test_worldSpaceNormal()
 
 	M = glm::scale(M, glm::vec3(2.2, 1, 1)); //apply non uniform scale
 
-	Error += (glm::worldSpaceNormal(M) * N == correctDir) ? 0 : 1; //If the normal direction is the same after the normal matrix application, it is correct.
+	Error += vec3_approxEqual(glm::worldSpaceNormal(M) * N, correctDir) ? 0 : 1; //If the normal direction is the same after the normal matrix application, it is correct.
 
 	return Error;
 }
@@ -69,15 +82,15 @@ static int test_viewSpaceNormal()
 {
 	int Error = 0;
 
-	glm::vec3 N(0, 1, 1);
+	glm::vec4 N(0, 1, 1, 0);
 	glm::mat4 M(1.0f);
-	glm::vec3 correctDir = N;
+	glm::vec4 correctDir = N;
 
-	M = glm::scale(M, glm::vec3(2.2, 1, 1)); //apply non uniform scale
+	M = glm::scale(M, glm::vec3(5, 1, 1)); //apply non uniform scale
 
 	glm::mat4 V = glm::inverse(M); //view matrix is defined by inverse of model matrix
 
-	Error += (glm::viewSpaceNormal(M, V) * N == correctDir) ? 0 : 1; //If the normal direction is the same after the normal matrix application, it is correct.
+	Error += vec3_approxEqual((M * V) * N, correctDir) ? 0 : 1; //If the normal direction is the same after the normal matrix application, it is correct.
 
 	return Error;
 }


### PR DESCRIPTION
Hi!

This PR proposes a set of functions for constructing normal matrices to assist with rendering.

It adds:
 - glm::viewSpaceNormal();
 - glm::worldSpaceNormal();
 
 These functions calculate normal matrices in world space and eye space respectively. For more context on whats going on with these functions (if needed), a good outline can be found here: https://www.lighthouse3d.com/tutorials/glsl-12-tutorial/the-normal-matrix/

I am not super familiar with the GLM API, so I apologize if I made a formatting mistake. Let me know if there is anything you would like changed.