### PR TITLE
make quaternion constructor respect GLM_FORCE_QUAT_DATA_XYZW

### DIFF
--- a/glm/detail/type_quat.hpp
+++ b/glm/detail/type_quat.hpp
@@ -88,7 +88,12 @@ namespace glm
 		// -- Explicit basic constructors --
 
 		GLM_FUNC_DECL GLM_CONSTEXPR qua(T s, vec<3, T, Q> const& v);
+
+#		ifdef GLM_FORCE_QUAT_DATA_XYZW
+		GLM_FUNC_DECL GLM_CONSTEXPR qua(T x, T y, T z, T w);
+#		else
 		GLM_FUNC_DECL GLM_CONSTEXPR qua(T w, T x, T y, T z);
+#		endif
 
 		// -- Conversion constructors --
 

--- a/glm/detail/type_quat.inl
+++ b/glm/detail/type_quat.inl
@@ -141,12 +141,13 @@ namespace detail
 	{}
 
 	template <typename T, qualifier Q>
-	GLM_FUNC_QUALIFIER GLM_CONSTEXPR qua<T, Q>::qua(T _w, T _x, T _y, T _z)
-#		ifdef GLM_FORCE_QUAT_DATA_XYZW
+#	ifdef GLM_FORCE_QUAT_DATA_XYZW
+	GLM_FUNC_QUALIFIER GLM_CONSTEXPR qua<T, Q>::qua(T _x, T _y, T _z, T _w)
 			: x(_x), y(_y), z(_z), w(_w)
-#		else
+#	else
+	GLM_FUNC_QUALIFIER GLM_CONSTEXPR qua<T, Q>::qua(T _w, T _x, T _y, T _z)
 			: w(_w), x(_x), y(_y), z(_z)
-#		endif
+#	endif
 	{}
 
 	// -- Conversion constructors --


### PR DESCRIPTION
I think these changes are missing from #1069

The quaternion constructor definition was not respecting the GLM_FORCE_QUAT_DATA_XYZW.

Sorry for the short description of the PR i was short on time.