### PR TITLE
Fix matrix decompose (wxyz quaternion)

### DIFF
--- a/glm/gtx/matrix_decompose.inl
+++ b/glm/gtx/matrix_decompose.inl
@@ -172,12 +172,18 @@ namespace detail
 			j = Next[i];
 			k = Next[j];
 
+#           ifdef GLM_FORCE_QUAT_DATA_XYZW
+                int off = 0;
+#           else
+                int off = 1;
+#           endif
+
 			root = sqrt(Row[i][i] - Row[j][j] - Row[k][k] + static_cast<T>(1.0));
 
-			Orientation[i] = static_cast<T>(0.5) * root;
+			Orientation[i + off] = static_cast<T>(0.5) * root;
 			root = static_cast<T>(0.5) / root;
-			Orientation[j] = root * (Row[i][j] + Row[j][i]);
-			Orientation[k] = root * (Row[i][k] + Row[k][i]);
+			Orientation[j + off] = root * (Row[i][j] + Row[j][i]);
+			Orientation[k + off] = root * (Row[i][k] + Row[k][i]);
 			Orientation.w = root * (Row[j][k] - Row[k][j]);
 		} // End if <= 0
 


### PR DESCRIPTION
Since https://github.com/g-truc/glm/pull/1069, the default behavior of `operator[]` has changed, and `decompose` is relying on it.

It also means that `decompose` was previously broken when `GLM_FORCE_QUAT_DATA_WXYZ` was used.

If you don't want preprocessor statement (or avoid `operato[]`), I can change the code to:
```
T qi = static_cast<T>(0.5) * root;
root = static_cast<T>(0.5) / root;
T qj = root * (Row[i][j] + Row[j][i]);
T qk = root * (Row[i][k] + Row[k][i]);

Orientation.w = root * (Row[j][k] - Row[k][j]);

if (i == 0) {
	Orientation.x = qi;
	Orientation.y = qj;
	Orientation.z = qk;
} else if (i == 1) {
	Orientation.y = qi;
	Orientation.z = qj;
	Orientation.x = qk;
} else {
	Orientation.z = qi;
	Orientation.x = qj;
	Orientation.y = qk;
}
```