### PR TITLE
Fix glm::bounceEaseInOut() easing formula

### DIFF
--- a/glm/gtx/easing.inl
+++ b/glm/gtx/easing.inl
@@ -425,7 +425,7 @@ namespace glm{
 
 		if(a < static_cast<genType>(0.5))
 		{
-			return static_cast<genType>(0.5) * (one<genType>() - bounceEaseOut(a * static_cast<genType>(2)));
+			return static_cast<genType>(0.5) * (one<genType>() - bounceEaseOut(one<genType>() - a * static_cast<genType>(2)));
 		}
 		else
 		{


### PR DESCRIPTION
Current implementation of `glm::bounceEaseInOut()` uses an incorrect formula for values in range `x < 0.5`. This pull request fixes that formula.