### PR TITLE
Fixed header comment

### DIFF
--- a/glm/gtc/matrix_inverse.hpp
+++ b/glm/gtc/matrix_inverse.hpp
@@ -6,7 +6,7 @@
 /// @defgroup gtc_matrix_inverse GLM_GTC_matrix_inverse
 /// @ingroup gtc
 ///
-/// Include <glm/gtc/matrix_integer.hpp> to use the features of this extension.
+/// Include <glm/gtc/matrix_inverse.hpp> to use the features of this extension.
 ///
 /// Defines additional matrix inverting functions.
 


### PR DESCRIPTION
Info how to include this header file contained a wrong path. Changed it to the correct path.