### PR TITLE
Get build running for Clang on Windows

### DIFF
--- a/glm/ext/quaternion_common.inl
+++ b/glm/ext/quaternion_common.inl
@@ -104,7 +104,7 @@ namespace glm
         {
             // Graphics Gems III, page 96
             T angle = acos(cosTheta);
-            T phi = angle + k * glm::pi<T>();
+            T phi = angle + static_cast<float>(k) * glm::pi<T>();
             return (sin(angle - a * phi)* x + sin(a * phi) * z) / sin(angle);
         }
     }

--- a/glm/gtc/random.inl
+++ b/glm/gtc/random.inl
@@ -22,7 +22,7 @@ namespace detail
 		GLM_FUNC_QUALIFIER static vec<1, uint8, P> call()
 		{
 			return vec<1, uint8, P>(
-				std::rand() % std::numeric_limits<uint8>::max());
+				static_cast<uint8>(std::rand()) % std::numeric_limits<uint8>::max());
 		}
 	};
 
@@ -32,8 +32,8 @@ namespace detail
 		GLM_FUNC_QUALIFIER static vec<2, uint8, P> call()
 		{
 			return vec<2, uint8, P>(
-				std::rand() % std::numeric_limits<uint8>::max(),
-				std::rand() % std::numeric_limits<uint8>::max());
+				static_cast<uint8>(std::rand()) % std::numeric_limits<uint8>::max(),
+				static_cast<uint8>(std::rand()) % std::numeric_limits<uint8>::max());
 		}
 	};
 
@@ -43,9 +43,9 @@ namespace detail
 		GLM_FUNC_QUALIFIER static vec<3, uint8, P> call()
 		{
 			return vec<3, uint8, P>(
-				std::rand() % std::numeric_limits<uint8>::max(),
-				std::rand() % std::numeric_limits<uint8>::max(),
-				std::rand() % std::numeric_limits<uint8>::max());
+				static_cast<uint8>(std::rand()) % std::numeric_limits<uint8>::max(),
+				static_cast<uint8>(std::rand()) % std::numeric_limits<uint8>::max(),
+				static_cast<uint8>(std::rand()) % std::numeric_limits<uint8>::max());
 		}
 	};
 
@@ -55,10 +55,10 @@ namespace detail
 		GLM_FUNC_QUALIFIER static vec<4, uint8, P> call()
 		{
 			return vec<4, uint8, P>(
-				std::rand() % std::numeric_limits<uint8>::max(),
-				std::rand() % std::numeric_limits<uint8>::max(),
-				std::rand() % std::numeric_limits<uint8>::max(),
-				std::rand() % std::numeric_limits<uint8>::max());
+				static_cast<uint8>(std::rand()) % std::numeric_limits<uint8>::max(),
+				static_cast<uint8>(std::rand()) % std::numeric_limits<uint8>::max(),
+				static_cast<uint8>(std::rand()) % std::numeric_limits<uint8>::max(),
+				static_cast<uint8>(std::rand()) % std::numeric_limits<uint8>::max());
 		}
 	};
 

--- a/glm/gtx/string_cast.inl
+++ b/glm/gtx/string_cast.inl
@@ -28,7 +28,9 @@ namespace detail
 			return std::string();
 
 		va_start(list, msg);
-#		if (GLM_COMPILER & GLM_COMPILER_VC)
+#		if ((GLM_COMPILER & GLM_COMPILER_VC) ||                \
+		    ((GLM_PLATFORM & GLM_PLATFORM_WINDOWS) &&          \
+		     (GLM_COMPILER & GLM_COMPILER_CLANG)))
 			vsprintf_s(text, STRING_BUFFER, msg, list);
 #		else//
 			std::vsprintf(text, msg, list);


### PR DESCRIPTION
Running Clang 12.0.1 on the Windows command-line via CMake and Ninja, without Bash or MinGW, results in some compilation errors:

- precision loss is an error by default; use static_cast instead
- use vsprintf_s when user is using Clang on plain Windows since
  std::vsprintf is hard deprecated

This patch is tested only on Windows + Clang 12.0.1.