### PR TITLE
fix quaternion constructors to respect GLM_FORCE_QUAT_DATA_XYZW

### DIFF
--- a/glm/detail/type_quat.hpp
+++ b/glm/detail/type_quat.hpp
@@ -3,6 +3,12 @@
 
 #pragma once
 
+#ifdef GLM_FORCE_QUAT_DATA_XYZW
+#define GLM_QUAT_LAYOUT(w, x, y, z) x, y, z, w
+#else
+#define GLM_QUAT_LAYOUT(w, x, y, z) w, x, y, z
+#endif
+
 // Dependency:
 #include "../detail/type_mat3x3.hpp"
 #include "../detail/type_mat4x4.hpp"

--- a/glm/detail/type_quat.hpp
+++ b/glm/detail/type_quat.hpp
@@ -93,7 +93,11 @@ namespace glm
 
 		// -- Explicit basic constructors --
 
-		GLM_FUNC_DECL GLM_CONSTEXPR qua(T s, vec<3, T, Q> const& v);
+#		ifdef GLM_FORCE_QUAT_DATA_XYZW
+		    GLM_FUNC_DECL GLM_CONSTEXPR qua(vec<3, T, Q> const& v, T s);
+#		else
+		    GLM_FUNC_DECL GLM_CONSTEXPR qua(T s, vec<3, T, Q> const& v);
+#		endif
 
 #		ifdef GLM_FORCE_QUAT_DATA_XYZW
 		GLM_FUNC_DECL GLM_CONSTEXPR qua(T x, T y, T z, T w);

--- a/glm/detail/type_quat.hpp
+++ b/glm/detail/type_quat.hpp
@@ -3,18 +3,13 @@
 
 #pragma once
 
-#ifdef GLM_FORCE_QUAT_DATA_XYZW
-#define GLM_QUAT_LAYOUT(w, x, y, z) x, y, z, w
-#else
-#define GLM_QUAT_LAYOUT(w, x, y, z) w, x, y, z
-#endif
-
 // Dependency:
 #include "../detail/type_mat3x3.hpp"
 #include "../detail/type_mat4x4.hpp"
 #include "../detail/type_vec3.hpp"
 #include "../detail/type_vec4.hpp"
 #include "../ext/vector_relational.hpp"
+#include "../ext/quaternion_layout.hpp"
 #include "../ext/quaternion_relational.hpp"
 #include "../gtc/constants.hpp"
 #include "../gtc/matrix_transform.hpp"

--- a/glm/detail/type_quat.inl
+++ b/glm/detail/type_quat.inl
@@ -18,7 +18,7 @@ namespace detail
 	{
 		GLM_FUNC_QUALIFIER GLM_CONSTEXPR static T call(qua<T, Q> const& a, qua<T, Q> const& b)
 		{
-			vec<4, T, Q> tmp(a.w * b.w, a.x * b.x, a.y * b.y, a.z * b.z);
+			vec<4, T, Q> tmp(GLM_QUAT_LAYOUT(a.w * b.w, a.x * b.x, a.y * b.y, a.z * b.z));
 			return (tmp.x + tmp.y) + (tmp.z + tmp.w);
 		}
 	};
@@ -28,7 +28,7 @@ namespace detail
 	{
 		GLM_FUNC_QUALIFIER GLM_CONSTEXPR static qua<T, Q> call(qua<T, Q> const& q, qua<T, Q> const& p)
 		{
-			return qua<T, Q>(q.w + p.w, q.x + p.x, q.y + p.y, q.z + p.z);
+			return qua<T, Q>(GLM_QUAT_LAYOUT(q.w + p.w, q.x + p.x, q.y + p.y, q.z + p.z));
 		}
 	};
 
@@ -37,7 +37,7 @@ namespace detail
 	{
 		GLM_FUNC_QUALIFIER GLM_CONSTEXPR static qua<T, Q> call(qua<T, Q> const& q, qua<T, Q> const& p)
 		{
-			return qua<T, Q>(q.w - p.w, q.x - p.x, q.y - p.y, q.z - p.z);
+			return qua<T, Q>(GLM_QUAT_LAYOUT(q.w - p.w, q.x - p.x, q.y - p.y, q.z - p.z));
 		}
 	};
 
@@ -46,7 +46,7 @@ namespace detail
 	{
 		GLM_FUNC_QUALIFIER GLM_CONSTEXPR static qua<T, Q> call(qua<T, Q> const& q, T s)
 		{
-			return qua<T, Q>(q.w * s, q.x * s, q.y * s, q.z * s);
+			return qua<T, Q>(GLM_QUAT_LAYOUT(q.w * s, q.x * s, q.y * s, q.z * s));
 		}
 	};
 
@@ -55,7 +55,7 @@ namespace detail
 	{
 		GLM_FUNC_QUALIFIER GLM_CONSTEXPR static qua<T, Q> call(qua<T, Q> const& q, T s)
 		{
-			return qua<T, Q>(q.w / s, q.x / s, q.y / s, q.z / s);
+			return qua<T, Q>(GLM_QUAT_LAYOUT(q.w / s, q.x / s, q.y / s, q.z / s));
 		}
 	};
 
@@ -132,12 +132,13 @@ namespace detail
 	// -- Explicit basic constructors --
 
 	template<typename T, qualifier Q>
-	GLM_FUNC_QUALIFIER GLM_CONSTEXPR qua<T, Q>::qua(T s, vec<3, T, Q> const& v)
-#		ifdef GLM_FORCE_QUAT_DATA_XYZW
+#   ifdef GLM_FORCE_QUAT_DATA_XYZW
+	GLM_FUNC_QUALIFIER GLM_CONSTEXPR qua<T, Q>::qua(vec<3, T, Q> const& v, T s)
 			: x(v.x), y(v.y), z(v.z), w(s)
-#		else
+#	else
+	GLM_FUNC_QUALIFIER GLM_CONSTEXPR qua<T, Q>::qua(T s, vec<3, T, Q> const& v)
 			: w(s), x(v.x), y(v.y), z(v.z)
-#		endif
+#	endif
 	{}
 
 	template <typename T, qualifier Q>
@@ -201,7 +202,7 @@ namespace detail
 			t = cross(u, v);
 		}
 
-		*this = normalize(qua<T, Q>(real_part, t.x, t.y, t.z));
+		*this = normalize(qua<T, Q>(GLM_QUAT_LAYOUT(real_part, t.x, t.y, t.z)));
 	}
 
 	template<typename T, qualifier Q>
@@ -320,7 +321,7 @@ namespace detail
 	template<typename T, qualifier Q>
 	GLM_FUNC_QUALIFIER GLM_CONSTEXPR qua<T, Q> operator-(qua<T, Q> const& q)
 	{
-		return qua<T, Q>(-q.w, -q.x, -q.y, -q.z);
+		return qua<T, Q>(GLM_QUAT_LAYOUT(-q.w, -q.x, -q.y, -q.z));
 	}
 
 	// -- Binary operators --
@@ -374,8 +375,7 @@ namespace detail
 	template<typename T, qualifier Q>
 	GLM_FUNC_QUALIFIER GLM_CONSTEXPR qua<T, Q> operator*(qua<T, Q> const& q, T const& s)
 	{
-		return qua<T, Q>(
-			q.w * s, q.x * s, q.y * s, q.z * s);
+		return qua<T, Q>(GLM_QUAT_LAYOUT(q.w * s, q.x * s, q.y * s, q.z * s));
 	}
 
 	template<typename T, qualifier Q>
@@ -387,8 +387,7 @@ namespace detail
 	template<typename T, qualifier Q>
 	GLM_FUNC_QUALIFIER GLM_CONSTEXPR qua<T, Q> operator/(qua<T, Q> const& q, T const& s)
 	{
-		return qua<T, Q>(
-			q.w / s, q.x / s, q.y / s, q.z / s);
+		return qua<T, Q>(GLM_QUAT_LAYOUT(q.w / s, q.x / s, q.y / s, q.z / s));
 	}
 
 	// -- Boolean operators --

--- a/glm/ext/quaternion_common.inl
+++ b/glm/ext/quaternion_common.inl
@@ -1,8 +1,4 @@
-#ifdef GLM_FORCE_QUAT_DATA_XYZW
-#define GLM_QUAT_LAYOUT(w, x, y, z) x, y, z, w
-#else
-#define GLM_QUAT_LAYOUT(w, x, y, z) w, x, y, z
-#endif
+#include "quaternion_layout.hpp"
 
 namespace glm
 {

--- a/glm/ext/quaternion_common.inl
+++ b/glm/ext/quaternion_common.inl
@@ -1,3 +1,9 @@
+#ifdef GLM_FORCE_QUAT_DATA_XYZW
+#define GLM_QUAT_LAYOUT(w, x, y, z) x, y, z, w
+#else
+#define GLM_QUAT_LAYOUT(w, x, y, z) w, x, y, z
+#endif
+
 namespace glm
 {
 	template<typename T, qualifier Q>

--- a/glm/ext/quaternion_common.inl
+++ b/glm/ext/quaternion_common.inl
@@ -11,11 +11,11 @@ namespace glm
 		if(cosTheta > static_cast<T>(1) - epsilon<T>())
 		{
 			// Linear interpolation
-			return qua<T, Q>(
+			return qua<T, Q>(GLM_QUAT_LAYOUT(
 				mix(x.w, y.w, a),
 				mix(x.x, y.x, a),
 				mix(x.y, y.y, a),
-				mix(x.z, y.z, a));
+				mix(x.z, y.z, a)));
 		}
 		else
 		{
@@ -58,11 +58,11 @@ namespace glm
 		if(cosTheta > static_cast<T>(1) - epsilon<T>())
 		{
 			// Linear interpolation
-			return qua<T, Q>(
+			return qua<T, Q>(GLM_QUAT_LAYOUT(
 				mix(x.w, z.w, a),
 				mix(x.x, z.x, a),
 				mix(x.y, z.y, a),
-				mix(x.z, z.z, a));
+				mix(x.z, z.z, a)));
 		}
 		else
 		{
@@ -94,11 +94,11 @@ namespace glm
         if (cosTheta > static_cast<T>(1) - epsilon<T>())
         {
             // Linear interpolation
-            return qua<T, Q>(
+            return qua<T, Q>(GLM_QUAT_LAYOUT(
                 mix(x.w, z.w, a),
                 mix(x.x, z.x, a),
                 mix(x.y, z.y, a),
-                mix(x.z, z.z, a));
+                mix(x.z, z.z, a)));
         }
         else
         {
@@ -112,7 +112,7 @@ namespace glm
 	template<typename T, qualifier Q>
 	GLM_FUNC_QUALIFIER qua<T, Q> conjugate(qua<T, Q> const& q)
 	{
-		return qua<T, Q>(q.w, -q.x, -q.y, -q.z);
+		return qua<T, Q>(GLM_QUAT_LAYOUT(q.w, -q.x, -q.y, -q.z));
 	}
 
 	template<typename T, qualifier Q>

--- a/glm/ext/quaternion_exponential.inl
+++ b/glm/ext/quaternion_exponential.inl
@@ -1,4 +1,5 @@
 #include "scalar_constants.hpp"
+#include "quaternion_layout.hpp"
 
 namespace glm
 {

--- a/glm/ext/quaternion_exponential.inl
+++ b/glm/ext/quaternion_exponential.inl
@@ -11,7 +11,11 @@ namespace glm
 			return qua<T, Q>();
 
 		vec<3, T, Q> const v(u / Angle);
-		return qua<T, Q>(cos(Angle), sin(Angle) * v);
+#       ifdef GLM_FORCE_QUAT_DATA_XYZW
+	    	return qua<T, Q>(sin(Angle) * v, cos(Angle));
+#       else
+    		return qua<T, Q>(cos(Angle), sin(Angle) * v);
+#       endif
 	}
 
 	template<typename T, qualifier Q>
@@ -23,17 +27,21 @@ namespace glm
 		if (Vec3Len < epsilon<T>())
 		{
 			if(q.w > static_cast<T>(0))
-				return qua<T, Q>(log(q.w), static_cast<T>(0), static_cast<T>(0), static_cast<T>(0));
+				return qua<T, Q>(GLM_QUAT_LAYOUT(log(q.w), static_cast<T>(0), static_cast<T>(0), static_cast<T>(0)));
 			else if(q.w < static_cast<T>(0))
-				return qua<T, Q>(log(-q.w), pi<T>(), static_cast<T>(0), static_cast<T>(0));
+				return qua<T, Q>(GLM_QUAT_LAYOUT(log(-q.w), pi<T>(), static_cast<T>(0), static_cast<T>(0)));
 			else
-				return qua<T, Q>(std::numeric_limits<T>::infinity(), std::numeric_limits<T>::infinity(), std::numeric_limits<T>::infinity(), std::numeric_limits<T>::infinity());
+				return qua<T, Q>(GLM_QUAT_LAYOUT(
+                    std::numeric_limits<T>::infinity(),
+                    std::numeric_limits<T>::infinity(),
+                    std::numeric_limits<T>::infinity(),
+                    std::numeric_limits<T>::infinity()));
 		}
 		else
 		{
 			T t = atan(Vec3Len, T(q.w)) / Vec3Len;
 			T QuatLen2 = Vec3Len * Vec3Len + q.w * q.w;
-			return qua<T, Q>(static_cast<T>(0.5) * log(QuatLen2), t * q.x, t * q.y, t * q.z);
+			return qua<T, Q>(GLM_QUAT_LAYOUT(static_cast<T>(0.5) * log(QuatLen2), t * q.x, t * q.y, t * q.z));
 		}
 	}
 
@@ -43,7 +51,7 @@ namespace glm
 		//Raising to the power of 0 should yield 1
 		//Needed to prevent a division by 0 error later on
 		if(y > -epsilon<T>() && y < epsilon<T>())
-			return qua<T, Q>(1,0,0,0);
+			return qua<T, Q>(GLM_QUAT_LAYOUT(static_cast<T>(1), static_cast<T>(0), static_cast<T>(0), static_cast<T>(0)));
 
 		//To deal with non-unit quaternions
 		T magnitude = sqrt(x.x * x.x + x.y * x.y + x.z * x.z + x.w *x.w);
@@ -62,7 +70,7 @@ namespace glm
 			//always false, even when VectorMagnitude is 0.
 			if (VectorMagnitude < std::numeric_limits<T>::min()) {
 				//Equivalent to raising a real number to a power
-				return qua<T, Q>(pow(x.w, y), 0, 0, 0);
+				return qua<T, Q>(GLM_QUAT_LAYOUT(pow(x.w, y), static_cast<T>(0), static_cast<T>(0), static_cast<T>(0)));
 			}
 
 			Angle = asin(sqrt(VectorMagnitude) / magnitude);
@@ -76,7 +84,7 @@ namespace glm
 		T NewAngle = Angle * y;
 		T Div = sin(NewAngle) / sin(Angle);
 		T Mag = pow(magnitude, y - static_cast<T>(1));
-		return qua<T, Q>(cos(NewAngle) * magnitude * Mag, x.x * Div * Mag, x.y * Div * Mag, x.z * Div * Mag);
+		return qua<T, Q>(GLM_QUAT_LAYOUT(cos(NewAngle) * magnitude * Mag, x.x * Div * Mag, x.y * Div * Mag, x.z * Div * Mag));
 	}
 
 	template<typename T, qualifier Q>

--- a/glm/ext/quaternion_geometric.inl
+++ b/glm/ext/quaternion_geometric.inl
@@ -18,19 +18,19 @@ namespace glm
 	{
 		T len = length(q);
 		if(len <= static_cast<T>(0)) // Problem
-			return qua<T, Q>(static_cast<T>(1), static_cast<T>(0), static_cast<T>(0), static_cast<T>(0));
+			return qua<T, Q>(GLM_QUAT_LAYOUT(static_cast<T>(1), static_cast<T>(0), static_cast<T>(0), static_cast<T>(0)));
 		T oneOverLen = static_cast<T>(1) / len;
-		return qua<T, Q>(q.w * oneOverLen, q.x * oneOverLen, q.y * oneOverLen, q.z * oneOverLen);
+		return qua<T, Q>(GLM_QUAT_LAYOUT(q.w * oneOverLen, q.x * oneOverLen, q.y * oneOverLen, q.z * oneOverLen));
 	}
 
 	template<typename T, qualifier Q>
 	GLM_FUNC_QUALIFIER qua<T, Q> cross(qua<T, Q> const& q1, qua<T, Q> const& q2)
 	{
-		return qua<T, Q>(
+		return qua<T, Q>(GLM_QUAT_LAYOUT(
 			q1.w * q2.w - q1.x * q2.x - q1.y * q2.y - q1.z * q2.z,
 			q1.w * q2.x + q1.x * q2.w + q1.y * q2.z - q1.z * q2.y,
 			q1.w * q2.y + q1.y * q2.w + q1.z * q2.x - q1.x * q2.z,
-			q1.w * q2.z + q1.z * q2.w + q1.x * q2.y - q1.y * q2.x);
+			q1.w * q2.z + q1.z * q2.w + q1.x * q2.y - q1.y * q2.x));
 	}
 }//namespace glm
 

--- a/glm/ext/quaternion_geometric.inl
+++ b/glm/ext/quaternion_geometric.inl
@@ -1,8 +1,4 @@
-#ifdef GLM_FORCE_QUAT_DATA_XYZW
-#define GLM_QUAT_LAYOUT(w, x, y, z) x, y, z, w
-#else
-#define GLM_QUAT_LAYOUT(w, x, y, z) w, x, y, z
-#endif
+#include "quaternion_layout.hpp"
 
 namespace glm
 {

--- a/glm/ext/quaternion_geometric.inl
+++ b/glm/ext/quaternion_geometric.inl
@@ -1,3 +1,9 @@
+#ifdef GLM_FORCE_QUAT_DATA_XYZW
+#define GLM_QUAT_LAYOUT(w, x, y, z) x, y, z, w
+#else
+#define GLM_QUAT_LAYOUT(w, x, y, z) w, x, y, z
+#endif
+
 namespace glm
 {
 	template<typename T, qualifier Q>

--- a/glm/ext/quaternion_layout.hpp
+++ b/glm/ext/quaternion_layout.hpp
@@ -1,0 +1,6 @@
+#pragma once
+#ifdef GLM_FORCE_QUAT_DATA_XYZW
+#define GLM_QUAT_LAYOUT(w, x, y, z) x, y, z, w
+#else
+#define GLM_QUAT_LAYOUT(w, x, y, z) w, x, y, z
+#endif

--- a/glm/ext/quaternion_transform.inl
+++ b/glm/ext/quaternion_transform.inl
@@ -1,3 +1,5 @@
+#include "quaternion_layout.hpp"
+
 namespace glm
 {
 	template<typename T, qualifier Q>

--- a/glm/ext/quaternion_transform.inl
+++ b/glm/ext/quaternion_transform.inl
@@ -18,7 +18,7 @@ namespace glm
 		T const AngleRad(angle);
 		T const Sin = sin(AngleRad * static_cast<T>(0.5));
 
-		return q * qua<T, Q>(cos(AngleRad * static_cast<T>(0.5)), Tmp.x * Sin, Tmp.y * Sin, Tmp.z * Sin);
+		return q * qua<T, Q>(GLM_QUAT_LAYOUT(cos(AngleRad * static_cast<T>(0.5)), Tmp.x * Sin, Tmp.y * Sin, Tmp.z * Sin));
 	}
 }//namespace glm
 

--- a/glm/ext/quaternion_trigonometric.inl
+++ b/glm/ext/quaternion_trigonometric.inl
@@ -32,6 +32,10 @@ namespace glm
 		T const a(angle);
 		T const s = glm::sin(a * static_cast<T>(0.5));
 
-		return qua<T, Q>(glm::cos(a * static_cast<T>(0.5)), v * s);
+#       ifdef GLM_FORCE_QUAT_DATA_XYZW
+		    return qua<T, Q>(v * s, glm::cos(a * static_cast<T>(0.5)));
+#       else
+		    return qua<T, Q>(glm::cos(a * static_cast<T>(0.5)), v * s);
+#       endif
 	}
 }//namespace glm

--- a/glm/ext/quaternion_trigonometric.inl
+++ b/glm/ext/quaternion_trigonometric.inl
@@ -1,4 +1,5 @@
 #include "scalar_constants.hpp"
+#include "quaternion_layout.hpp"
 
 namespace glm
 {

--- a/glm/gtc/quaternion.inl
+++ b/glm/gtc/quaternion.inl
@@ -109,16 +109,16 @@ namespace glm
 		switch(biggestIndex)
 		{
 		case 0:
-			return qua<T, Q>(biggestVal, (m[1][2] - m[2][1]) * mult, (m[2][0] - m[0][2]) * mult, (m[0][1] - m[1][0]) * mult);
+			return qua<T, Q>(GLM_QUAT_LAYOUT(biggestVal, (m[1][2] - m[2][1]) * mult, (m[2][0] - m[0][2]) * mult, (m[0][1] - m[1][0]) * mult));
 		case 1:
-			return qua<T, Q>((m[1][2] - m[2][1]) * mult, biggestVal, (m[0][1] + m[1][0]) * mult, (m[2][0] + m[0][2]) * mult);
+			return qua<T, Q>(GLM_QUAT_LAYOUT((m[1][2] - m[2][1]) * mult, biggestVal, (m[0][1] + m[1][0]) * mult, (m[2][0] + m[0][2]) * mult));
 		case 2:
-			return qua<T, Q>((m[2][0] - m[0][2]) * mult, (m[0][1] + m[1][0]) * mult, biggestVal, (m[1][2] + m[2][1]) * mult);
+			return qua<T, Q>(GLM_QUAT_LAYOUT((m[2][0] - m[0][2]) * mult, (m[0][1] + m[1][0]) * mult, biggestVal, (m[1][2] + m[2][1]) * mult));
 		case 3:
-			return qua<T, Q>((m[0][1] - m[1][0]) * mult, (m[2][0] + m[0][2]) * mult, (m[1][2] + m[2][1]) * mult, biggestVal);
+			return qua<T, Q>(GLM_QUAT_LAYOUT((m[0][1] - m[1][0]) * mult, (m[2][0] + m[0][2]) * mult, (m[1][2] + m[2][1]) * mult, biggestVal));
 		default: // Silence a -Wswitch-default warning in GCC. Should never actually get here. Assert is just for sanity.
 			assert(false);
-			return qua<T, Q>(1, 0, 0, 0);
+			return qua<T, Q>(GLM_QUAT_LAYOUT(static_cast<T>(1), static_cast<T>(0), static_cast<T>(0), static_cast<T>(0)));
 		}
 	}
 

--- a/glm/gtx/dual_quaternion.inl
+++ b/glm/gtx/dual_quaternion.inl
@@ -219,8 +219,8 @@ namespace glm
 	GLM_FUNC_QUALIFIER tdualquat<T, Q> dual_quat_identity()
 	{
 		return tdualquat<T, Q>(
-			qua<T, Q>(static_cast<T>(1), static_cast<T>(0), static_cast<T>(0), static_cast<T>(0)),
-			qua<T, Q>(static_cast<T>(0), static_cast<T>(0), static_cast<T>(0), static_cast<T>(0)));
+			qua<T, Q>(GLM_QUAT_LAYOUT(static_cast<T>(1), static_cast<T>(0), static_cast<T>(0), static_cast<T>(0))),
+			qua<T, Q>(GLM_QUAT_LAYOUT(static_cast<T>(0), static_cast<T>(0), static_cast<T>(0), static_cast<T>(0))));
 	}
 
 	template<typename T, qualifier Q>
@@ -295,8 +295,8 @@ namespace glm
 	GLM_FUNC_QUALIFIER tdualquat<T, Q> dualquat_cast(mat<2, 4, T, Q> const& x)
 	{
 		return tdualquat<T, Q>(
-			qua<T, Q>( x[0].w, x[0].x, x[0].y, x[0].z ),
-			qua<T, Q>( x[1].w, x[1].x, x[1].y, x[1].z ));
+			qua<T, Q>(GLM_QUAT_LAYOUT(x[0].w, x[0].x, x[0].y, x[0].z)),
+			qua<T, Q>(GLM_QUAT_LAYOUT(x[1].w, x[1].x, x[1].y, x[1].z)));
 	}
 
 	template<typename T, qualifier Q>

--- a/glm/gtx/quaternion.inl
+++ b/glm/gtx/quaternion.inl
@@ -8,7 +8,7 @@ namespace glm
 	template<typename T, qualifier Q>
 	GLM_FUNC_QUALIFIER GLM_CONSTEXPR qua<T, Q> quat_identity()
 	{
-		return qua<T, Q>(static_cast<T>(1), static_cast<T>(0), static_cast<T>(0), static_cast<T>(0));
+		return qua<T, Q>(GLM_QUAT_LAYOUT(static_cast<T>(1), static_cast<T>(0), static_cast<T>(0), static_cast<T>(0)));
 	}
 
 	template<typename T, qualifier Q>
@@ -105,11 +105,11 @@ namespace glm
 			k1 = sin((static_cast<T>(0) + a) * fAngle) * fOneOverSin;
 		}
 
-		return qua<T, Q>(
+		return qua<T, Q>(GLM_QUAT_LAYOUT(
 			k0 * x.w + k1 * y2.w,
 			k0 * x.x + k1 * y2.x,
 			k0 * x.y + k1 * y2.y,
-			k0 * x.z + k1 * y2.z);
+			k0 * x.z + k1 * y2.z));
 	}
 
 	template<typename T, qualifier Q>
@@ -150,10 +150,10 @@ namespace glm
 		T s = sqrt((T(1) + cosTheta) * static_cast<T>(2));
 		T invs = static_cast<T>(1) / s;
 
-		return qua<T, Q>(
+		return qua<T, Q>(GLM_QUAT_LAYOUT(
 			s * static_cast<T>(0.5f),
 			rotationAxis.x * invs,
 			rotationAxis.y * invs,
-			rotationAxis.z * invs);
+			rotationAxis.z * invs));
 	}
 }//namespace glm

--- a/glm/gtx/rotate_normalized_axis.inl
+++ b/glm/gtx/rotate_normalized_axis.inl
@@ -52,7 +52,7 @@ namespace glm
 		T const AngleRad(angle);
 		T const Sin = sin(AngleRad * T(0.5));
 
-		return q * qua<T, Q>(cos(AngleRad * static_cast<T>(0.5)), Tmp.x * Sin, Tmp.y * Sin, Tmp.z * Sin);
+		return q * qua<T, Q>(GLM_QUAT_LAYOUT(cos(AngleRad * static_cast<T>(0.5)), Tmp.x * Sin, Tmp.y * Sin, Tmp.z * Sin));
 		//return gtc::quaternion::cross(q, tquat<T, Q>(cos(AngleRad * T(0.5)), Tmp.x * fSin, Tmp.y * fSin, Tmp.z * fSin));
 	}
 }//namespace glm


### PR DESCRIPTION
my previous pull request to get the constructor respect the quaternion layout was missing these changes.

Problem:

the quaternion constructor was used internally for example in slerp, I overlooked these places and only patched the constructor to respect the parameter ordering.

This PR adds a macro to reorder the parameters within the implementation, this adds a minimal risk of breaking code compared to wrapping all these lines with ifdefs.
