### PR TITLE
Fixed MSVC compilation error with C++ 20

### DIFF
--- a/glm/detail/type_vec1.inl
+++ b/glm/detail/type_vec1.inl
@@ -234,7 +234,7 @@ namespace glm
 	template<typename U>
 	GLM_FUNC_QUALIFIER GLM_CONSTEXPR vec<1, T, Q> & vec<1, T, Q>::operator|=(vec<1, U, Q> const& v)
 	{
-		this->x |= U(v.x);
+		this->x |= static_cast<T>(v.x);
 		return *this;
 	}
 


### PR DESCRIPTION
This doesn't happen in every project I try to compile with C++ 20 flag with MSVC and I don't know what exactly triggers it. The code that triggered the error is not something I can share. The error is not pointing to any particular line and I don't see this specific template being instantiated.

Compiler output:
```
error C3861: 'Lv': identifier not found
This diagnostic occurred in the compiler generated function 'glm::vec<1,T,Q> &glm::vec<1,T,Q>::operator |=(const glm::vec<1,A,Q> &)'
```