### PR TITLE
Fix test-core_func_integer with GCC-11

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -206,7 +206,7 @@ elseif(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
 		message("GLM: GCC - ${CMAKE_CXX_COMPILER_ID} compiler")
 	endif()
 
-	add_compile_options(-O2)
+	add_compile_options(-O0)
 	add_compile_options(-Wno-long-long)
 
 elseif(CMAKE_CXX_COMPILER_ID MATCHES "Intel")


### PR DESCRIPTION
Unit-tests are failing if built using GCC-11.

```
99% tests passed, 2 tests failed out of 188

Total Test time (real) = 3.86 sec

The following tests FAILED:
  39 - test-core_func_integer (Child aborted)
  97 - test-ext_vector_integer (Child aborted)
```

test-ext_vector_integer seems to be flaky, while test-core_func_integer fails consistently.

If built with -Wall this warning shows up, which seems to be relevant:
cd /home/user/glm-gu/obj-x86_64-linux-gnu/test/core && /usr/bin/cmake -E cmake_link_script CMakeFiles/test-core_func_matrix.dir/link.txt --verbose=1
/usr/bin/c++ -g -O2 -ffile-prefix-map=/home/user/glm-gu=. -flto=auto -ffat-lto-objects -fstack-protector-strong -Wformat -Werror=format-security -Wall -Wno-error -Wdate-time -D_FORTIFY_SOURCE=2 -Wl,-Bsymbolic-functions -flto=auto -Wl,-z,relro -rdynamic CMakeFiles/test-core_func_matrix.dir/core_func_matrix.cpp.o -o test-core_func_matrix
In function â€˜bitCount::bitCount_bitfield<int>(int)intâ€™,
    inlined from â€˜bitCount::test()â€™ at /home/user/glm-gu/test/core/core_func_integer.cpp:1515:35,
    inlined from â€˜mainâ€™ at /home/user/glm-gu/test/core/core_func_integer.cpp:1533:27:
/home/user/glm-gu/test/core/core_func_integer.cpp:1442:41: warning: â€˜<anonymous>â€™ may be used uninitialized [-Wmaybe-uninitialized]
 1442 | return bitCount_bitfield(glm::vec<1, genType, glm::defaultp>(x)).x;
      | ~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/user/glm-gu/test/core/core_func_integer.cpp: In function â€˜mainâ€™:
/home/user/glm-gu/test/core/core_func_integer.cpp:1427:36: note: by argument 1 of type â€˜const struct vec &â€™ to â€˜bitCount::bitCount_bitfield<1, int, (glm::qualifier)0>(glm::vec<1, int, (glm::qualifier)0> const&)glm::vec<1, int, (glm::qualifier)0>â€™ declared here
 1427 | static glm::vec<L, int, Q> bitCount_bitfield(glm::vec<L, T, Q> const& v)
      | ^~~~~~~~~~~~~~~~~
/home/user/glm-gu/test/core/core_func_integer.cpp:1442:47: note: â€˜<anonymous>â€™ declared here
 1442 | return bitCount_bitfield(glm::vec<1, genType, glm::defaultp>(x)).x;
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/user/glm-gu/test/core/core_func_common.cpp: In function â€˜int test_constexpr()â€™:
/home/user/glm-gu/test/core/core_func_common.cpp:1306:35: warning: variable â€˜Aâ€™ set but not used [-Wunused-but-set-variable]
 1306 | constexpr glm::vec1 const A = glm::abs(glm::vec1(1.0f));
      | ^
/home/user/glm-gu/test/core/core_func_common.cpp:1307:35: warning: variable â€˜Bâ€™ set but not used [-Wunused-but-set-variable]
 1307 | constexpr glm::vec2 const B = glm::abs(glm::vec2(1.0f));
      | ^
/home/user/glm-gu/test/core/core_func_common.cpp:1308:35: warning: variable â€˜Câ€™ set but not used [-Wunused-but-set-variable]
 1308 | constexpr glm::vec3 const C = glm::abs(glm::vec3(1.0f));
      | ^
/home/user/glm-gu/test/core/core_func_common.cpp:1309:35: warning: variable â€˜Dâ€™ set but not used [-Wunused-but-set-variable]
 1309 | constexpr glm::vec4 const D = glm::abs(glm::vec4(1.0f));
      | ^


See https://bugs.launchpad.net/ubuntu/+source/glm/+bug/1946750