### PR TITLE
fix: GLM_NEVER_INLINE

### DIFF
--- a/glm/detail/setup.hpp
+++ b/glm/detail/setup.hpp
@@ -434,7 +434,7 @@
 #if defined(GLM_FORCE_INLINE)
 #	if GLM_COMPILER & GLM_COMPILER_VC
 #		define GLM_INLINE __forceinline
-#		define GLM_NEVER_INLINE __declspec((noinline))
+#		define GLM_NEVER_INLINE __declspec(noinline)
 #	elif GLM_COMPILER & (GLM_COMPILER_GCC | GLM_COMPILER_CLANG)
 #		define GLM_INLINE inline __attribute__((__always_inline__))
 #		define GLM_NEVER_INLINE __attribute__((__noinline__))


### PR DESCRIPTION
Invalid syntax when compiling with Visual C++.

If needed, I can include a small test to ensure there is at least *some* test coverage for this unused macro.