### PR TITLE
fix mat2 constructors

### DIFF
--- a/glm/detail/type_mat2x2.inl
+++ b/glm/detail/type_mat2x2.inl
@@ -22,7 +22,7 @@ namespace glm
 	template<qualifier P>
 	GLM_FUNC_QUALIFIER GLM_CONSTEXPR mat<2, 2, T, Q>::mat(mat<2, 2, T, P> const& m)
 #		if GLM_HAS_INITIALIZER_LISTS
-			: value{m[0], m[1]}
+			: value{col_type(m[0]), col_type(m[1])}
 #		endif
 	{
 #		if !GLM_HAS_INITIALIZER_LISTS

--- a/glm/detail/type_mat2x3.inl
+++ b/glm/detail/type_mat2x3.inl
@@ -20,7 +20,7 @@ namespace glm
 	template<qualifier P>
 	GLM_FUNC_QUALIFIER GLM_CONSTEXPR mat<2, 3, T, Q>::mat(mat<2, 3, T, P> const& m)
 #		if GLM_HAS_INITIALIZER_LISTS
-			: value{m.value[0], m.value[1]}
+			: value{col_type(m[0]), col_type(m[1])}
 #		endif
 	{
 #		if !GLM_HAS_INITIALIZER_LISTS

--- a/glm/detail/type_mat2x4.inl
+++ b/glm/detail/type_mat2x4.inl
@@ -20,7 +20,7 @@ namespace glm
 	template<qualifier P>
 	GLM_FUNC_QUALIFIER GLM_CONSTEXPR mat<2, 4, T, Q>::mat(mat<2, 4, T, P> const& m)
 #		if GLM_HAS_INITIALIZER_LISTS
-			: value{m[0], m[1]}
+			: value{col_type(m[0]), col_type(m[1])}
 #		endif
 	{
 #		if !GLM_HAS_INITIALIZER_LISTS


### PR DESCRIPTION
The `glm::mat<2, 3, ...>` constructor will throw a compilation [error](https://github.com/g-truc/glm/blob/master/glm/detail/type_mat2x3.inl#L23) when the template context is different. For example,

```
./glm/./ext/../detail/.././ext/../detail/type_mat2x3.inl:23:14: error: ‘glm::mat<2, 3, float, glm::packed_lowp>::col_type glm::mat<2, 3, float, glm::packed_lowp>::value [2]’ is private within this context
   23 |    : value{m.value[0], m.value[1]}
```

This PR fixes this and makes each `mat2` constructor follow the convention used in `mat3` and `mat4`. For reference: [mat3x2](https://github.com/g-truc/glm/blob/master/glm/detail/type_mat3x2.inl#L24), [mat3x3](https://github.com/g-truc/glm/blob/master/glm/detail/type_mat3x3.inl#L26), [mat4x3](https://github.com/g-truc/glm/blob/master/glm/detail/type_mat4x3.inl#L25), and [mat4x4](https://github.com/g-truc/glm/blob/master/glm/detail/type_mat4x4.inl#L27)