### PR TITLE
Fix implicit conversion compiler error in glm/gtc/random.inl

### DIFF
--- a/glm/gtc/random.inl
+++ b/glm/gtc/random.inl
@@ -22,7 +22,7 @@ namespace detail
 		GLM_FUNC_QUALIFIER static vec<1, uint8, P> call()
 		{
 			return vec<1, uint8, P>(
-				std::rand() % std::numeric_limits<uint8>::max());
+				static_cast<uint8>(std::rand() % std::numeric_limits<uint8>::max()));
 		}
 	};
 


### PR DESCRIPTION
/glm/gtc/random.inl:25:17: error: implicit conversion loses integer precision: 'int' to 'unsigned char' [-Werror,-Wimplicit-int-conversion]
                                std::rand() % std::numeric_limits<uint8>::max());
                                ~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~