### PR TITLE
Add define macro to select CUDA function qualifier

### DIFF
--- a/glm/detail/setup.hpp
+++ b/glm/detail/setup.hpp
@@ -424,8 +424,20 @@
 // Qualifiers
 
 #if (GLM_COMPILER & GLM_COMPILER_CUDA) || (GLM_COMPILER & GLM_COMPILER_HIP)
-#	define GLM_CUDA_FUNC_DEF __device__ __host__
-#	define GLM_CUDA_FUNC_DECL __device__ __host__
+#	if defined(GLM_CUDA_FORCE_DEVICE_FUNC) && defined(GLM_CUDA_FORCE_HOST_FUNC)
+#		error "GLM error: GLM_CUDA_FORCE_DEVICE_FUNC and GLM_CUDA_FORCE_HOST_FUNC should not be defined at the same time, GLM by default generates both device and host code for CUDA compiler."
+#	endif//defined(GLM_CUDA_FORCE_DEVICE_FUNC) && defined(GLM_CUDA_FORCE_HOST_FUNC)
+
+#	if defined(GLM_CUDA_FORCE_DEVICE_FUNC)
+#		define GLM_CUDA_FUNC_DEF __device__
+#		define GLM_CUDA_FUNC_DECL __device__
+#	elif defined(GLM_CUDA_FORCE_HOST_FUNC)
+#		define GLM_CUDA_FUNC_DEF __host__
+#		define GLM_CUDA_FUNC_DECL __host__
+#	else
+#		define GLM_CUDA_FUNC_DEF __device__ __host__
+#		define GLM_CUDA_FUNC_DECL __device__ __host__
+#	endif//defined(GLM_CUDA_FORCE_XXXX_FUNC)
 #else
 #	define GLM_CUDA_FUNC_DEF
 #	define GLM_CUDA_FUNC_DECL

--- a/glm/detail/setup.hpp
+++ b/glm/detail/setup.hpp
@@ -423,6 +423,8 @@
 ///////////////////////////////////////////////////////////////////////////////////
 // Qualifiers
 
+// User defines: GLM_CUDA_FORCE_DEVICE_FUNC, GLM_CUDA_FORCE_HOST_FUNC
+
 #if (GLM_COMPILER & GLM_COMPILER_CUDA) || (GLM_COMPILER & GLM_COMPILER_HIP)
 #	if defined(GLM_CUDA_FORCE_DEVICE_FUNC) && defined(GLM_CUDA_FORCE_HOST_FUNC)
 #		error "GLM error: GLM_CUDA_FORCE_DEVICE_FUNC and GLM_CUDA_FORCE_HOST_FUNC should not be defined at the same time, GLM by default generates both device and host code for CUDA compiler."


### PR DESCRIPTION
GLM automatically qualifies `__device__` and `__host__` for all GLM functions when a CUDA-like compiler is found. However there are some situations when users only want to use GLM in device functions, then code generated for host functions are wasteful; and vice versa.

The intuition behinds this PR is to prevent generation of unnecessary code as selected by user to speed up compilation and reduce code size.

### Usage

- Define `GLM_CUDA_FORCE_DEVICE_FUNC` before including any GLM header to force all functions to use `__device__` qualifier.
- Similarly, define `GLM_CUDA_FORCE_HOST_FUNC` for `__host__`.
- Define nothing will make GLM behaves as before, that is to use `__device__ __host__`.
- If both macros are defined, a compile-time error is generated.