### PR TITLE
Force no default function when using CUDA

### DIFF
--- a/glm/detail/setup.hpp
+++ b/glm/detail/setup.hpp
@@ -212,14 +212,16 @@
 // N2346
 #if GLM_COMPILER & GLM_COMPILER_CLANG
 #	define GLM_HAS_DEFAULTED_FUNCTIONS __has_feature(cxx_defaulted_functions)
+#elif GLM_COMPILER & GLM_COMPILER_CUDA
+	// Do not use defaulted functions for CUDA compiler when function qualifiers are present
+#	define GLM_HAS_DEFAULTED_FUNCTIONS 0
 #elif GLM_LANG & GLM_LANG_CXX11_FLAG
 #	define GLM_HAS_DEFAULTED_FUNCTIONS 1
 #else
 #	define GLM_HAS_DEFAULTED_FUNCTIONS ((GLM_LANG & GLM_LANG_CXX0X_FLAG) && (\
 		((GLM_COMPILER & GLM_COMPILER_VC) && (GLM_COMPILER >= GLM_COMPILER_VC12)) || \
 		((GLM_COMPILER & GLM_COMPILER_INTEL)) || \
-		(GLM_COMPILER & GLM_COMPILER_CUDA)) || \
-		((GLM_COMPILER & GLM_COMPILER_HIP)))
+		((GLM_COMPILER & GLM_COMPILER_HIP))))
 #endif
 
 // N2118


### PR DESCRIPTION
The compiler emits a ton of warnings when using CUDA. An snippet of the warning message looks like this:

> type_vec4.hpp(101): warning : `__device__` annotation is ignored on a function("vec") that is explicitly defaulted on its first declaration
> type_vec4.hpp(101): warning : `__host__` annotation is ignored on a function("vec") that is explicitly defaulted on its first declaration

For CUDA, a trivial default function already tells both host and device compilers to emit code, therefore `__device__` and `__host__` qualifiers are ignored. In another word, function declared as default implies `__device__ __host__` qualifier.

As a resolution, either the function qualifiers should be removed, or force to not use default function. Considering the changes made in #1106, I picked the second choice.