### PR TITLE
Fix glm::rotate for GLM_FORCE_QUAT_DATA_XYZW configuration

### DIFF
--- a/glm/ext/quaternion_transform.inl
+++ b/glm/ext/quaternion_transform.inl
@@ -18,7 +18,7 @@ namespace glm
 		T const AngleRad(angle);
 		T const Sin = sin(AngleRad * static_cast<T>(0.5));
 
-		return q * qua<T, Q>(cos(AngleRad * static_cast<T>(0.5)), Tmp.x * Sin, Tmp.y * Sin, Tmp.z * Sin);
+		return q * qua<T, Q>(cos(AngleRad * static_cast<T>(0.5)), Tmp * Sin);
 	}
 }//namespace glm
 


### PR DESCRIPTION
GLM_FORCE_QUAT_DATA_XYZW doesn't simply change the data layout, it also changes the meaning of quat constructor.
This means that every call inside glm itself that passes 4 arguments needs to check that define.

This change fixes glm::rotate specifically by relying on scalar+vector ctor (which is stable across configurations), although
there are other instances in glm that are likely problematic eg glm::cross.