### PR TITLE
cleanup doxygen and codespell

### DIFF
--- a/glm/ext/matrix_clip_space.hpp
+++ b/glm/ext/matrix_clip_space.hpp
@@ -212,7 +212,7 @@ namespace glm
 		T left, T right, T bottom, T top, T near, T far);
 
 
-	/// Creates a matrix for a right handed, symetric perspective-view frustum.
+	/// Creates a matrix for a right handed, symmetric perspective-view frustum.
 	/// The near and far clip planes correspond to z normalized device coordinates of 0 and +1 respectively. (Direct3D clip volume definition)
 	///
 	/// @param fovy Specifies the field of view angle, in degrees, in the y direction. Expressed in radians.
@@ -225,7 +225,7 @@ namespace glm
 	GLM_FUNC_DECL mat<4, 4, T, defaultp> perspectiveRH_ZO(
 		T fovy, T aspect, T near, T far);
 
-	/// Creates a matrix for a right handed, symetric perspective-view frustum.
+	/// Creates a matrix for a right handed, symmetric perspective-view frustum.
 	/// The near and far clip planes correspond to z normalized device coordinates of -1 and +1 respectively. (OpenGL clip volume definition)
 	///
 	/// @param fovy Specifies the field of view angle, in degrees, in the y direction. Expressed in radians.
@@ -238,7 +238,7 @@ namespace glm
 	GLM_FUNC_DECL mat<4, 4, T, defaultp> perspectiveRH_NO(
 		T fovy, T aspect, T near, T far);
 
-	/// Creates a matrix for a left handed, symetric perspective-view frustum.
+	/// Creates a matrix for a left handed, symmetric perspective-view frustum.
 	/// The near and far clip planes correspond to z normalized device coordinates of 0 and +1 respectively. (Direct3D clip volume definition)
 	///
 	/// @param fovy Specifies the field of view angle, in degrees, in the y direction. Expressed in radians.
@@ -251,7 +251,7 @@ namespace glm
 	GLM_FUNC_DECL mat<4, 4, T, defaultp> perspectiveLH_ZO(
 		T fovy, T aspect, T near, T far);
 
-	/// Creates a matrix for a left handed, symetric perspective-view frustum.
+	/// Creates a matrix for a left handed, symmetric perspective-view frustum.
 	/// The near and far clip planes correspond to z normalized device coordinates of -1 and +1 respectively. (OpenGL clip volume definition)
 	///
 	/// @param fovy Specifies the field of view angle, in degrees, in the y direction. Expressed in radians.
@@ -264,7 +264,7 @@ namespace glm
 	GLM_FUNC_DECL mat<4, 4, T, defaultp> perspectiveLH_NO(
 		T fovy, T aspect, T near, T far);
 
-	/// Creates a matrix for a symetric perspective-view frustum using left-handed coordinates if GLM_FORCE_LEFT_HANDED if defined or right-handed coordinates otherwise.
+	/// Creates a matrix for a symmetric perspective-view frustum using left-handed coordinates if GLM_FORCE_LEFT_HANDED if defined or right-handed coordinates otherwise.
 	/// The near and far clip planes correspond to z normalized device coordinates of 0 and +1 respectively. (Direct3D clip volume definition)
 	///
 	/// @param fovy Specifies the field of view angle, in degrees, in the y direction. Expressed in radians.
@@ -277,7 +277,7 @@ namespace glm
 	GLM_FUNC_DECL mat<4, 4, T, defaultp> perspectiveZO(
 		T fovy, T aspect, T near, T far);
 
-	/// Creates a matrix for a symetric perspective-view frustum using left-handed coordinates if GLM_FORCE_LEFT_HANDED if defined or right-handed coordinates otherwise.
+	/// Creates a matrix for a symmetric perspective-view frustum using left-handed coordinates if GLM_FORCE_LEFT_HANDED if defined or right-handed coordinates otherwise.
 	/// The near and far clip planes correspond to z normalized device coordinates of -1 and +1 respectively. (OpenGL clip volume definition)
 	///
 	/// @param fovy Specifies the field of view angle, in degrees, in the y direction. Expressed in radians.
@@ -290,7 +290,7 @@ namespace glm
 	GLM_FUNC_DECL mat<4, 4, T, defaultp> perspectiveNO(
 		T fovy, T aspect, T near, T far);
 
-	/// Creates a matrix for a right handed, symetric perspective-view frustum.
+	/// Creates a matrix for a right handed, symmetric perspective-view frustum.
 	/// If GLM_FORCE_DEPTH_ZERO_TO_ONE is defined, the near and far clip planes correspond to z normalized device coordinates of 0 and +1 respectively. (Direct3D clip volume definition)
 	/// Otherwise, the near and far clip planes correspond to z normalized device coordinates of -1 and +1 respectively. (OpenGL clip volume definition)
 	///
@@ -304,7 +304,7 @@ namespace glm
 	GLM_FUNC_DECL mat<4, 4, T, defaultp> perspectiveRH(
 		T fovy, T aspect, T near, T far);
 
-	/// Creates a matrix for a left handed, symetric perspective-view frustum.
+	/// Creates a matrix for a left handed, symmetric perspective-view frustum.
 	/// If GLM_FORCE_DEPTH_ZERO_TO_ONE is defined, the near and far clip planes correspond to z normalized device coordinates of 0 and +1 respectively. (Direct3D clip volume definition)
 	/// Otherwise, the near and far clip planes correspond to z normalized device coordinates of -1 and +1 respectively. (OpenGL clip volume definition)
 	///
@@ -318,7 +318,7 @@ namespace glm
 	GLM_FUNC_DECL mat<4, 4, T, defaultp> perspectiveLH(
 		T fovy, T aspect, T near, T far);
 
-	/// Creates a matrix for a symetric perspective-view frustum based on the default handedness and default near and far clip planes definition.
+	/// Creates a matrix for a symmetric perspective-view frustum based on the default handedness and default near and far clip planes definition.
 	/// To change default handedness use GLM_FORCE_LEFT_HANDED. To change default near and far clip planes definition use GLM_FORCE_DEPTH_ZERO_TO_ONE.
 	///
 	/// @param fovy Specifies the field of view angle in the y direction. Expressed in radians.

--- a/glm/ext/matrix_float3x2.hpp
+++ b/glm/ext/matrix_float3x2.hpp
@@ -6,7 +6,7 @@
 
 namespace glm
 {
-	/// @addtogroup core
+	/// @addtogroup core_matrix
 	/// @{
 
 	/// 3 columns of 2 components matrix of single-precision floating-point numbers.

--- a/glm/ext/matrix_uint2x3.hpp
+++ b/glm/ext/matrix_uint2x3.hpp
@@ -3,7 +3,7 @@
 ///
 /// @see core (dependence)
 ///
-/// @defgroup ext_matrix_int2x3 GLM_EXT_matrix_uint2x3
+/// @defgroup ext_matrix_uint2x3 GLM_EXT_matrix_uint2x3
 /// @ingroup ext
 ///
 /// Include <glm/ext/matrix_uint2x3.hpp> to use the features of this extension.

--- a/glm/ext/matrix_uint2x4_sized.hpp
+++ b/glm/ext/matrix_uint2x4_sized.hpp
@@ -1,5 +1,5 @@
 /// @ref ext_matrix_uint2x4_sized
-/// @file glm/ext/matrixu_uint2x4_sized.hpp
+/// @file glm/ext/matrix_uint2x4_sized.hpp
 ///
 /// @see core (dependence)
 ///

--- a/glm/ext/matrix_uint3x2.hpp
+++ b/glm/ext/matrix_uint3x2.hpp
@@ -3,7 +3,7 @@
 ///
 /// @see core (dependence)
 ///
-/// @defgroup ext_matrix_int3x2 GLM_EXT_matrix_uint3x2
+/// @defgroup ext_matrix_uint3x2 GLM_EXT_matrix_uint3x2
 /// @ingroup ext
 ///
 /// Include <glm/ext/matrix_uint3x2.hpp> to use the features of this extension.

--- a/glm/ext/quaternion_geometric.hpp
+++ b/glm/ext/quaternion_geometric.hpp
@@ -8,7 +8,7 @@
 ///
 /// Include <glm/ext/quaternion_geometric.hpp> to use the features of this extension.
 ///
-/// @see core_geometric
+/// @see core_func_geometric
 /// @see ext_quaternion_float
 /// @see ext_quaternion_double
 

--- a/glm/ext/scalar_relational.hpp
+++ b/glm/ext/scalar_relational.hpp
@@ -23,6 +23,9 @@
 
 namespace glm
 {
+	/// @addtogroup ext_scalar_relational
+	/// @{
+
 	/// Returns the component-wise comparison of |x - y| < epsilon.
 	/// True if this expression is satisfied.
 	///

--- a/glm/ext/scalar_ulp.hpp
+++ b/glm/ext/scalar_ulp.hpp
@@ -26,6 +26,9 @@
 
 namespace glm
 {
+	/// @addtogroup ext_scalar_ulp
+	/// @{
+
 	/// Return the next ULP value(s) after the input value(s).
 	///
 	/// @tparam genType A floating-point scalar type.

--- a/glm/ext/vector_reciprocal.hpp
+++ b/glm/ext/vector_reciprocal.hpp
@@ -3,7 +3,7 @@
 ///
 /// @see core (dependence)
 ///
-/// @defgroup gtc_reciprocal GLM_EXT_vector_reciprocal
+/// @defgroup ext_vector_reciprocal GLM_EXT_vector_reciprocal
 /// @ingroup ext
 ///
 /// Include <glm/ext/vector_reciprocal.hpp> to use the features of this extension.

--- a/glm/ext/vector_ulp.hpp
+++ b/glm/ext/vector_ulp.hpp
@@ -25,6 +25,9 @@
 
 namespace glm
 {
+	/// @addtogroup ext_vector_ulp
+	/// @{
+
 	/// Return the next ULP value(s) after the input value(s).
 	///
 	/// @tparam L Integer between 1 and 4 included that qualify the dimension of the vector

--- a/glm/glm.hpp
+++ b/glm/glm.hpp
@@ -1,6 +1,11 @@
 /// @ref core
 /// @file glm/glm.hpp
 ///
+/// @mainpage OpenGL Mathematics (GLM)
+/// - Website: <a href="https://glm.g-truc.net">glm.g-truc.net</a>
+/// - <a href="modules.html">GLM API documentation</a>
+/// - <a href="https://github.com/g-truc/glm/blob/master/manual.md">GLM Manual</a>
+///
 /// @defgroup core Core features
 ///
 /// @brief Features that implement in C++ the GLSL specification as closely as possible.
@@ -95,10 +100,6 @@
 /// at once by including <glm/ext.hpp>. Otherwise, each extension needs to be
 /// included  a specific file.
 ///
-/// @mainpage OpenGL Mathematics (GLM)
-/// - Website: <a href="https://glm.g-truc.net">glm.g-truc.net</a>
-/// - <a href="modules.html">GLM API documentation</a>
-/// - <a href="https://github.com/g-truc/glm/blob/master/manual.md">GLM Manual</a>
 
 #include "detail/_fixes.hpp"
 

--- a/glm/gtc/integer.hpp
+++ b/glm/gtc/integer.hpp
@@ -32,7 +32,7 @@ namespace glm
 	/// @addtogroup gtc_integer
 	/// @{
 
-	/// Returns the log2 of x for integer values. Usefull to compute mipmap count from the texture size.
+	/// Returns the log2 of x for integer values. Useful to compute mipmap count from the texture size.
 	/// @see gtc_integer
 	template<typename genIUType>
 	GLM_FUNC_DECL genIUType log2(genIUType x);

--- a/glm/gtc/matrix_inverse.hpp
+++ b/glm/gtc/matrix_inverse.hpp
@@ -31,7 +31,7 @@ namespace glm
 	/// Fast matrix inverse for affine matrix.
 	///
 	/// @param m Input matrix to invert.
-	/// @tparam genType Squared floating-point matrix: half, float or double. Inverse of matrix based of half-qualifier floating point value is highly innacurate.
+	/// @tparam genType Squared floating-point matrix: half, float or double. Inverse of matrix based of half-qualifier floating point value is highly inaccurate.
 	/// @see gtc_matrix_inverse
 	template<typename genType>
 	GLM_FUNC_DECL genType affineInverse(genType const& m);
@@ -39,7 +39,7 @@ namespace glm
 	/// Compute the inverse transpose of a matrix.
 	///
 	/// @param m Input matrix to invert transpose.
-	/// @tparam genType Squared floating-point matrix: half, float or double. Inverse of matrix based of half-qualifier floating point value is highly innacurate.
+	/// @tparam genType Squared floating-point matrix: half, float or double. Inverse of matrix based of half-qualifier floating point value is highly inaccurate.
 	/// @see gtc_matrix_inverse
 	template<typename genType>
 	GLM_FUNC_DECL genType inverseTranspose(genType const& m);

--- a/glm/gtc/random.hpp
+++ b/glm/gtc/random.hpp
@@ -52,25 +52,25 @@ namespace glm
 	template<typename genType>
 	GLM_FUNC_DECL genType gaussRand(genType Mean, genType Deviation);
 
-	/// Generate a random 2D vector which coordinates are regulary distributed on a circle of a given radius
+	/// Generate a random 2D vector which coordinates are regularly distributed on a circle of a given radius
 	///
 	/// @see gtc_random
 	template<typename T>
 	GLM_FUNC_DECL vec<2, T, defaultp> circularRand(T Radius);
 
-	/// Generate a random 3D vector which coordinates are regulary distributed on a sphere of a given radius
+	/// Generate a random 3D vector which coordinates are regularly distributed on a sphere of a given radius
 	///
 	/// @see gtc_random
 	template<typename T>
 	GLM_FUNC_DECL vec<3, T, defaultp> sphericalRand(T Radius);
 
-	/// Generate a random 2D vector which coordinates are regulary distributed within the area of a disk of a given radius
+	/// Generate a random 2D vector which coordinates are regularly distributed within the area of a disk of a given radius
 	///
 	/// @see gtc_random
 	template<typename T>
 	GLM_FUNC_DECL vec<2, T, defaultp> diskRand(T Radius);
 
-	/// Generate a random 3D vector which coordinates are regulary distributed within the volume of a ball of a given radius
+	/// Generate a random 3D vector which coordinates are regularly distributed within the volume of a ball of a given radius
 	///
 	/// @see gtc_random
 	template<typename T>

--- a/glm/gtc/ulp.hpp
+++ b/glm/gtc/ulp.hpp
@@ -26,6 +26,9 @@
 
 namespace glm
 {
+	/// @addtogroup gtc_ulp
+	/// @{
+
 	/// Return the next ULP value(s) after the input value(s).
 	///
 	/// @tparam genType A floating-point scalar type.

--- a/glm/gtx/associated_min_max.hpp
+++ b/glm/gtx/associated_min_max.hpp
@@ -9,7 +9,7 @@
 ///
 /// Include <glm/gtx/associated_min_max.hpp> to use the features of this extension.
 ///
-/// @brief Min and max functions that return associated values not the compared onces.
+/// @brief Min and max functions that return associated values not the compared ones.
 
 #pragma once
 

--- a/glm/gtx/easing.hpp
+++ b/glm/gtx/easing.hpp
@@ -9,7 +9,7 @@
 ///
 /// Include <glm/gtx/easing.hpp> to use the features of this extension.
 ///
-/// Easing functions for animations and transitons
+/// Easing functions for animations and transitions
 /// All functions take a parameter x in the range [0.0,1.0]
 ///
 /// Based on the AHEasing project of Warren Moore (https://github.com/warrenm/AHEasing)

--- a/glm/gtx/extended_min_max.hpp
+++ b/glm/gtx/extended_min_max.hpp
@@ -3,10 +3,10 @@
 ///
 /// @see core (dependence)
 ///
-/// @defgroup gtx_extended_min_max GLM_GTX_extented_min_max
+/// @defgroup gtx_extended_min_max GLM_GTX_extended_min_max
 /// @ingroup gtx
 ///
-/// Include <glm/gtx/extented_min_max.hpp> to use the features of this extension.
+/// Include <glm/gtx/extended_min_max.hpp> to use the features of this extension.
 ///
 /// Min and max functions for 3 to 4 parameters.
 
@@ -18,9 +18,9 @@
 
 #if GLM_MESSAGES == GLM_ENABLE && !defined(GLM_EXT_INCLUDED)
 #	ifndef GLM_ENABLE_EXPERIMENTAL
-#		pragma message("GLM: GLM_GTX_extented_min_max is an experimental extension and may change in the future. Use #define GLM_ENABLE_EXPERIMENTAL before including it, if you really want to use it.")
+#		pragma message("GLM: GLM_GTX_extended_min_max is an experimental extension and may change in the future. Use #define GLM_ENABLE_EXPERIMENTAL before including it, if you really want to use it.")
 #	else
-#		pragma message("GLM: GLM_GTX_extented_min_max extension included")
+#		pragma message("GLM: GLM_GTX_extended_min_max extension included")
 #	endif
 #endif
 

--- a/glm/gtx/handed_coordinate_space.hpp
+++ b/glm/gtx/handed_coordinate_space.hpp
@@ -6,7 +6,7 @@
 /// @defgroup gtx_handed_coordinate_space GLM_GTX_handed_coordinate_space
 /// @ingroup gtx
 ///
-/// Include <glm/gtx/handed_coordinate_system.hpp> to use the features of this extension.
+/// Include <glm/gtx/handed_coordinate_space.hpp> to use the features of this extension.
 ///
 /// To know if a set of three basis vectors defines a right or left-handed coordinate system.
 

--- a/glm/gtx/hash.inl
+++ b/glm/gtx/hash.inl
@@ -1,13 +1,4 @@
 /// @ref gtx_hash
-///
-/// @see core (dependence)
-///
-/// @defgroup gtx_hash GLM_GTX_hash
-/// @ingroup gtx
-///
-/// @brief Add std::hash support for glm types
-///
-/// <glm/gtx/hash.inl> need to be included to use the features of this extension.
 
 namespace glm {
 namespace detail

--- a/glm/gtx/normalize_dot.hpp
+++ b/glm/gtx/normalize_dot.hpp
@@ -7,7 +7,7 @@
 /// @defgroup gtx_normalize_dot GLM_GTX_normalize_dot
 /// @ingroup gtx
 ///
-/// Include <glm/gtx/normalized_dot.hpp> to use the features of this extension.
+/// Include <glm/gtx/normalize_dot.hpp> to use the features of this extension.
 ///
 /// Dot product of vectors that need to be normalize with a single square root.
 

--- a/glm/gtx/pca.hpp
+++ b/glm/gtx/pca.hpp
@@ -33,7 +33,7 @@
 /// 
 /// glm::sortEigenvalues(evals, evecs);
 /// 
-/// // ... now evecs[0] points in the direction (symmetric) of the largest spatial distribuion within ptData
+/// // ... now evecs[0] points in the direction (symmetric) of the largest spatial distribution within ptData
 /// ```
 
 #pragma once
@@ -57,11 +57,14 @@ namespace glm {
 
 	/// Compute a covariance matrix form an array of relative coordinates `v` (e.g., relative to the center of gravity of the object)
 	/// @param v Points to a memory holding `n` times vectors
+	/// @param n Number of points in v
 	template<length_t D, typename T, qualifier Q>
 	GLM_INLINE mat<D, D, T, Q> computeCovarianceMatrix(vec<D, T, Q> const* v, size_t n);
 
 	/// Compute a covariance matrix form an array of absolute coordinates `v` and a precomputed center of gravity `c`
 	/// @param v Points to a memory holding `n` times vectors
+	/// @param n Number of points in v
+	/// @param c Precomputed center of gravity
 	template<length_t D, typename T, qualifier Q>
 	GLM_INLINE mat<D, D, T, Q> computeCovarianceMatrix(vec<D, T, Q> const* v, size_t n, vec<D, T, Q> const& c);
 
@@ -78,9 +81,10 @@ namespace glm {
 	/// Assuming the provided covariance matrix `covarMat` is symmetric and real-valued, this function find the `D` Eigenvalues of the matrix, and also provides the corresponding Eigenvectors.
 	/// Note: the data in `outEigenvalues` and `outEigenvectors` are in matching order, i.e. `outEigenvector[i]` is the Eigenvector of the Eigenvalue `outEigenvalue[i]`.
 	/// This is a numeric implementation to find the Eigenvalues, using 'QL decomposition` (variant of QR decomposition: https://en.wikipedia.org/wiki/QR_decomposition).
-	/// @param covarMat A symmetric, real-valued covariance matrix, e.g. computed from `computeCovarianceMatrix`.
-	/// @param outEigenvalues Vector to receive the found eigenvalues
-	/// @param outEigenvectors Matrix to receive the found eigenvectors corresponding to the found eigenvalues, as column vectors
+	///
+	/// @param[in] covarMat A symmetric, real-valued covariance matrix, e.g. computed from computeCovarianceMatrix
+	/// @param[out] outEigenvalues Vector to receive the found eigenvalues
+	/// @param[out] outEigenvectors Matrix to receive the found eigenvectors corresponding to the found eigenvalues, as column vectors
 	/// @return The number of eigenvalues found, usually D if the precondition of the covariance matrix is met.
 	template<length_t D, typename T, qualifier Q>
 	GLM_FUNC_DECL unsigned int findEigenvaluesSymReal

--- a/glm/gtx/quaternion.hpp
+++ b/glm/gtx/quaternion.hpp
@@ -9,7 +9,7 @@
 ///
 /// Include <glm/gtx/quaternion.hpp> to use the features of this extension.
 ///
-/// Extented quaternion types and functions
+/// Extended quaternion types and functions
 
 #pragma once
 

--- a/glm/gtx/scalar_multiplication.hpp
+++ b/glm/gtx/scalar_multiplication.hpp
@@ -1,6 +1,9 @@
-/// @ref gtx
+/// @ref gtx_scalar_multiplication
 /// @file glm/gtx/scalar_multiplication.hpp
 /// @author Joshua Moerman
+///
+/// @defgroup gtx_scalar_multiplication GLM_GTX_scalar_multiplication
+/// @ingroup gtx
 ///
 /// Include <glm/gtx/scalar_multiplication.hpp> to use the features of this extension.
 ///
@@ -32,6 +35,9 @@
 
 namespace glm
 {
+	/// @addtogroup gtx_scalar_multiplication
+	/// @{
+
 	template<typename T, typename Vec>
 	using return_type_scalar_multiplication = typename std::enable_if<
 		!std::is_same<T, float>::value       // T may not be a float
@@ -72,4 +78,5 @@ GLM_IMPLEMENT_SCAL_MULT(mat4x3)
 GLM_IMPLEMENT_SCAL_MULT(mat4)
 
 #undef GLM_IMPLEMENT_SCAL_MULT
+	/// @}
 } // namespace glm

--- a/glm/gtx/vec_swizzle.hpp
+++ b/glm/gtx/vec_swizzle.hpp
@@ -23,6 +23,9 @@
 #endif
 
 namespace glm {
+	/// @addtogroup gtx_vec_swizzle
+	/// @{
+
 	// xx
 	template<typename T, qualifier Q>
 	GLM_INLINE glm::vec<2, T, Q> xx(const glm::vec<1, T, Q> &v) {
@@ -2779,4 +2782,5 @@ namespace glm {
 		return glm::vec<4, T, Q>(v.w, v.w, v.w, v.w);
 	}
 
-}
+	/// @}
+}//namespace glm

--- a/glm/gtx/vector_query.hpp
+++ b/glm/gtx/vector_query.hpp
@@ -8,7 +8,7 @@
 ///
 /// Include <glm/gtx/vector_query.hpp> to use the features of this extension.
 ///
-/// Query informations of vector types
+/// Query information of vector types
 
 #pragma once
 


### PR DESCRIPTION
Fixes some missing/incorrect doxygen commands/labels. `@mainpage` in `glm.hpp` was also moved above `@defgroup/@ingroup` to avoid potential Doxygen member-group confusion with the last `@defgroup` command.

Few additional notes:

1. The doxyfile and doxygen.css could be updated to 1.9
1. Doxygen will spew typedef conflicts between `gtc/matrix_integer.hpp` and `ext/matrix_*int*.hpp`
1. There is some inconsistent description ordering in `ext` when compared to `gtc` and `gtx`, e.g., "Include <*.hpp> to use the features of this extension" versus "Defines functions that generate common transformation matrices"
