### PR TITLE
GLM_EXT_matrix_common : add glm::mat<> support to glm::abs()

### DIFF
--- a/glm/ext/_matrix_vectorize.hpp
+++ b/glm/ext/_matrix_vectorize.hpp
@@ -1,0 +1,128 @@
+#pragma once
+
+namespace glm {
+
+	namespace detail {
+
+		template<template<length_t C, length_t R, typename T, qualifier Q> class mat, length_t C, length_t R, typename Ret, typename T, qualifier Q>
+		struct matrix_functor_1 {
+		};
+
+		template<template<length_t C, length_t R, typename T, qualifier Q> class mat, typename Ret, typename T, qualifier Q>
+		struct matrix_functor_1<mat, 2, 2, Ret, T, Q> {
+			GLM_FUNC_QUALIFIER GLM_CONSTEXPR static mat<2, 2, T, Q> call(Ret (*Func)(T x), mat<2, 2, T, Q> const &x) {
+				return mat<2, 2, Ret, Q>(
+					Func(x[0][0]), Func(x[0][1]),
+					Func(x[1][0]), Func(x[1][1])
+				);
+			}
+		};
+
+		template<template<length_t C, length_t R, typename T, qualifier Q> class mat, typename Ret, typename T, qualifier Q>
+		struct matrix_functor_1<mat, 2, 3, Ret, T, Q> {
+
+			GLM_FUNC_QUALIFIER GLM_CONSTEXPR static mat<2, 3, T, Q> call(Ret (*Func)(T x), mat<2, 3, T, Q> const &x) {
+				return mat<2, 3, Ret, Q>(
+					Func(x[0][0]), Func(x[0][1]),
+					Func(x[1][0]), Func(x[1][1]),
+					Func(x[2][0]), Func(x[2][1])
+				);
+			}
+
+		};
+
+		template<template<length_t C, length_t R, typename T, qualifier Q> class mat, typename Ret, typename T, qualifier Q>
+		struct matrix_functor_1<mat, 2, 4, Ret, T, Q> {
+
+			GLM_FUNC_QUALIFIER GLM_CONSTEXPR static mat<2, 4, T, Q> call(Ret (*Func)(T x), mat<2, 4, T, Q> const &x) {
+				return mat<2, 4, Ret, Q>(
+					Func(x[0][0]), Func(x[0][1]),
+					Func(x[1][0]), Func(x[1][1]),
+					Func(x[2][0]), Func(x[2][1]),
+					Func(x[3][0]), Func(x[3][1])
+				);
+			}
+
+		};
+
+		template<template<length_t C, length_t R, typename T, qualifier Q> class mat, typename Ret, typename T, qualifier Q>
+		struct matrix_functor_1<mat, 3, 2, Ret, T, Q> {
+
+			GLM_FUNC_QUALIFIER GLM_CONSTEXPR static mat<3, 2, T, Q> call(Ret (*Func)(T x), mat<3, 2, T, Q> const &x) {
+				return mat<3, 2, Ret, Q>(
+					Func(x[0][0]), Func(x[0][1]), Func(x[0][2]),
+					Func(x[1][0]), Func(x[1][1]), Func(x[1][2])
+				);
+			}
+
+		};
+
+		template<template<length_t C, length_t R, typename T, qualifier Q> class mat, typename Ret, typename T, qualifier Q>
+		struct matrix_functor_1<mat, 3, 3, Ret, T, Q> {
+
+			GLM_FUNC_QUALIFIER GLM_CONSTEXPR static mat<3, 3, T, Q> call(Ret (*Func)(T x), mat<3, 3, T, Q> const &x) {
+				return mat<3, 3, Ret, Q>(
+					Func(x[0][0]), Func(x[0][1]), Func(x[0][2]),
+					Func(x[1][0]), Func(x[1][1]), Func(x[1][2]),
+					Func(x[2][0]), Func(x[2][1]), Func(x[2][2])
+				);
+			}
+
+		};
+
+		template<template<length_t C, length_t R, typename T, qualifier Q> class mat, typename Ret, typename T, qualifier Q>
+		struct matrix_functor_1<mat, 3, 4, Ret, T, Q> {
+
+			GLM_FUNC_QUALIFIER GLM_CONSTEXPR static mat<3, 4, T, Q> call(Ret (*Func)(T x), mat<3, 4, T, Q> const &x) {
+				return mat<3, 4, Ret, Q>(
+					Func(x[0][0]), Func(x[0][1]), Func(x[0][2]),
+					Func(x[1][0]), Func(x[1][1]), Func(x[1][2]),
+					Func(x[2][0]), Func(x[2][1]), Func(x[2][2]),
+					Func(x[3][0]), Func(x[3][1]), Func(x[3][2])
+				);
+			}
+
+		};
+
+		template<template<length_t C, length_t R, typename T, qualifier Q> class mat, typename Ret, typename T, qualifier Q>
+		struct matrix_functor_1<mat, 4, 2, Ret, T, Q> {
+
+			GLM_FUNC_QUALIFIER GLM_CONSTEXPR static mat<4, 2, T, Q> call(Ret (*Func)(T x), mat<4, 2, T, Q> const &x) {
+				return mat<4, 2, Ret, Q>(
+					Func(x[0][0]), Func(x[0][1]), Func(x[0][2]), Func(x[0][3]),
+					Func(x[1][0]), Func(x[1][1]), Func(x[1][2]), Func(x[1][3])
+				);
+			}
+
+		};
+
+		template<template<length_t C, length_t R, typename T, qualifier Q> class mat, typename Ret, typename T, qualifier Q>
+		struct matrix_functor_1<mat, 4, 3, Ret, T, Q> {
+
+			GLM_FUNC_QUALIFIER GLM_CONSTEXPR static mat<4, 3, T, Q> call(Ret (*Func)(T x), mat<4, 3, T, Q> const &x) {
+				return mat<4, 3, Ret, Q>(
+					Func(x[0][0]), Func(x[0][1]), Func(x[0][2]), Func(x[0][3]),
+					Func(x[1][0]), Func(x[1][1]), Func(x[1][2]), Func(x[1][3]),
+					Func(x[2][0]), Func(x[2][1]), Func(x[2][2]), Func(x[2][3])
+				);
+			}
+
+		};
+
+		template<template<length_t C, length_t R, typename T, qualifier Q> class mat, typename Ret, typename T, qualifier Q>
+		struct matrix_functor_1<mat, 4, 4, Ret, T, Q> {
+
+			GLM_FUNC_QUALIFIER GLM_CONSTEXPR static mat<4, 4, T, Q> call(Ret (*Func)(T x), mat<4, 4, T, Q> const &x) {
+				return mat<4, 4, Ret, Q>(
+					Func(x[0][0]), Func(x[0][1]), Func(x[0][2]), Func(x[0][3]),
+					Func(x[1][0]), Func(x[1][1]), Func(x[1][2]), Func(x[1][3]),
+					Func(x[2][0]), Func(x[2][1]), Func(x[2][2]), Func(x[2][3]),
+					Func(x[3][0]), Func(x[3][1]), Func(x[3][2]), Func(x[3][3])
+				);
+			}
+
+		};
+
+	}
+
+}// namespace glm

--- a/glm/ext/matrix_common.hpp
+++ b/glm/ext/matrix_common.hpp
@@ -16,7 +16,7 @@
 #include "../detail/_fixes.hpp"
 
 #if GLM_MESSAGES == GLM_ENABLE && !defined(GLM_EXT_INCLUDED)
-#	pragma message("GLM: GLM_EXT_matrix_transform extension included")
+#	pragma message("GLM: GLM_EXT_matrix_common extension included")
 #endif
 
 namespace glm

--- a/glm/ext/matrix_common.hpp
+++ b/glm/ext/matrix_common.hpp
@@ -30,6 +30,9 @@ namespace glm
 	template<length_t C, length_t R, typename T, typename U, qualifier Q>
 	GLM_FUNC_DECL mat<C, R, T, Q> mix(mat<C, R, T, Q> const& x, mat<C, R, T, Q> const& y, U a);
 
+	template <length_t C, length_t R, typename T, qualifier Q>
+	GLM_FUNC_DECL GLM_CONSTEXPR mat<C, R, T, Q> abs(mat<C, R, T, Q> const& x);
+
 	/// @}
 }//namespace glm
 

--- a/glm/ext/matrix_common.inl
+++ b/glm/ext/matrix_common.inl
@@ -1,5 +1,7 @@
 #include "../matrix.hpp"
 
+#include "_matrix_vectorize.hpp"
+
 namespace glm
 {
 	template<length_t C, length_t R, typename T, typename U, qualifier Q>
@@ -13,4 +15,20 @@ namespace glm
 	{
 		return matrixCompMult(mat<C, R, U, Q>(x), static_cast<U>(1) - a) + matrixCompMult(mat<C, R, U, Q>(y), a);
 	}
+
+	template<length_t C, length_t R, typename T, qualifier Q, bool Aligned>
+	struct compute_abs_matrix
+	{
+		GLM_FUNC_QUALIFIER GLM_CONSTEXPR static mat<C, R, T, Q> call(mat<C, R, T, Q> const& x)
+		{
+			return detail::matrix_functor_1<mat, C, R, T, T, Q>::call(abs, x);
+		}
+	};
+
+	template<length_t C, length_t R, typename T, qualifier Q>
+	GLM_FUNC_DECL GLM_CONSTEXPR mat<C, R, T, Q> abs(mat<C, R, T, Q> const& x)
+	{
+		return compute_abs_matrix<C, R, T, Q, detail::is_aligned<Q>::value>::call(x);
+	}
+
 }//namespace glm

--- a/test/ext/ext_matrix_common.cpp
+++ b/test/ext/ext_matrix_common.cpp
@@ -43,11 +43,41 @@ static int test_mix()
 	return Error;
 }
 
+static int test_abs()
+{
+	int Error = 0;
+
+	{
+		glm::mat4 A(
+			3.0f, 1.0f, 5.2f, 4.9f,
+			1.4f, 0.5f, 9.3f, 3.7f,
+			6.8f, 8.4f, 4.3f, 3.9f,
+			5.6f, 7.2f, 1.1f, 4.4f
+		);
+		glm::mat4 B(
+			 1.0,-1.0, 1.0, 1.0,
+			-1.0, 1.0, 1.0,-1.0,
+			 1.0,-1.0,-1.0,-1.0,
+			-1.0,-1.0, 1.0, 1.0
+		);
+		glm::mat4 C = glm::matrixCompMult(A, B); // Not * to avoid matrix product.
+		glm::mat4 D = glm::abs(C);
+		glm::bvec4 const row1 = glm::equal(D[0], A[0]);
+		glm::bvec4 const row2 = glm::equal(D[1], A[1]);
+		glm::bvec4 const row3 = glm::equal(D[2], A[2]);
+		glm::bvec4 const row4 = glm::equal(D[3], A[3]);
+		Error += glm::all(glm::bvec4{glm::all(row1), glm::all(row2), glm::all(row3), glm::all(row4)}) ? 0 : 1;
+
+		return Error;
+	}
+}
+
 int main()
 {
 	int Error = 0;
 
 	Error += test_mix();
+	Error += test_abs();
 
 	return Error;
 }


### PR DESCRIPTION
## Main contributions

- The implementation of `glm::abs()` on matrix types.
- Fix typo in glm/ext/matrix_common.hpp : wrong extension name in `#pragma` message

## Description of the PR

I was doing some tests on a piece of code for work, and noticed that `glm::abs()` does not officially support the `glm::mat<>` type. Nor does it allow the function to exist in any extensions proposed by GLM, as far as I can tell.

As this is not officially supported by the GLSL specification, the new implementation lives  in the `glm/ext/matrix_common.hpp` file, which is part of the `GLM_EXT_matrix_common` extension. **I can make it a new unsupported extension, in the `GTX` category if necessary.**

The implementation mirrors that of `glm::abs()` for vector types. As far as I can tell, this allows compilers to perform optimization/vectorization of the resulting code if necessary.

Along with this implementation, there is also an updated test file for the `GLM_EXT_matrix_common` extension which can be found in `test/ext/ext_matrix_common.cpp`.

Also, fixed a small typo in the `#pragma` message of the `glm/ext/matrix_common.hpp` file : it is part of the `GLM_EXT_matrix_common` extension, but was mentioning the `GLM_EXT_matrix_transform` extension.

## Testing

All tests relating to the matrix extensions are passing, there's only one that fails on my machine : the `test-core_func_integer` (which is also broken on the current master : cc98465e3508535ba8c7f6208df934c156a018dc)

