### PR TITLE
build: various install improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,8 +33,7 @@ CMakeFiles
 cmake_install.cmake
 install_manifest.txt
 *.cmake
-!glmConfig.cmake
-!glmConfig-version.cmake
+!/cmake/JoinPaths.cmake
 # ^ May need to add future .cmake files as exceptions
 
 # Test logs

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,14 @@ if(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_CURRENT_SOURCE_DIR})
 	write_basic_package_version_file("glmConfigVersion.cmake" COMPATIBILITY AnyNewerVersion)
 	install(FILES ${CMAKE_CURRENT_BINARY_DIR}/glmConfigVersion.cmake DESTINATION ${CMAKE_INSTALL_DATADIR}/cmake/glm)
 
+	include(cmake/JoinPaths.cmake) # can be replaced by cmake_path(APPEND) in CMake 3.20
+	join_paths(PKGCONFIG_INCLUDEDIR "\${prefix}" "${CMAKE_INSTALL_INCLUDEDIR}")
+	configure_file("cmake/glm.pc.in" "glm.pc" @ONLY)
+	install(
+		FILES "${CMAKE_CURRENT_BINARY_DIR}/glm.pc"
+		DESTINATION "${CMAKE_INSTALL_DATADIR}/pkgconfig"
+	)
+
 	include(CTest)
 	if(BUILD_TESTING)
 		add_subdirectory(test)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,17 +16,18 @@ set(GLM_VERSION ${GLM_VERSION_MAJOR}.${GLM_VERSION_MINOR}.${GLM_VERSION_PATCH}.$
 project(glm VERSION ${GLM_VERSION} LANGUAGES CXX)
 message(STATUS "GLM: Version " ${GLM_VERSION})
 
+include(GNUInstallDirs)
+
 add_subdirectory(glm)
 add_library(glm::glm ALIAS glm)
 
 if(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_CURRENT_SOURCE_DIR})
 
-	include(CPack)
 	install(DIRECTORY glm DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} PATTERN "CMakeLists.txt" EXCLUDE)
-	install(EXPORT glm FILE glmConfig.cmake DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/glm NAMESPACE glm::)
+	install(EXPORT glm FILE glmConfig.cmake DESTINATION ${CMAKE_INSTALL_DATADIR}/cmake/glm NAMESPACE glm::)
 	include(CMakePackageConfigHelpers)
 	write_basic_package_version_file("glmConfigVersion.cmake" COMPATIBILITY AnyNewerVersion)
-	install(FILES ${CMAKE_CURRENT_BINARY_DIR}/glmConfigVersion.cmake DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/glm)
+	install(FILES ${CMAKE_CURRENT_BINARY_DIR}/glmConfigVersion.cmake DESTINATION ${CMAKE_INSTALL_DATADIR}/cmake/glm)
 
 	include(CTest)
 	if(BUILD_TESTING)

--- a/cmake/JoinPaths.cmake
+++ b/cmake/JoinPaths.cmake
@@ -1,0 +1,23 @@
+# This module provides function for joining paths
+# known from most languages
+#
+# SPDX-License-Identifier: (MIT OR CC0-1.0)
+# Copyright 2020 Jan Tojnar
+# https://github.com/jtojnar/cmake-snips
+#
+# Modelled after Python’s os.path.join
+# https://docs.python.org/3.7/library/os.path.html#os.path.join
+# Windows not supported
+function(join_paths joined_path first_path_segment)
+    set(temp_path "${first_path_segment}")
+    foreach(current_segment IN LISTS ARGN)
+        if(NOT ("${current_segment}" STREQUAL ""))
+            if(IS_ABSOLUTE "${current_segment}")
+                set(temp_path "${current_segment}")
+            else()
+                set(temp_path "${temp_path}/${current_segment}")
+            endif()
+        endif()
+    endforeach()
+    set(${joined_path} "${temp_path}" PARENT_SCOPE)
+endfunction()

--- a/cmake/glm.pc.in
+++ b/cmake/glm.pc.in
@@ -1,0 +1,8 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+includedir=@PKGCONFIG_INCLUDEDIR@
+
+Name: GLM
+Description: OpenGL Mathematics
+URL: https://glm.g-truc.net
+Version: @GLM_VERSION@
+Cflags: -I${includedir}

--- a/glm/CMakeLists.txt
+++ b/glm/CMakeLists.txt
@@ -44,8 +44,6 @@ source_group("SIMD Files" FILES ${SIMD_HEADER})
 
 add_library(glm INTERFACE)
 
-include(GNUInstallDirs)
-
 target_include_directories(glm INTERFACE
 	$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
 	$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>


### PR DESCRIPTION
With this PR I've made two main improvements:

- Moved install location of the .cmake files from lib/ to share/
- (re)added a pkg-config file

Also, please don't squash this PR on merge, otherwise all the information in the commits will be lost. Thanks :)

Here are the commit messages:

1.  As GLM is a header-only library, its cmake config files should be installed to `share/` (GNUInstallDirs' DATADIR), as `share/` is the canonical directory where architecture-independent files should be stored, while `lib/` is for architecture-dependent stuff (see the [FHS]).
  
    Apart from being technically correct, installing to `share/` can help with cross-compiling, for example in Debian-based environments. If you're interested, I'd suggest reading this [thread].
  
    I've also made a few minor fixes, like moving GNUInstallDirs in the main CMakeLists.txt so that it is accessible project-wide and removed the unneeded include(CPack) directive.
  
    [FHS]: https://refspecs.linuxfoundation.org/FHS_3.0/fhs-3.0.html#usrshareArchitectureindependentData
    [thread]: https://github.com/marzer/tomlplusplus/pull/165 (comment)

2.  GLM used to ship a pkg-config file since version 0.9.8.0, added in commit https://github.com/Tachi107/glm/commit/0e018a5262b881e3b49b8a49ae56292ab9a7bb10, but it was removed together with the install target in commit https://github.com/Tachi107/glm/commit/5f352ecce21bb1ab37fa56fac0f383c779b351a3. While the install target was re-added in commit https://github.com/Tachi107/glm/commit/631faffab37bd14f0ac8cec74711d670538a2702, the .pc file has been left behind.
  
    This patch re-adds it, and, compared to the old one, this pkg-config file also accounts for the cases where GLM is installed in an include directory that is not a subdirectory of the install prefix (i.e. it does the right thing™ when `CMAKE_INSTALL_INCLUDEDIR` is an absolute path).
  
    To read why the JoinPaths module is needed, take a look at <https://github.com/jtojnar/cmake-snips#concatenating-paths-when-building-pkg-config-files>