### PR TITLE
Make vec4, mat4x3 and mat4x4 binary operators and contructors for scalars consistent with other types

### DIFF
--- a/glm/detail/type_mat4x3.hpp
+++ b/glm/detail/type_mat4x3.hpp
@@ -37,7 +37,7 @@ namespace glm
 		template<qualifier P>
 		GLM_FUNC_DECL GLM_CONSTEXPR mat(mat<4, 3, T, P> const& m);
 
-		GLM_FUNC_DECL explicit GLM_CONSTEXPR mat(T const& x);
+		GLM_FUNC_DECL explicit GLM_CONSTEXPR mat(T s);
 		GLM_FUNC_DECL GLM_CONSTEXPR mat(
 			T const& x0, T const& y0, T const& z0,
 			T const& x1, T const& y1, T const& z1,
@@ -119,22 +119,22 @@ namespace glm
 	// -- Binary operators --
 
 	template<typename T, qualifier Q>
-	GLM_FUNC_DECL mat<4, 3, T, Q> operator+(mat<4, 3, T, Q> const& m, T const& s);
+	GLM_FUNC_DECL mat<4, 3, T, Q> operator+(mat<4, 3, T, Q> const& m, T scalar);
 
 	template<typename T, qualifier Q>
 	GLM_FUNC_DECL mat<4, 3, T, Q> operator+(mat<4, 3, T, Q> const& m1, mat<4, 3, T, Q> const& m2);
 
 	template<typename T, qualifier Q>
-	GLM_FUNC_DECL mat<4, 3, T, Q> operator-(mat<4, 3, T, Q> const& m, T const& s);
+	GLM_FUNC_DECL mat<4, 3, T, Q> operator-(mat<4, 3, T, Q> const& m, T scalar);
 
 	template<typename T, qualifier Q>
 	GLM_FUNC_DECL mat<4, 3, T, Q> operator-(mat<4, 3, T, Q> const& m1, mat<4, 3, T, Q> const& m2);
 
 	template<typename T, qualifier Q>
-	GLM_FUNC_DECL mat<4, 3, T, Q> operator*(mat<4, 3, T, Q> const& m, T const& s);
+	GLM_FUNC_DECL mat<4, 3, T, Q> operator*(mat<4, 3, T, Q> const& m, T scalar);
 
 	template<typename T, qualifier Q>
-	GLM_FUNC_DECL mat<4, 3, T, Q> operator*(T const& s, mat<4, 3, T, Q> const& m);
+	GLM_FUNC_DECL mat<4, 3, T, Q> operator*(T scalar, mat<4, 3, T, Q> const& m);
 
 	template<typename T, qualifier Q>
 	GLM_FUNC_DECL typename mat<4, 3, T, Q>::col_type operator*(mat<4, 3, T, Q> const& m, typename mat<4, 3, T, Q>::row_type const& v);
@@ -152,10 +152,10 @@ namespace glm
 	GLM_FUNC_DECL mat<4, 3, T, Q> operator*(mat<4, 3, T, Q> const& m1, mat<4, 4, T, Q> const& m2);
 
 	template<typename T, qualifier Q>
-	GLM_FUNC_DECL mat<4, 3, T, Q> operator/(mat<4, 3, T, Q> const& m, T const& s);
+	GLM_FUNC_DECL mat<4, 3, T, Q> operator/(mat<4, 3, T, Q> const& m, T scalar);
 
 	template<typename T, qualifier Q>
-	GLM_FUNC_DECL mat<4, 3, T, Q> operator/(T const& s, mat<4, 3, T, Q> const& m);
+	GLM_FUNC_DECL mat<4, 3, T, Q> operator/(T scalar, mat<4, 3, T, Q> const& m);
 
 	// -- Boolean operators --
 

--- a/glm/detail/type_mat4x3.inl
+++ b/glm/detail/type_mat4x3.inl
@@ -34,7 +34,7 @@ namespace glm
 	}
 
 	template<typename T, qualifier Q>
-	GLM_FUNC_QUALIFIER GLM_CONSTEXPR mat<4, 3, T, Q>::mat(T const& s)
+	GLM_FUNC_QUALIFIER GLM_CONSTEXPR mat<4, 3, T, Q>::mat(T s)
 #		if GLM_HAS_INITIALIZER_LISTS
 			: value{col_type(s, 0, 0), col_type(0, s, 0), col_type(0, 0, s), col_type(0, 0, 0)}
 #		endif
@@ -406,13 +406,13 @@ namespace glm
 	// -- Binary arithmetic operators --
 
 	template<typename T, qualifier Q>
-	GLM_FUNC_QUALIFIER mat<4, 3, T, Q> operator+(mat<4, 3, T, Q> const& m, T const& s)
+	GLM_FUNC_QUALIFIER mat<4, 3, T, Q> operator+(mat<4, 3, T, Q> const& m, T scalar)
 	{
 		return mat<4, 3, T, Q>(
-			m[0] + s,
-			m[1] + s,
-			m[2] + s,
-			m[3] + s);
+			m[0] + scalar,
+			m[1] + scalar,
+			m[2] + scalar,
+			m[3] + scalar);
 	}
 
 	template<typename T, qualifier Q>
@@ -426,13 +426,13 @@ namespace glm
 	}
 
 	template<typename T, qualifier Q>
-	GLM_FUNC_QUALIFIER mat<4, 3, T, Q> operator-(mat<4, 3, T, Q> const& m, T const& s)
+	GLM_FUNC_QUALIFIER mat<4, 3, T, Q> operator-(mat<4, 3, T, Q> const& m, T scalar)
 	{
 		return mat<4, 3, T, Q>(
-			m[0] - s,
-			m[1] - s,
-			m[2] - s,
-			m[3] - s);
+			m[0] - scalar,
+			m[1] - scalar,
+			m[2] - scalar,
+			m[3] - scalar);
 	}
 
 	template<typename T, qualifier Q>
@@ -446,23 +446,23 @@ namespace glm
 	}
 
 	template<typename T, qualifier Q>
-	GLM_FUNC_QUALIFIER mat<4, 3, T, Q> operator*(mat<4, 3, T, Q> const& m, T const& s)
+	GLM_FUNC_QUALIFIER mat<4, 3, T, Q> operator*(mat<4, 3, T, Q> const& m, T scalar)
 	{
 		return mat<4, 3, T, Q>(
-			m[0] * s,
-			m[1] * s,
-			m[2] * s,
-			m[3] * s);
+			m[0] * scalar,
+			m[1] * scalar,
+			m[2] * scalar,
+			m[3] * scalar);
 	}
 
 	template<typename T, qualifier Q>
-	GLM_FUNC_QUALIFIER mat<4, 3, T, Q> operator*(T const& s, mat<4, 3, T, Q> const& m)
+	GLM_FUNC_QUALIFIER mat<4, 3, T, Q> operator*(T scalar, mat<4, 3, T, Q> const& m)
 	{
 		return mat<4, 3, T, Q>(
-			m[0] * s,
-			m[1] * s,
-			m[2] * s,
-			m[3] * s);
+			m[0] * scalar,
+			m[1] * scalar,
+			m[2] * scalar,
+			m[3] * scalar);
 	}
 
 	template<typename T, qualifier Q>
@@ -563,23 +563,23 @@ namespace glm
 	}
 
 	template<typename T, qualifier Q>
-	GLM_FUNC_QUALIFIER mat<4, 3, T, Q> operator/(mat<4, 3, T, Q> const& m, T const& s)
+	GLM_FUNC_QUALIFIER mat<4, 3, T, Q> operator/(mat<4, 3, T, Q> const& m, T scalar)
 	{
 		return mat<4, 3, T, Q>(
-			m[0] / s,
-			m[1] / s,
-			m[2] / s,
-			m[3] / s);
+			m[0] / scalar,
+			m[1] / scalar,
+			m[2] / scalar,
+			m[3] / scalar);
 	}
 
 	template<typename T, qualifier Q>
-	GLM_FUNC_QUALIFIER mat<4, 3, T, Q> operator/(T const& s, mat<4, 3, T, Q> const& m)
+	GLM_FUNC_QUALIFIER mat<4, 3, T, Q> operator/(T scalar, mat<4, 3, T, Q> const& m)
 	{
 		return mat<4, 3, T, Q>(
-			s / m[0],
-			s / m[1],
-			s / m[2],
-			s / m[3]);
+			scalar / m[0],
+			scalar / m[1],
+			scalar / m[2],
+			scalar / m[3]);
 	}
 
 	// -- Boolean operators --

--- a/glm/detail/type_mat4x4.hpp
+++ b/glm/detail/type_mat4x4.hpp
@@ -36,7 +36,7 @@ namespace glm
 		template<qualifier P>
 		GLM_FUNC_DECL GLM_CONSTEXPR mat(mat<4, 4, T, P> const& m);
 
-		GLM_FUNC_DECL explicit GLM_CONSTEXPR mat(T const& x);
+		GLM_FUNC_DECL explicit GLM_CONSTEXPR mat(T s);
 		GLM_FUNC_DECL GLM_CONSTEXPR mat(
 			T const& x0, T const& y0, T const& z0, T const& w0,
 			T const& x1, T const& y1, T const& z1, T const& w1,
@@ -122,28 +122,28 @@ namespace glm
 	// -- Binary operators --
 
 	template<typename T, qualifier Q>
-	GLM_FUNC_DECL mat<4, 4, T, Q> operator+(mat<4, 4, T, Q> const& m, T const& s);
+	GLM_FUNC_DECL mat<4, 4, T, Q> operator+(mat<4, 4, T, Q> const& m, T scalar);
 
 	template<typename T, qualifier Q>
-	GLM_FUNC_DECL mat<4, 4, T, Q> operator+(T const& s, mat<4, 4, T, Q> const& m);
+	GLM_FUNC_DECL mat<4, 4, T, Q> operator+(T scalar, mat<4, 4, T, Q> const& m);
 
 	template<typename T, qualifier Q>
 	GLM_FUNC_DECL mat<4, 4, T, Q> operator+(mat<4, 4, T, Q> const& m1, mat<4, 4, T, Q> const& m2);
 
 	template<typename T, qualifier Q>
-	GLM_FUNC_DECL mat<4, 4, T, Q> operator-(mat<4, 4, T, Q> const& m, T const& s);
+	GLM_FUNC_DECL mat<4, 4, T, Q> operator-(mat<4, 4, T, Q> const& m, T scalar);
 
 	template<typename T, qualifier Q>
-	GLM_FUNC_DECL mat<4, 4, T, Q> operator-(T const& s, mat<4, 4, T, Q> const& m);
+	GLM_FUNC_DECL mat<4, 4, T, Q> operator-(T scalar, mat<4, 4, T, Q> const& m);
 
 	template<typename T, qualifier Q>
 	GLM_FUNC_DECL mat<4, 4, T, Q> operator-(mat<4, 4, T, Q> const& m1,	mat<4, 4, T, Q> const& m2);
 
 	template<typename T, qualifier Q>
-	GLM_FUNC_DECL mat<4, 4, T, Q> operator*(mat<4, 4, T, Q> const& m, T const& s);
+	GLM_FUNC_DECL mat<4, 4, T, Q> operator*(mat<4, 4, T, Q> const& m, T scalar);
 
 	template<typename T, qualifier Q>
-	GLM_FUNC_DECL mat<4, 4, T, Q> operator*(T const& s, mat<4, 4, T, Q> const& m);
+	GLM_FUNC_DECL mat<4, 4, T, Q> operator*(T scalar, mat<4, 4, T, Q> const& m);
 
 	template<typename T, qualifier Q>
 	GLM_FUNC_DECL typename mat<4, 4, T, Q>::col_type operator*(mat<4, 4, T, Q> const& m, typename mat<4, 4, T, Q>::row_type const& v);
@@ -161,10 +161,10 @@ namespace glm
 	GLM_FUNC_DECL mat<4, 4, T, Q> operator*(mat<4, 4, T, Q> const& m1, mat<4, 4, T, Q> const& m2);
 
 	template<typename T, qualifier Q>
-	GLM_FUNC_DECL mat<4, 4, T, Q> operator/(mat<4, 4, T, Q> const& m, T const& s);
+	GLM_FUNC_DECL mat<4, 4, T, Q> operator/(mat<4, 4, T, Q> const& m, T scalar);
 
 	template<typename T, qualifier Q>
-	GLM_FUNC_DECL mat<4, 4, T, Q> operator/(T const& s, mat<4, 4, T, Q> const& m);
+	GLM_FUNC_DECL mat<4, 4, T, Q> operator/(T scalar, mat<4, 4, T, Q> const& m);
 
 	template<typename T, qualifier Q>
 	GLM_FUNC_DECL typename mat<4, 4, T, Q>::col_type operator/(mat<4, 4, T, Q> const& m, typename mat<4, 4, T, Q>::row_type const& v);

--- a/glm/detail/type_mat4x4.inl
+++ b/glm/detail/type_mat4x4.inl
@@ -36,7 +36,7 @@ namespace glm
 	}
 
 	template<typename T, qualifier Q>
-	GLM_FUNC_QUALIFIER GLM_CONSTEXPR mat<4, 4, T, Q>::mat(T const& s)
+	GLM_FUNC_QUALIFIER GLM_CONSTEXPR mat<4, 4, T, Q>::mat(T s)
 #		if GLM_HAS_INITIALIZER_LISTS
 			: value{col_type(s, 0, 0, 0), col_type(0, s, 0, 0), col_type(0, 0, s, 0), col_type(0, 0, 0, s)}
 #		endif
@@ -453,23 +453,23 @@ namespace glm
 	// -- Binary arithmetic operators --
 
 	template<typename T, qualifier Q>
-	GLM_FUNC_QUALIFIER mat<4, 4, T, Q> operator+(mat<4, 4, T, Q> const& m, T const& s)
+	GLM_FUNC_QUALIFIER mat<4, 4, T, Q> operator+(mat<4, 4, T, Q> const& m, T scalar)
 	{
 		return mat<4, 4, T, Q>(
-			m[0] + s,
-			m[1] + s,
-			m[2] + s,
-			m[3] + s);
+			m[0] + scalar,
+			m[1] + scalar,
+			m[2] + scalar,
+			m[3] + scalar);
 	}
 
 	template<typename T, qualifier Q>
-	GLM_FUNC_QUALIFIER mat<4, 4, T, Q> operator+(T const& s, mat<4, 4, T, Q> const& m)
+	GLM_FUNC_QUALIFIER mat<4, 4, T, Q> operator+(T scalar, mat<4, 4, T, Q> const& m)
 	{
 		return mat<4, 4, T, Q>(
-			m[0] + s,
-			m[1] + s,
-			m[2] + s,
-			m[3] + s);
+			m[0] + scalar,
+			m[1] + scalar,
+			m[2] + scalar,
+			m[3] + scalar);
 	}
 
 	template<typename T, qualifier Q>
@@ -483,23 +483,23 @@ namespace glm
 	}
 
 	template<typename T, qualifier Q>
-	GLM_FUNC_QUALIFIER mat<4, 4, T, Q> operator-(mat<4, 4, T, Q> const& m, T const& s)
+	GLM_FUNC_QUALIFIER mat<4, 4, T, Q> operator-(mat<4, 4, T, Q> const& m, T scalar)
 	{
 		return mat<4, 4, T, Q>(
-			m[0] - s,
-			m[1] - s,
-			m[2] - s,
-			m[3] - s);
+			m[0] - scalar,
+			m[1] - scalar,
+			m[2] - scalar,
+			m[3] - scalar);
 	}
 
 	template<typename T, qualifier Q>
-	GLM_FUNC_QUALIFIER mat<4, 4, T, Q> operator-(T const& s, mat<4, 4, T, Q> const& m)
+	GLM_FUNC_QUALIFIER mat<4, 4, T, Q> operator-(T scalar, mat<4, 4, T, Q> const& m)
 	{
 		return mat<4, 4, T, Q>(
-			s - m[0],
-			s - m[1],
-			s - m[2],
-			s - m[3]);
+			scalar - m[0],
+			scalar - m[1],
+			scalar - m[2],
+			scalar - m[3]);
 	}
 
 	template<typename T, qualifier Q>
@@ -513,23 +513,23 @@ namespace glm
 	}
 
 	template<typename T, qualifier Q>
-	GLM_FUNC_QUALIFIER mat<4, 4, T, Q> operator*(mat<4, 4, T, Q> const& m, T const  & s)
+	GLM_FUNC_QUALIFIER mat<4, 4, T, Q> operator*(mat<4, 4, T, Q> const& m, T scalar)
 	{
 		return mat<4, 4, T, Q>(
-			m[0] * s,
-			m[1] * s,
-			m[2] * s,
-			m[3] * s);
+			m[0] * scalar,
+			m[1] * scalar,
+			m[2] * scalar,
+			m[3] * scalar);
 	}
 
 	template<typename T, qualifier Q>
-	GLM_FUNC_QUALIFIER mat<4, 4, T, Q> operator*(T const& s, mat<4, 4, T, Q> const& m)
+	GLM_FUNC_QUALIFIER mat<4, 4, T, Q> operator*(T scalar, mat<4, 4, T, Q> const& m)
 	{
 		return mat<4, 4, T, Q>(
-			m[0] * s,
-			m[1] * s,
-			m[2] * s,
-			m[3] * s);
+			m[0] * scalar,
+			m[1] * scalar,
+			m[2] * scalar,
+			m[3] * scalar);
 	}
 
 	template<typename T, qualifier Q>
@@ -648,23 +648,23 @@ namespace glm
 	}
 
 	template<typename T, qualifier Q>
-	GLM_FUNC_QUALIFIER mat<4, 4, T, Q> operator/(mat<4, 4, T, Q> const& m, T const& s)
+	GLM_FUNC_QUALIFIER mat<4, 4, T, Q> operator/(mat<4, 4, T, Q> const& m, T scalar)
 	{
 		return mat<4, 4, T, Q>(
-			m[0] / s,
-			m[1] / s,
-			m[2] / s,
-			m[3] / s);
+			m[0] / scalar,
+			m[1] / scalar,
+			m[2] / scalar,
+			m[3] / scalar);
 	}
 
 	template<typename T, qualifier Q>
-	GLM_FUNC_QUALIFIER mat<4, 4, T, Q> operator/(T const& s,	mat<4, 4, T, Q> const& m)
+	GLM_FUNC_QUALIFIER mat<4, 4, T, Q> operator/(T scalar,	mat<4, 4, T, Q> const& m)
 	{
 		return mat<4, 4, T, Q>(
-			s / m[0],
-			s / m[1],
-			s / m[2],
-			s / m[3]);
+			scalar / m[0],
+			scalar / m[1],
+			scalar / m[2],
+			scalar / m[3]);
 	}
 
 	template<typename T, qualifier Q>

--- a/glm/detail/type_vec4.hpp
+++ b/glm/detail/type_vec4.hpp
@@ -336,7 +336,7 @@ namespace glm
 	// -- Binary operators --
 
 	template<typename T, qualifier Q>
-	GLM_FUNC_DECL GLM_CONSTEXPR vec<4, T, Q> operator+(vec<4, T, Q> const& v, T const & scalar);
+	GLM_FUNC_DECL GLM_CONSTEXPR vec<4, T, Q> operator+(vec<4, T, Q> const& v, T scalar);
 
 	template<typename T, qualifier Q>
 	GLM_FUNC_DECL GLM_CONSTEXPR vec<4, T, Q> operator+(vec<4, T, Q> const& v1, vec<1, T, Q> const& v2);
@@ -351,7 +351,7 @@ namespace glm
 	GLM_FUNC_DECL GLM_CONSTEXPR vec<4, T, Q> operator+(vec<4, T, Q> const& v1, vec<4, T, Q> const& v2);
 
 	template<typename T, qualifier Q>
-	GLM_FUNC_DECL GLM_CONSTEXPR vec<4, T, Q> operator-(vec<4, T, Q> const& v, T const & scalar);
+	GLM_FUNC_DECL GLM_CONSTEXPR vec<4, T, Q> operator-(vec<4, T, Q> const& v, T scalar);
 
 	template<typename T, qualifier Q>
 	GLM_FUNC_DECL GLM_CONSTEXPR vec<4, T, Q> operator-(vec<4, T, Q> const& v1, vec<1, T, Q> const& v2);
@@ -366,7 +366,7 @@ namespace glm
 	GLM_FUNC_DECL GLM_CONSTEXPR vec<4, T, Q> operator-(vec<4, T, Q> const& v1, vec<4, T, Q> const& v2);
 
 	template<typename T, qualifier Q>
-	GLM_FUNC_DECL GLM_CONSTEXPR vec<4, T, Q> operator*(vec<4, T, Q> const& v, T const & scalar);
+	GLM_FUNC_DECL GLM_CONSTEXPR vec<4, T, Q> operator*(vec<4, T, Q> const& v, T scalar);
 
 	template<typename T, qualifier Q>
 	GLM_FUNC_DECL GLM_CONSTEXPR vec<4, T, Q> operator*(vec<4, T, Q> const& v1, vec<1, T, Q> const& v2);
@@ -381,7 +381,7 @@ namespace glm
 	GLM_FUNC_DECL GLM_CONSTEXPR vec<4, T, Q> operator*(vec<4, T, Q> const& v1, vec<4, T, Q> const& v2);
 
 	template<typename T, qualifier Q>
-	GLM_FUNC_DECL GLM_CONSTEXPR vec<4, T, Q> operator/(vec<4, T, Q> const& v, T const & scalar);
+	GLM_FUNC_DECL GLM_CONSTEXPR vec<4, T, Q> operator/(vec<4, T, Q> const& v, T scalar);
 
 	template<typename T, qualifier Q>
 	GLM_FUNC_DECL GLM_CONSTEXPR vec<4, T, Q> operator/(vec<4, T, Q> const& v1, vec<1, T, Q> const& v2);

--- a/glm/detail/type_vec4.inl
+++ b/glm/detail/type_vec4.inl
@@ -803,7 +803,7 @@ namespace detail
 	// -- Binary arithmetic operators --
 
 	template<typename T, qualifier Q>
-	GLM_FUNC_QUALIFIER GLM_CONSTEXPR vec<4, T, Q> operator+(vec<4, T, Q> const& v, T const & scalar)
+	GLM_FUNC_QUALIFIER GLM_CONSTEXPR vec<4, T, Q> operator+(vec<4, T, Q> const& v, T scalar)
 	{
 		return vec<4, T, Q>(v) += scalar;
 	}
@@ -833,7 +833,7 @@ namespace detail
 	}
 
 	template<typename T, qualifier Q>
-	GLM_FUNC_QUALIFIER GLM_CONSTEXPR vec<4, T, Q> operator-(vec<4, T, Q> const& v, T const & scalar)
+	GLM_FUNC_QUALIFIER GLM_CONSTEXPR vec<4, T, Q> operator-(vec<4, T, Q> const& v, T scalar)
 	{
 		return vec<4, T, Q>(v) -= scalar;
 	}
@@ -863,7 +863,7 @@ namespace detail
 	}
 
 	template<typename T, qualifier Q>
-	GLM_FUNC_QUALIFIER GLM_CONSTEXPR vec<4, T, Q> operator*(vec<4, T, Q> const& v, T const & scalar)
+	GLM_FUNC_QUALIFIER GLM_CONSTEXPR vec<4, T, Q> operator*(vec<4, T, Q> const& v, T scalar)
 	{
 		return vec<4, T, Q>(v) *= scalar;
 	}
@@ -893,7 +893,7 @@ namespace detail
 	}
 
 	template<typename T, qualifier Q>
-	GLM_FUNC_QUALIFIER GLM_CONSTEXPR vec<4, T, Q> operator/(vec<4, T, Q> const& v, T const & scalar)
+	GLM_FUNC_QUALIFIER GLM_CONSTEXPR vec<4, T, Q> operator/(vec<4, T, Q> const& v, T scalar)
 	{
 		return vec<4, T, Q>(v) /= scalar;
 	}


### PR DESCRIPTION
Binary operators with a scalar type generally use `T scalar` in the signature:

```
$ git grep 'operator.*\*.*scalar' "glm/**.hpp"
glm/detail/type_mat2x2.hpp:     GLM_FUNC_DECL mat<2, 2, T, Q> operator*(mat<2, 2, T, Q> const& m, T scalar);
glm/detail/type_mat2x2.hpp:     GLM_FUNC_DECL mat<2, 2, T, Q> operator*(T scalar, mat<2, 2, T, Q> const& m);
glm/detail/type_mat2x3.hpp:     GLM_FUNC_DECL mat<2, 3, T, Q> operator*(mat<2, 3, T, Q> const& m, T scalar);
glm/detail/type_mat2x3.hpp:     GLM_FUNC_DECL mat<2, 3, T, Q> operator*(T scalar, mat<2, 3, T, Q> const& m);
glm/detail/type_mat2x4.hpp:     GLM_FUNC_DECL mat<2, 4, T, Q> operator*(mat<2, 4, T, Q> const& m, T scalar);
glm/detail/type_mat2x4.hpp:     GLM_FUNC_DECL mat<2, 4, T, Q> operator*(T scalar, mat<2, 4, T, Q> const& m);
glm/detail/type_mat3x2.hpp:     GLM_FUNC_DECL mat<3, 2, T, Q> operator*(mat<3, 2, T, Q> const& m, T scalar);
glm/detail/type_mat3x2.hpp:     GLM_FUNC_DECL mat<3, 2, T, Q> operator*(T scalar, mat<3, 2, T, Q> const& m);
glm/detail/type_mat3x3.hpp:     GLM_FUNC_DECL mat<3, 3, T, Q> operator*(mat<3, 3, T, Q> const& m, T scalar);
glm/detail/type_mat3x3.hpp:     GLM_FUNC_DECL mat<3, 3, T, Q> operator*(T scalar, mat<3, 3, T, Q> const& m);
glm/detail/type_mat3x4.hpp:     GLM_FUNC_DECL mat<3, 4, T, Q> operator*(mat<3, 4, T, Q> const& m, T scalar);
glm/detail/type_mat3x4.hpp:     GLM_FUNC_DECL mat<3, 4, T, Q> operator*(T scalar, mat<3, 4, T, Q> const& m);
glm/detail/type_mat4x2.hpp:     GLM_FUNC_DECL mat<4, 2, T, Q> operator*(mat<4, 2, T, Q> const& m, T scalar);
glm/detail/type_mat4x2.hpp:     GLM_FUNC_DECL mat<4, 2, T, Q> operator*(T scalar, mat<4, 2, T, Q> const& m);
glm/detail/type_vec1.hpp:               GLM_FUNC_DECL GLM_CONSTEXPR vec<1, T, Q> & operator*=(U scalar);
glm/detail/type_vec1.hpp:       GLM_FUNC_DECL GLM_CONSTEXPR vec<1, T, Q> operator*(vec<1, T, Q> const& v, T scalar);
glm/detail/type_vec1.hpp:       GLM_FUNC_DECL GLM_CONSTEXPR vec<1, T, Q> operator*(T scalar, vec<1, T, Q> const& v);
glm/detail/type_vec2.hpp:               GLM_FUNC_DECL GLM_CONSTEXPR vec<2, T, Q> & operator*=(U scalar);
glm/detail/type_vec2.hpp:       GLM_FUNC_DECL GLM_CONSTEXPR vec<2, T, Q> operator*(vec<2, T, Q> const& v, T scalar);
glm/detail/type_vec2.hpp:       GLM_FUNC_DECL GLM_CONSTEXPR vec<2, T, Q> operator*(T scalar, vec<2, T, Q> const& v);
glm/detail/type_vec3.hpp:               GLM_FUNC_DECL GLM_CONSTEXPR vec<3, T, Q> & operator*=(U scalar);
glm/detail/type_vec3.hpp:       GLM_FUNC_DECL GLM_CONSTEXPR vec<3, T, Q> operator*(vec<3, T, Q> const& v, T scalar);
glm/detail/type_vec3.hpp:       GLM_FUNC_DECL GLM_CONSTEXPR vec<3, T, Q> operator*(T scalar, vec<3, T, Q> const& v);
glm/detail/type_vec4.hpp:               GLM_FUNC_DECL GLM_CONSTEXPR vec<4, T, Q>& operator*=(U scalar);
glm/detail/type_vec4.hpp:       GLM_FUNC_DECL GLM_CONSTEXPR vec<4, T, Q> operator*(vec<4, T, Q> const& v, T const & scalar);
glm/detail/type_vec4.hpp:       GLM_FUNC_DECL GLM_CONSTEXPR vec<4, T, Q> operator*(T scalar, vec<4, T, Q> const& v);
```

**vec4** is different, as are **mat4x3** and **mat4x4**:

```
$ git grep 'operator.*\*.*scalar' "glm/**.hpp" | grep "T const"
glm/detail/type_vec4.hpp:       GLM_FUNC_DECL GLM_CONSTEXPR vec<4, T, Q> operator*(vec<4, T, Q> const& v, T const & scalar);
```

This change updates the signatures for the `vec4`, `mat4x3` and `mat4x4` types to match those of the other vector and matrix type binary operators.

I noticed this when writing Lua/Sol2 bindings for GLM and found that the signatures were not compatible.  Here's an example of the binding of `vec3` vs `vec4` for the basic operators:

```c++
  state.new_usertype<glm::vec3>(
      "vec3",
      sol::constructors<glm::vec3(), glm::vec3(float const &),
                        glm::vec3(float const &, float const &, float const &)>(),
      sol::meta_function::multiplication,
      sol::overload(
          sol::resolve<glm::vec3(glm::vec3 const &, glm::vec3 const &)>(
              &glm::operator*),
          sol::resolve<glm::vec3(glm::vec3 const &, glm::vec1 const &)>(
              &glm::operator*),
          sol::resolve<glm::vec3(glm::vec3 const &, float)>(&glm::operator*)),
      sol::meta_function::division,
      sol::overload(
          sol::resolve<glm::vec3(glm::vec3 const &, glm::vec3 const &)>(
              &glm::operator/),
          sol::resolve<glm::vec3(glm::vec3 const &, glm::vec1 const &)>(
              &glm::operator/),
          sol::resolve<glm::vec3(glm::vec3 const &, float)>(&glm::operator/)),
      sol::meta_function::addition,
      sol::overload(
          sol::resolve<glm::vec3(glm::vec3 const &, glm::vec3 const &)>(
              &glm::operator+),
          sol::resolve<glm::vec3(glm::vec3 const &, glm::vec1 const &)>(
              &glm::operator/),
          sol::resolve<glm::vec3(glm::vec3 const &, float)>(&glm::operator/)),
      sol::meta_function::subtraction,
      sol::overload(
          sol::resolve<glm::vec3(glm::vec3 const &, glm::vec3 const &)>(
              &glm::operator-),
          sol::resolve<glm::vec3(glm::vec3 const &, glm::vec1 const &)>(
              &glm::operator/),
          sol::resolve<glm::vec3(glm::vec3 const &, float)>(&glm::operator/)),
      sol::meta_function::index,
      sol::resolve<const float &(glm::vec3 const &, glm::length_t)>(fetchIndex),
      sol::meta_function::new_index,
      sol::resolve<void(glm::vec3 &, glm::length_t, float const &)>(
          storeIndex));

  state.new_usertype<glm::vec4>(
      "vec4",
      sol::constructors<glm::vec4(), glm::vec4(float const &),
                        glm::vec4(float const &, float const &, float const &, float const &)>(),
      sol::meta_function::multiplication,
      sol::overload(
          sol::resolve<glm::vec4(glm::vec4 const &, glm::vec4 const &)>(
              &glm::operator*),
          sol::resolve<glm::vec4(glm::vec4 const &, glm::vec1 const &)>(
              &glm::operator*),
          sol::resolve<glm::vec4(glm::vec4 const &, float const &)>(
              &glm::operator*)),
      sol::meta_function::division,
      sol::overload(
          sol::resolve<glm::vec4(glm::vec4 const &, glm::vec4 const &)>(
              &glm::operator/),
          sol::resolve<glm::vec4(glm::vec4 const &, glm::vec1 const &)>(
              &glm::operator/),
          sol::resolve<glm::vec4(glm::vec4 const &, float const &)>(
              &glm::operator/)),
      sol::meta_function::addition,
      sol::overload(
          sol::resolve<glm::vec4(glm::vec4 const &, glm::vec4 const &)>(
              &glm::operator+),
          sol::resolve<glm::vec4(glm::vec4 const &, glm::vec1 const &)>(
              &glm::operator/),
          sol::resolve<glm::vec4(glm::vec4 const &, float const &)>(
              &glm::operator/)),
      sol::meta_function::subtraction,
      sol::overload(
          sol::resolve<glm::vec4(glm::vec4 const &, glm::vec4 const &)>(
              &glm::operator-),
          sol::resolve<glm::vec4(glm::vec4 const &, glm::vec1 const &)>(
              &glm::operator/),
          sol::resolve<glm::vec4(glm::vec4 const &, float const &)>(
              &glm::operator/)),
      sol::meta_function::index,
      sol::resolve<const float &(glm::vec4 const &, glm::length_t)>(fetchIndex),
      sol::meta_function::new_index,
      sol::resolve<void(glm::vec4 &, glm::length_t, float const &)>(
          storeIndex));
```

Note the `float const&` in the `vec4` case vs the `float` in the `vec3` case (likewise for `vec2` and `vec1`).

Note: I have not yet wrapped all overloads, just vecn, vec1 and float for each operator.

For ease of writing bindings, having consistency would enable more generalised template functions to be written to automate the wrapping.