### PR TITLE
Fix GLM_EXT_matrix_common : row to column-major

### DIFF
--- a/glm/ext/_matrix_vectorize.hpp
+++ b/glm/ext/_matrix_vectorize.hpp
@@ -23,9 +23,8 @@ namespace glm {
 
 			GLM_FUNC_QUALIFIER GLM_CONSTEXPR static mat<2, 3, T, Q> call(Ret (*Func)(T x), mat<2, 3, T, Q> const &x) {
 				return mat<2, 3, Ret, Q>(
-					Func(x[0][0]), Func(x[0][1]),
-					Func(x[1][0]), Func(x[1][1]),
-					Func(x[2][0]), Func(x[2][1])
+					Func(x[0][0]), Func(x[0][1]), Func(x[0][2]),
+					Func(x[1][0]), Func(x[1][1]), Func(x[1][2])
 				);
 			}
 
@@ -36,10 +35,8 @@ namespace glm {
 
 			GLM_FUNC_QUALIFIER GLM_CONSTEXPR static mat<2, 4, T, Q> call(Ret (*Func)(T x), mat<2, 4, T, Q> const &x) {
 				return mat<2, 4, Ret, Q>(
-					Func(x[0][0]), Func(x[0][1]),
-					Func(x[1][0]), Func(x[1][1]),
-					Func(x[2][0]), Func(x[2][1]),
-					Func(x[3][0]), Func(x[3][1])
+					Func(x[0][0]), Func(x[0][1]), Func(x[0][2]), Func(x[0][3]),
+					Func(x[1][0]), Func(x[1][1]), Func(x[1][2]), Func(x[1][3])
 				);
 			}
 
@@ -50,8 +47,9 @@ namespace glm {
 
 			GLM_FUNC_QUALIFIER GLM_CONSTEXPR static mat<3, 2, T, Q> call(Ret (*Func)(T x), mat<3, 2, T, Q> const &x) {
 				return mat<3, 2, Ret, Q>(
-					Func(x[0][0]), Func(x[0][1]), Func(x[0][2]),
-					Func(x[1][0]), Func(x[1][1]), Func(x[1][2])
+					Func(x[0][0]), Func(x[0][1]),
+					Func(x[1][0]), Func(x[1][1]),
+					Func(x[2][0]), Func(x[2][1])
 				);
 			}
 
@@ -75,10 +73,9 @@ namespace glm {
 
 			GLM_FUNC_QUALIFIER GLM_CONSTEXPR static mat<3, 4, T, Q> call(Ret (*Func)(T x), mat<3, 4, T, Q> const &x) {
 				return mat<3, 4, Ret, Q>(
-					Func(x[0][0]), Func(x[0][1]), Func(x[0][2]),
-					Func(x[1][0]), Func(x[1][1]), Func(x[1][2]),
-					Func(x[2][0]), Func(x[2][1]), Func(x[2][2]),
-					Func(x[3][0]), Func(x[3][1]), Func(x[3][2])
+					Func(x[0][0]), Func(x[0][1]), Func(x[0][2]), Func(x[0][3]),
+					Func(x[1][0]), Func(x[1][1]), Func(x[1][2]), Func(x[1][3]),
+					Func(x[2][0]), Func(x[2][1]), Func(x[2][2]), Func(x[2][3])
 				);
 			}
 
@@ -89,8 +86,10 @@ namespace glm {
 
 			GLM_FUNC_QUALIFIER GLM_CONSTEXPR static mat<4, 2, T, Q> call(Ret (*Func)(T x), mat<4, 2, T, Q> const &x) {
 				return mat<4, 2, Ret, Q>(
-					Func(x[0][0]), Func(x[0][1]), Func(x[0][2]), Func(x[0][3]),
-					Func(x[1][0]), Func(x[1][1]), Func(x[1][2]), Func(x[1][3])
+					Func(x[0][0]), Func(x[0][1]),
+					Func(x[1][0]), Func(x[1][1]),
+					Func(x[2][0]), Func(x[2][1]),
+					Func(x[3][0]), Func(x[3][1])
 				);
 			}
 
@@ -101,9 +100,10 @@ namespace glm {
 
 			GLM_FUNC_QUALIFIER GLM_CONSTEXPR static mat<4, 3, T, Q> call(Ret (*Func)(T x), mat<4, 3, T, Q> const &x) {
 				return mat<4, 3, Ret, Q>(
-					Func(x[0][0]), Func(x[0][1]), Func(x[0][2]), Func(x[0][3]),
-					Func(x[1][0]), Func(x[1][1]), Func(x[1][2]), Func(x[1][3]),
-					Func(x[2][0]), Func(x[2][1]), Func(x[2][2]), Func(x[2][3])
+					Func(x[0][0]), Func(x[0][1]), Func(x[0][2]),
+					Func(x[1][0]), Func(x[1][1]), Func(x[1][2]),
+					Func(x[2][0]), Func(x[2][1]), Func(x[2][2]),
+					Func(x[3][0]), Func(x[3][1]), Func(x[3][2])
 				);
 			}
 

--- a/test/ext/ext_matrix_common.cpp
+++ b/test/ext/ext_matrix_common.cpp
@@ -3,6 +3,7 @@
 #include <glm/ext/matrix_float4x4.hpp>
 #include <glm/ext/matrix_relational.hpp>
 #include <glm/ext/vector_bool4.hpp>
+#include <glm/ext/matrix_float4x3.hpp>
 
 static int test_mix()
 {
@@ -47,6 +48,9 @@ static int test_abs()
 {
 	int Error = 0;
 
+	// -------------------- //
+	// glm::mat4 variants : //
+	// -------------------- //
 	{
 		glm::mat4 A(
 			3.0f, 1.0f, 5.2f, 4.9f,
@@ -62,14 +66,163 @@ static int test_abs()
 		);
 		glm::mat4 C = glm::matrixCompMult(A, B); // Not * to avoid matrix product.
 		glm::mat4 D = glm::abs(C);
-		glm::bvec4 const row1 = glm::equal(D[0], A[0]);
-		glm::bvec4 const row2 = glm::equal(D[1], A[1]);
-		glm::bvec4 const row3 = glm::equal(D[2], A[2]);
-		glm::bvec4 const row4 = glm::equal(D[3], A[3]);
-		Error += glm::all(glm::bvec4{glm::all(row1), glm::all(row2), glm::all(row3), glm::all(row4)}) ? 0 : 1;
-
-		return Error;
+		glm::bvec4 const col1 = glm::equal(D[0], A[0]);
+		glm::bvec4 const col2 = glm::equal(D[1], A[1]);
+		glm::bvec4 const col3 = glm::equal(D[2], A[2]);
+		glm::bvec4 const col4 = glm::equal(D[3], A[3]);
+		Error += glm::all(glm::bvec4{glm::all(col1), glm::all(col2), glm::all(col3), glm::all(col4)}) ? 0 : 1;
 	}
+	{
+		glm::mat4x3 A(
+			3.0f, 1.0f, 5.2f,
+			4.9f, 1.4f, 0.5f,
+			9.3f, 3.7f, 6.8f,
+			8.4f, 4.3f, 3.9f
+		);
+		glm::mat4x3 B(
+			 1.0,-1.0, 1.0,
+			 1.0,-1.0, 1.0,
+			 1.0,-1.0, 1.0,
+			-1.0,-1.0,-1.0
+		);
+		glm::mat4x3 C = glm::matrixCompMult(A, B); // Not * to avoid matrix product.
+		glm::mat4x3 D = glm::abs(C);
+		glm::bvec3 const col1 = glm::equal(D[0], A[0]);
+		glm::bvec3 const col2 = glm::equal(D[1], A[1]);
+		glm::bvec3 const col3 = glm::equal(D[2], A[2]);
+		glm::bvec3 const col4 = glm::equal(D[3], A[3]);
+		Error += glm::all(glm::bvec4{glm::all(col1), glm::all(col2), glm::all(col3), glm::all(col4)}) ? 0 : 1;
+	}
+	{
+		glm::mat4x2 A(
+			3.0f, 1.0f,
+			1.4f, 0.5f,
+			6.8f, 8.4f,
+			5.6f, 7.2f
+		);
+		glm::mat4x2 B(
+			 1.0,-1.0,
+			-1.0, 1.0,
+			 1.0,-1.0,
+			-1.0,-1.0
+		);
+		glm::mat4x2 C = glm::matrixCompMult(A, B); // Not * to avoid matrix product.
+		glm::mat4x2 D = glm::abs(C);
+		glm::bvec2 const col1 = glm::equal(D[0], A[0]);
+		glm::bvec2 const col2 = glm::equal(D[1], A[1]);
+		glm::bvec2 const col3 = glm::equal(D[2], A[2]);
+		glm::bvec2 const col4 = glm::equal(D[3], A[3]);
+		Error += glm::all(glm::bvec4{glm::all(col1), glm::all(col2), glm::all(col3), glm::all(col4)}) ? 0 : 1;
+	}
+
+	// -------------------- //
+	// glm::mat3 variants : //
+	// -------------------- //
+	{
+		glm::mat3x4 A(
+			3.0f, 1.0f, 5.2f, 4.9f,
+			1.4f, 0.5f, 9.3f, 3.7f,
+			6.8f, 8.4f, 4.3f, 3.9f
+		);
+		glm::mat3x4 B(
+			 1.0,-1.0, 1.0, 1.0,
+			-1.0, 1.0, 1.0,-1.0,
+			 1.0,-1.0,-1.0,-1.0
+		);
+		glm::mat3x4 C = glm::matrixCompMult(A, B); // Not * to avoid matrix product.
+		glm::mat3x4 D = glm::abs(C);
+		glm::bvec4 const col1 = glm::equal(D[0], A[0]);
+		glm::bvec4 const col2 = glm::equal(D[1], A[1]);
+		glm::bvec4 const col3 = glm::equal(D[2], A[2]);
+		Error += glm::all(glm::bvec3{glm::all(col1), glm::all(col2), glm::all(col3)}) ? 0 : 1;
+	}
+	{
+		glm::mat3 A(
+			3.0f, 1.0f, 5.2f,
+			1.4f, 0.5f, 9.3f,
+			6.8f, 8.4f, 4.3f
+		);
+		glm::mat3 B(
+			1.0,-1.0, 1.0,
+			-1.0, 1.0, 1.0,
+			1.0,-1.0,-1.0
+		);
+		glm::mat3 C = glm::matrixCompMult(A, B); // Not * to avoid matrix product.
+		glm::mat3 D = glm::abs(C);
+		glm::bvec3 const col1 = glm::equal(D[0], A[0]);
+		glm::bvec3 const col2 = glm::equal(D[1], A[1]);
+		glm::bvec3 const col3 = glm::equal(D[2], A[2]);
+		Error += glm::all(glm::bvec3{glm::all(col1), glm::all(col2), glm::all(col3)}) ? 0 : 1;
+	}
+	{
+		glm::mat3x2 A(
+			5.2f, 4.9f,
+			9.3f, 3.7f,
+			4.3f, 3.9f
+		);
+		glm::mat3x2 B(
+			 1.0, 1.0,
+			 1.0,-1.0,
+			-1.0,-1.0
+		);
+		glm::mat3x2 C = glm::matrixCompMult(A, B); // Not * to avoid matrix product.
+		glm::mat3x2 D = glm::abs(C);
+		glm::bvec2 const col1 = glm::equal(D[0], A[0]);
+		glm::bvec2 const col2 = glm::equal(D[1], A[1]);
+		glm::bvec2 const col3 = glm::equal(D[2], A[2]);
+		Error += glm::all(glm::bvec3{glm::all(col1), glm::all(col2), glm::all(col3)}) ? 0 : 1;
+	}
+
+	// -------------------- //
+	// glm::mat2 variants : //
+	// -------------------- //
+	{
+		glm::mat2x4 A(
+			3.0f, 1.0f, 5.2f, 4.9f,
+			5.6f, 7.2f, 1.1f, 4.4f
+		);
+		glm::mat2x4 B(
+			 1.0,-1.0, 1.0, 1.0,
+			-1.0,-1.0, 1.0, 1.0
+		);
+		glm::mat2x4 C = glm::matrixCompMult(A, B); // Not * to avoid matrix product.
+		glm::mat2x4 D = glm::abs(C);
+		glm::bvec4 const col1 = glm::equal(D[0], A[0]);
+		glm::bvec4 const col2 = glm::equal(D[1], A[1]);
+		Error += glm::all(glm::bvec2{glm::all(col1), glm::all(col2)}) ? 0 : 1;
+	}
+	{
+		glm::mat2x3 A(
+			3.0f, 1.0f, 5.2f,
+			8.4f, 4.3f, 3.9f
+		);
+		glm::mat2x3 B(
+			 1.0,-1.0, 1.0,
+			-1.0,-1.0,-1.0
+		);
+		glm::mat2x3 C = glm::matrixCompMult(A, B); // Not * to avoid matrix product.
+		glm::mat2x3 D = glm::abs(C);
+		glm::bvec3 const col1 = glm::equal(D[0], A[0]);
+		glm::bvec3 const col2 = glm::equal(D[1], A[1]);
+		Error += glm::all(glm::bvec2{glm::all(col1), glm::all(col2)}) ? 0 : 1;
+	}
+	{
+		glm::mat2 A(
+			3.0f, 1.0f,
+			5.6f, 7.2f
+		);
+		glm::mat2 B(
+			 1.0,-1.0,
+			-1.0,-1.0
+		);
+		glm::mat2 C = glm::matrixCompMult(A, B); // Not * to avoid matrix product.
+		glm::mat2 D = glm::abs(C);
+		glm::bvec2 const col1 = glm::equal(D[0], A[0]);
+		glm::bvec2 const col2 = glm::equal(D[1], A[1]);
+		Error += glm::all(glm::bvec2{glm::all(col1), glm::all(col2)}) ? 0 : 1;
+	}
+
+	return Error;
 }
 
 int main()


### PR DESCRIPTION
The previous pull request (#1116) made the incorrect assumption matrices were row-major instead of column-major (got the two mixed up in my head).

This fixes this problem.

Also, this extends the test files to cover all matrix sizes (not types, as this would be redundant).

Sorry for the troubles this might've caused !