### PR TITLE
fix: missing genTypeTrait qualifier

### DIFF
--- a/glm/detail/qualifier.hpp
+++ b/glm/detail/qualifier.hpp
@@ -197,8 +197,8 @@ namespace detail
 	struct genTypeTrait
 	{};
 
-	template <length_t C, length_t R, typename T>
-	struct genTypeTrait<mat<C, R, T> >
+	template <length_t C, length_t R, typename T, qualifier Q>
+	struct genTypeTrait<mat<C, R, T, Q>>
 	{
 		static const genTypeEnum GENTYPE = GENTYPE_MAT;
 	};

--- a/glm/detail/type_quat.inl
+++ b/glm/detail/type_quat.inl
@@ -7,8 +7,8 @@
 namespace glm{
 namespace detail
 {
-	template <typename T>
-	struct genTypeTrait<qua<T> >
+	template <typename T, qualifier Q>
+	struct genTypeTrait<qua<T, Q>>
 	{
 		static const genTypeEnum GENTYPE = GENTYPE_QUAT;
 	};


### PR DESCRIPTION
Otherwise, [ext/matrix_transform/identity](https://github.com/g-truc/glm/blob/1c18fca7890112e7ae15a600e35f850217f3674f/glm/ext/matrix_transform.inl#L3-L7) can only work with `defaultp` qualified types.