### PR TITLE
fix: ensure scaleBias matrix is zeroed

### DIFF
--- a/glm/gtx/transform2.inl
+++ b/glm/gtx/transform2.inl
@@ -108,7 +108,7 @@ namespace glm
 	template<typename T, qualifier Q>
 	GLM_FUNC_QUALIFIER mat<4, 4, T, Q> scaleBias(T scale, T bias)
 	{
-		mat<4, 4, T, Q> result;
+		mat<4, 4, T, Q> result(T(0));
 		result[3] = vec<4, T, Q>(vec<3, T, Q>(bias), static_cast<T>(1));
 		result[0][0] = scale;
 		result[1][1] = scale;


### PR DESCRIPTION
Depending on `GLM_CONFIG_DEFAULTED_*`; the constructor may not initialize the contents of the matrix. Leading to invalid results, e.g.,

```cpp
#include <glm/glm.hpp>
#include <glm/gtx/transform2.hpp>
#include <glm/gtx/string_cast.hpp>

#include <iostream>
int main(void) {
	auto m = glm::scaleBias<float, glm::defaultp>(1.f, 1.f);
	std::cout << glm::to_string(m) << std::endl;
	return 0;
}

/*
clang++ -O3 -Wall -Wextra ...

mat4x4((1.000000, 0.000000, -0.000000, 0.000000), (0.000000, 1.000000, 1934398915687138790655997016801280.000000, 0.000000), (1934366729246117370768849639571456.000000, 0.000000, 1.000000, 0.000000), (1.000000, 1.000000, 1.000000, 1.000000)) 
*/
```