### PR TITLE
Revert "Merge pull request #1074 from szabolcsdombi/quaternion-constr…

### DIFF
--- a/glm/detail/type_quat.hpp
+++ b/glm/detail/type_quat.hpp
@@ -88,12 +88,7 @@ namespace glm
 		// -- Explicit basic constructors --
 
 		GLM_FUNC_DECL GLM_CONSTEXPR qua(T s, vec<3, T, Q> const& v);
-
-#		ifdef GLM_FORCE_QUAT_DATA_XYZW
-		GLM_FUNC_DECL GLM_CONSTEXPR qua(T x, T y, T z, T w);
-#		else
 		GLM_FUNC_DECL GLM_CONSTEXPR qua(T w, T x, T y, T z);
-#		endif
 
 		// -- Conversion constructors --
 

--- a/glm/detail/type_quat.inl
+++ b/glm/detail/type_quat.inl
@@ -141,13 +141,12 @@ namespace detail
 	{}
 
 	template <typename T, qualifier Q>
-#	ifdef GLM_FORCE_QUAT_DATA_XYZW
-	GLM_FUNC_QUALIFIER GLM_CONSTEXPR qua<T, Q>::qua(T _x, T _y, T _z, T _w)
-			: x(_x), y(_y), z(_z), w(_w)
-#	else
 	GLM_FUNC_QUALIFIER GLM_CONSTEXPR qua<T, Q>::qua(T _w, T _x, T _y, T _z)
+#		ifdef GLM_FORCE_QUAT_DATA_XYZW
+			: x(_x), y(_y), z(_z), w(_w)
+#		else
 			: w(_w), x(_x), y(_y), z(_z)
-#	endif
+#		endif
 	{}
 
 	// -- Conversion constructors --


### PR DESCRIPTION
As I initially noted here https://github.com/g-truc/glm/commit/f0066a2acf24ae2e0aba4a2712bb4a36d27c0fd4#comments and later discussed in #1084 and #1111. #1074 has left `GLM_FORCE_QUAT_DATA_XYZW` in an unusable state. 

I do not find the proposed fix in #1084 particularly appealing. Instead, this PR proposes to revert #1074.