### PR TITLE
fix: generalize epsilonEqual

### DIFF
--- a/glm/gtc/epsilon.inl
+++ b/glm/gtc/epsilon.inl
@@ -6,24 +6,8 @@
 
 namespace glm
 {
-	template<>
-	GLM_FUNC_QUALIFIER bool epsilonEqual
-	(
-		float const& x,
-		float const& y,
-		float const& epsilon
-	)
-	{
-		return abs(x - y) < epsilon;
-	}
-
-	template<>
-	GLM_FUNC_QUALIFIER bool epsilonEqual
-	(
-		double const& x,
-		double const& y,
-		double const& epsilon
-	)
+	template<typename genType>
+	GLM_FUNC_QUALIFIER bool epsilonEqual(genType const& x, genType const& y, genType const& epsilon)
 	{
 		return abs(x - y) < epsilon;
 	}
@@ -40,14 +24,8 @@ namespace glm
 		return lessThan(abs(x - y), vec<L, T, Q>(epsilon));
 	}
 
-	template<>
-	GLM_FUNC_QUALIFIER bool epsilonNotEqual(float const& x, float const& y, float const& epsilon)
-	{
-		return abs(x - y) >= epsilon;
-	}
-
-	template<>
-	GLM_FUNC_QUALIFIER bool epsilonNotEqual(double const& x, double const& y, double const& epsilon)
+	template<typename genType>
+	GLM_FUNC_QUALIFIER bool epsilonNotEqual(genType const& x, genType const& y, genType const& epsilon)
 	{
 		return abs(x - y) >= epsilon;
 	}


### PR DESCRIPTION
Generalize `epsilonEqual` and `epsilonNotEqual` to match its [declaration](https://github.com/g-truc/glm/blob/master/glm/gtc/epsilon.hpp#L41). This allows long doubles (or custom types, etc) to use these functions.

And related question: should the definition to `epsilonEqual` be: `|x - y| <= epsilon`, not `... < epsilon` (and the opposite for `epsilonNotEqual`). Otherwise, `glm::epsilonEqual(1.f, 1.f, 0.f)` will return false even though the values are byte identical.