### PR TITLE
fix: mask warning

### DIFF
--- a/glm/gtc/bitfield.inl
+++ b/glm/gtc/bitfield.inl
@@ -226,7 +226,7 @@ namespace detail
 	{
 		GLM_STATIC_ASSERT(std::numeric_limits<genIUType>::is_integer, "'mask' accepts only integer values");
 
-		return Bits >= sizeof(genIUType) * 8 ? ~static_cast<genIUType>(0) : (static_cast<genIUType>(1) << Bits) - static_cast<genIUType>(1);
+		return Bits >= static_cast<genIUType>(sizeof(genIUType) * 8) ? ~static_cast<genIUType>(0) : (static_cast<genIUType>(1) << Bits) - static_cast<genIUType>(1);
 	}
 
 	template<length_t L, typename T, qualifier Q>


### PR DESCRIPTION
Fixes a `sign-compare` warning in `glm::mask` when compiling w/ clang or g++ (and presumably others):

```
./glm/gtc/bitfield.inl:229:15: warning: comparison of integers of different signs: 'int' and 'unsigned long' [-Wsign-compare]
                return Bits >= sizeof(genIUType) * 8 ? ~static_cast<genIUType>(0) : (static_cast<genIUType>(1) << Bits) - static_cast<genIUType>(1);
```

This function, and fix, is mirrored in [detail/func_integer.inl](https://github.com/g-truc/glm/blob/master/glm/detail/func_integer.inl#L25).