### PR TITLE
Automatically add lightweight archives to releases

### DIFF
--- a/.github/workflows/make_light_release.yml
+++ b/.github/workflows/make_light_release.yml
@@ -21,12 +21,18 @@ jobs:
       run: mv copying.txt glm
       
     - name: Create zip archive
-      run: zip -r glm-${{ github.GITHUB_REF }}-light.zip glm
+      run: zip -r glm-${{ github.ref }}-light.zip glm
       
     - name: Create 7z archive
-      run: 7z a glm-${{ github.GITHUB_REF }}-light.7z glm
+      run: 7z a glm-${{ github.ref }}-light.7z glm
       
     - uses: actions/upload-artifact@v3
       with:
-        name: glm-${{ github.GITHUB_REF }}-light
-        path: glm-${{ github.GITHUB_REF }}-light.*
+        name: glm-${{ github.ref }}-light
+        path: glm-${{ github.ref }}-light.*
+        
+    - name: Add to Release
+        uses: softprops/action-gh-release@v1
+        files: |
+          glm-${{ github.ref }}-light.zip
+          glm-${{ github.ref }}-light.7z

--- a/.github/workflows/make_light_release.yml
+++ b/.github/workflows/make_light_release.yml
@@ -1,0 +1,29 @@
+# A workflow that creates a minimal archive with only the glm/ headers and copying.txt.
+
+name: Make light release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  make_zip:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Install dependencies
+      run: sudo apt-get update -y && sudo apt-get install -y zip p7zip
+      
+    - name: Prepare layout
+      run: mv copying.txt glm
+      
+    - name: Create zip archive
+      run: zip -r glm-${{ github.GITHUB_REF }}-light.zip glm
+      
+    - name: Create 7z archive
+      run: 7z a glm-${{ github.GITHUB_REF }}-light.7z glm
+      
+    - uses: actions/upload-artifact@v3
+      with:
+        name: glm-${{ github.GITHUB_REF }}-light
+        path: glm-${{ github.GITHUB_REF }}-light.*

--- a/.github/workflows/make_light_release.yml
+++ b/.github/workflows/make_light_release.yml
@@ -32,7 +32,8 @@ jobs:
         path: glm-${{ github.ref }}-light.*
         
     - name: Add to Release
-        uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@v1
+      with:
         files: |
           glm-${{ github.ref }}-light.zip
           glm-${{ github.ref }}-light.7z

--- a/.github/workflows/make_light_release.yml
+++ b/.github/workflows/make_light_release.yml
@@ -14,6 +14,9 @@ jobs:
     - name: Install dependencies
       run: sudo apt-get update -y && sudo apt-get install -y zip p7zip
       
+    - name: Check out repository code
+      uses: actions/checkout@v3
+      
     - name: Prepare layout
       run: mv copying.txt glm
       

--- a/.github/workflows/make_light_release.yml
+++ b/.github/workflows/make_light_release.yml
@@ -17,23 +17,26 @@ jobs:
     - name: Check out repository code
       uses: actions/checkout@v3
       
+    - name: Set env
+      run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+      
     - name: Prepare layout
       run: mv copying.txt glm
       
     - name: Create zip archive
-      run: zip -r glm-${{ github.ref }}-light.zip glm
+      run: zip -r glm-${{ env.RELEASE_VERSION }}-light.zip glm
       
     - name: Create 7z archive
-      run: 7z a glm-${{ github.ref }}-light.7z glm
+      run: 7z a glm-${{ env.RELEASE_VERSION }}-light.7z glm
       
     - uses: actions/upload-artifact@v3
       with:
-        name: glm-${{ github.ref }}-light
-        path: glm-${{ github.ref }}-light.*
+        name: glm-${{ env.RELEASE_VERSION }}-light
+        path: glm-${{ env.RELEASE_VERSION }}-light.*
         
     - name: Add to Release
       uses: softprops/action-gh-release@v1
       with:
         files: |
-          glm-${{ github.ref }}-light.zip
-          glm-${{ github.ref }}-light.7z
+          glm-${{ env.RELEASE_VERSION }}-light.zip
+          glm-${{ env.RELEASE_VERSION }}-light.7z


### PR DESCRIPTION
Although it is supposedly header-only, glm release archives contain the whole repository, including test data, doc and build scripts. This is a true case of **digital waste** (of bandwidth and disk space) for a lot of common usages:


| Archive type | Full release  | Light release | Savings |
| ------------- | ------------- | ------------- | ------------- |
| 7z          | 3.27 MB  | 159 KB  | 99.95% |
| zip    | 5.41 MB  | 406 KB  | 99.93% |

This PR adds an automatic workflow to generate and attach to releases a lightweight release, which only includes the `glm/` directory (and the `copying.txt` license file).