### PR TITLE
fix: declarations

### DIFF
--- a/glm/gtx/pca.hpp
+++ b/glm/gtx/pca.hpp
@@ -97,17 +97,17 @@ namespace glm {
 	/// Sorts a group of Eigenvalues&Eigenvectors, for largest Eigenvalue to smallest Eigenvalue.
 	/// The data in `outEigenvalues` and `outEigenvectors` are assumed to be matching order, i.e. `outEigenvector[i]` is the Eigenvector of the Eigenvalue `outEigenvalue[i]`.
 	template<typename T, qualifier Q>
-	GLM_INLINE void sortEigenvalues(vec<2, T, Q>& eigenvalues, mat<2, 2, T, Q>& eigenvectors);
+	GLM_FUNC_DECL void sortEigenvalues(vec<2, T, Q>& eigenvalues, mat<2, 2, T, Q>& eigenvectors);
 
 	/// Sorts a group of Eigenvalues&Eigenvectors, for largest Eigenvalue to smallest Eigenvalue.
 	/// The data in `outEigenvalues` and `outEigenvectors` are assumed to be matching order, i.e. `outEigenvector[i]` is the Eigenvector of the Eigenvalue `outEigenvalue[i]`.
 	template<typename T, qualifier Q>
-	GLM_INLINE void sortEigenvalues(vec<3, T, Q>& eigenvalues, mat<3, 3, T, Q>& eigenvectors);
+	GLM_FUNC_DECL void sortEigenvalues(vec<3, T, Q>& eigenvalues, mat<3, 3, T, Q>& eigenvectors);
 
 	/// Sorts a group of Eigenvalues&Eigenvectors, for largest Eigenvalue to smallest Eigenvalue.
 	/// The data in `outEigenvalues` and `outEigenvectors` are assumed to be matching order, i.e. `outEigenvector[i]` is the Eigenvector of the Eigenvalue `outEigenvalue[i]`.
 	template<typename T, qualifier Q>
-	GLM_INLINE void sortEigenvalues(vec<4, T, Q>& eigenvalues, mat<4, 4, T, Q>& eigenvectors);
+	GLM_FUNC_DECL void sortEigenvalues(vec<4, T, Q>& eigenvalues, mat<4, 4, T, Q>& eigenvectors);
 
 	/// @}
 }//namespace glm

--- a/glm/gtx/pca.inl
+++ b/glm/gtx/pca.inl
@@ -10,21 +10,21 @@ namespace glm {
 
 
 	template<length_t D, typename T, qualifier Q>
-	GLM_INLINE mat<D, D, T, Q> computeCovarianceMatrix(vec<D, T, Q> const* v, size_t n)
+	GLM_FUNC_QUALIFIER mat<D, D, T, Q> computeCovarianceMatrix(vec<D, T, Q> const* v, size_t n)
 	{
 		return computeCovarianceMatrix<D, T, Q, vec<D, T, Q> const*>(v, v + n);
 	}
 
 
 	template<length_t D, typename T, qualifier Q>
-	GLM_INLINE mat<D, D, T, Q> computeCovarianceMatrix(vec<D, T, Q> const* v, size_t n, vec<D, T, Q> const& c)
+	GLM_FUNC_QUALIFIER mat<D, D, T, Q> computeCovarianceMatrix(vec<D, T, Q> const* v, size_t n, vec<D, T, Q> const& c)
 	{
 		return computeCovarianceMatrix<D, T, Q, vec<D, T, Q> const*>(v, v + n, c);
 	}
 
 
 	template<length_t D, typename T, qualifier Q, typename I>
-	GLM_FUNC_DECL mat<D, D, T, Q> computeCovarianceMatrix(I const& b, I const& e)
+	GLM_FUNC_QUALIFIER mat<D, D, T, Q> computeCovarianceMatrix(I const& b, I const& e)
 	{
 		glm::mat<D, D, T, Q> m(0);
 
@@ -45,7 +45,7 @@ namespace glm {
 
 
 	template<length_t D, typename T, qualifier Q, typename I>
-	GLM_FUNC_DECL mat<D, D, T, Q> computeCovarianceMatrix(I const& b, I const& e, vec<D, T, Q> const& c)
+	GLM_FUNC_QUALIFIER mat<D, D, T, Q> computeCovarianceMatrix(I const& b, I const& e, vec<D, T, Q> const& c)
 	{
 		glm::mat<D, D, T, Q> m(0);
 		glm::vec<D, T, Q> v;
@@ -69,13 +69,13 @@ namespace glm {
 	{
 
 		template<typename T>
-		GLM_INLINE T transferSign(T const& v, T const& s)
+		GLM_FUNC_QUALIFIER static T transferSign(T const& v, T const& s)
 		{
 			return ((s) >= 0 ? glm::abs(v) : -glm::abs(v));
 		}
 
 		template<typename T>
-		GLM_INLINE T pythag(T const& a, T const& b) {
+		GLM_FUNC_QUALIFIER static T pythag(T const& a, T const& b) {
 			static const T epsilon = static_cast<T>(0.0000001);
 			T absa = glm::abs(a);
 			T absb = glm::abs(b);
@@ -93,7 +93,7 @@ namespace glm {
 	}
 
 	template<length_t D, typename T, qualifier Q>
-	GLM_FUNC_DECL unsigned int findEigenvaluesSymReal
+	GLM_FUNC_QUALIFIER unsigned int findEigenvaluesSymReal
 	(
 		mat<D, D, T, Q> const& covarMat,
 		vec<D, T, Q>& outEigenvalues,
@@ -281,7 +281,7 @@ namespace glm {
 	}
 
 	template<typename T, qualifier Q>
-	GLM_INLINE void sortEigenvalues(vec<2, T, Q>& eigenvalues, mat<2, 2, T, Q>& eigenvectors)
+	GLM_FUNC_QUALIFIER void sortEigenvalues(vec<2, T, Q>& eigenvalues, mat<2, 2, T, Q>& eigenvectors)
 	{
 		if (eigenvalues[0] < eigenvalues[1])
 		{
@@ -291,7 +291,7 @@ namespace glm {
 	}
 
 	template<typename T, qualifier Q>
-	GLM_INLINE void sortEigenvalues(vec<3, T, Q>& eigenvalues, mat<3, 3, T, Q>& eigenvectors)
+	GLM_FUNC_QUALIFIER void sortEigenvalues(vec<3, T, Q>& eigenvalues, mat<3, 3, T, Q>& eigenvectors)
 	{
 		if (eigenvalues[0] < eigenvalues[1])
 		{
@@ -311,7 +311,7 @@ namespace glm {
 	}
 
 	template<typename T, qualifier Q>
-	GLM_INLINE void sortEigenvalues(vec<4, T, Q>& eigenvalues, mat<4, 4, T, Q>& eigenvectors)
+	GLM_FUNC_QUALIFIER void sortEigenvalues(vec<4, T, Q>& eigenvalues, mat<4, 4, T, Q>& eigenvectors)
 	{
 		if (eigenvalues[0] < eigenvalues[2])
 		{

--- a/glm/gtx/quaternion.hpp
+++ b/glm/gtx/quaternion.hpp
@@ -110,28 +110,28 @@ namespace glm
 	///
 	/// @see gtx_quaternion
 	template<typename T, qualifier Q>
-	GLM_FUNC_DECL mat<3, 3, T, Q> toMat3(
+	GLM_FUNC_QUALIFIER mat<3, 3, T, Q> toMat3(
 		qua<T, Q> const& x){return mat3_cast(x);}
 
 	/// Converts a quaternion to a 4 * 4 matrix.
 	///
 	/// @see gtx_quaternion
 	template<typename T, qualifier Q>
-	GLM_FUNC_DECL mat<4, 4, T, Q> toMat4(
+	GLM_FUNC_QUALIFIER mat<4, 4, T, Q> toMat4(
 		qua<T, Q> const& x){return mat4_cast(x);}
 
 	/// Converts a 3 * 3 matrix to a quaternion.
 	///
 	/// @see gtx_quaternion
 	template<typename T, qualifier Q>
-	GLM_FUNC_DECL qua<T, Q> toQuat(
+	GLM_FUNC_QUALIFIER qua<T, Q> toQuat(
 		mat<3, 3, T, Q> const& x){return quat_cast(x);}
 
 	/// Converts a 4 * 4 matrix to a quaternion.
 	///
 	/// @see gtx_quaternion
 	template<typename T, qualifier Q>
-	GLM_FUNC_DECL qua<T, Q> toQuat(
+	GLM_FUNC_QUALIFIER qua<T, Q> toQuat(
 		mat<4, 4, T, Q> const& x){return quat_cast(x);}
 
 	/// Quaternion interpolation using the rotation short path.


### PR DESCRIPTION
Inspecting the symbols of a library using glm (compiled w/ default visibility) lead me to notice these being externalized:

```
unsigned int glm::findEigenvaluesSymReal<2, float, (glm::qualifier)3>(glm::mat<2, 2, float, (glm::qualifier)3> const&, glm::vec<2, float, (glm::qualifier)3>&, glm::mat<2, 2, float, (glm::qualifier)3>&)
unsigned int glm::findEigenvaluesSymReal<3, float, (glm::qualifier)3>(glm::mat<3, 3, float, (glm::qualifier)3> const&, glm::vec<3, float, (glm::qualifier)3>&, glm::mat<3, 3, float, (glm::qualifier)3>&)
unsigned int glm::findEigenvaluesSymReal<4, float, (glm::qualifier)3>(glm::mat<4, 4, float, (glm::qualifier)3> const&, glm::vec<4, float, (glm::qualifier)3>&, glm::mat<4, 4, float, (glm::qualifier)3>&)
glm::mat<2, 2, float, (glm::qualifier)3> glm::computeCovarianceMatrix<2, float, (glm::qualifier)3, ...
glm::mat<2, 2, float, (glm::qualifier)3> glm::computeCovarianceMatrix<2, float, (glm::qualifier)3, ...
glm::mat<3, 3, float, (glm::qualifier)3> glm::computeCovarianceMatrix<3, float, (glm::qualifier)3, ...
glm::qua<float, (glm::qualifier)0> glm::toQuat<float, (glm::qualifier)0>(glm::mat<4, 4, float, (glm::qualifier)0> const&)
glm::qua<float, (glm::qualifier)3> glm::toQuat<float, (glm::qualifier)3>(glm::mat<3, 3, float, (glm::qualifier)3> const&)
```

This commit fixes the declarations to the listed functions.