### PR TITLE
fix: glm_vec4_round for SSE2

### DIFF
--- a/glm/simd/common.h
+++ b/glm/simd/common.h
@@ -117,7 +117,10 @@ GLM_FUNC_QUALIFIER glm_vec4 glm_vec4_round(glm_vec4 x)
 		glm_vec4 const or0 = _mm_or_ps(and0, _mm_set_ps1(8388608.0f));
 		glm_vec4 const add0 = glm_vec4_add(x, or0);
 		glm_vec4 const sub0 = glm_vec4_sub(add0, or0);
-		return sub0;
+		glm_vec4 const abs0 = glm_vec4_abs(x);  // keep values too large for a fraction unchanged
+		glm_vec4 const cmp = _mm_cmple_ps(abs0, _mm_set_ps1(8388608.0f));
+		glm_vec4 const xor0 = _mm_xor_ps(_mm_and_ps(cmp, sub0), _mm_andnot_ps(cmp, x));
+		return xor0;
 #	endif
 }
 
@@ -140,17 +143,6 @@ GLM_FUNC_QUALIFIER glm_vec4 glm_vec4_trunc(glm_vec4 x)
 	return glm_vec4();
 }
 */
-
-//roundEven
-GLM_FUNC_QUALIFIER glm_vec4 glm_vec4_roundEven(glm_vec4 x)
-{
-	glm_vec4 const sgn0 = _mm_castsi128_ps(_mm_set1_epi32(int(0x80000000)));
-	glm_vec4 const and0 = _mm_and_ps(sgn0, x);
-	glm_vec4 const or0 = _mm_or_ps(and0, _mm_set_ps1(8388608.0f));
-	glm_vec4 const add0 = glm_vec4_add(x, or0);
-	glm_vec4 const sub0 = glm_vec4_sub(add0, or0);
-	return sub0;
-}
 
 GLM_FUNC_QUALIFIER glm_vec4 glm_vec4_ceil(glm_vec4 x)
 {


### PR DESCRIPTION
`glm_vec4_round` without `SSE41` does not properly handle values outside of +/- 2^23. For instance (contrived for demonstration):

```cpp
#include <glm/glm.hpp>
#include <glm/gtx/string_cast.hpp>
#include <iostream>
#include <iomanip>

int main(void) {
	glm::vec4 v(8388609.f, 8428605.f, 9988605.f, 10388605.f);
	std::cout << "Expected: " << std::hexfloat << v.x << ", " << v.y << ", " << v.z << ", " << v.w << std::endl;
	std::cout << "Expected: " << glm::to_string(v) << std::endl;
	std::cout << std::endl;

	v = glm::floor(v);
	std::cout << "Actual:   " << glm::to_string(v) << std::endl;
	std::cout << "Actual:   " << std::hexfloat << v.x << ", " << v.y << ", " << v.z << ", " << v.w << std::endl;
	return 0;
}

// └> clang++ -O3 -I. -DGLM_FORCE_SSE2 -DGLM_FORCE_DEFAULT_ALIGNED_GENTYPES ...
// Expected: 0x1.000002p+23, 0x1.01387ap+23, 0x1.30d3fap+23, 0x1.3d08fap+23
// Expected: vec4(8388609.000000, 8428605.000000, 9988605.000000, 10388605.000000)
// Actual:   vec4(8388608.000000, 8428604.000000, 9988604.000000, 10388604.000000)
// Actual:   0x1p+23, 0x1.013878p+23, 0x1.30d3f8p+23, 0x1.3d08f8p+23
```

`glm_vec4_roundEven` is also incorrect. As it is unused, I have removed it.
