### PR TITLE
improve glm_vec4_normalize

### DIFF
--- a/glm/simd/geometric.h
+++ b/glm/simd/geometric.h
@@ -77,9 +77,11 @@ GLM_FUNC_QUALIFIER glm_vec4 glm_vec4_cross(glm_vec4 v1, glm_vec4 v2)
 GLM_FUNC_QUALIFIER glm_vec4 glm_vec4_normalize(glm_vec4 v)
 {
 	glm_vec4 const dot0 = glm_vec4_dot(v, v);
-	glm_vec4 const isr0 = _mm_rsqrt_ps(dot0);
-	glm_vec4 const mul0 = _mm_mul_ps(v, isr0);
-	return mul0;
+	if (_mm_cvtss_f32(dot0) == 0.0f)
+		return _mm_set1_ps(0.0f);
+	glm_vec4 const sr0 = _mm_sqrt_ps(dot0);
+	glm_vec4 const div0 = _mm_div_ps(v, sr0);
+	return div0;
 }
 
 GLM_FUNC_QUALIFIER glm_vec4 glm_vec4_faceforward(glm_vec4 N, glm_vec4 I, glm_vec4 Nref)


### PR DESCRIPTION
The current implementation of `glm_vec4_normalize` uses `_mm_rsqrt_ps`. While its relative error is small (`< 1.5*2^-12` per documentation), when used in more complicated functions it can lead incorrect results (imprecision amplifies). 

For example, modifying [test/gtx/gtx_matrix_factorisation.cpp](https://github.com/g-truc/glm/blob/efec5db081e3aad807d0731e172ac597f6a39447/test/gtx/gtx_matrix_factorisation.cpp#L87-L102) to operate on floats instead of doubles (replace `glm::dmat` with `glm::mat`) and reducing [both](https://github.com/g-truc/glm/blob/efec5db081e3aad807d0731e172ac597f6a39447/test/gtx/gtx_matrix_factorisation.cpp#L11) [epsilon](https://github.com/g-truc/glm/blob/efec5db081e3aad807d0731e172ac597f6a39447/test/gtx/gtx_matrix_factorisation.cpp#L48) values to `1E-3`:

```bash
# Scalar:
└> g++ -I. gtx_matrix_factorisation.cpp
└> ./a.out ; echo $?
0

# SSE:
└> g++ -I. -DGLM_FORCE_SSE2 -DGLM_FORCE_DEFAULT_ALIGNED_GENTYPES gtx_matrix_factorisation.cpp
└> ./a.out ; echo $?
2

# Arm64+NEON (different box):
└> g++ -I. -DGLM_FORCE_NEON -DGLM_FORCE_DEFAULT_ALIGNED_GENTYPES gtx_matrix_factorisation.cpp
└> ./a.out ; echo $?
2
```

In both SIMD cases, the error count of `gtx_matrix_factorisation` is two.

This PR replaces the vec4 normalization implementations with ones more precise (albeit not perfect and AArch64 could be handled separately). The previous implementations could be moved to [fastNormalize](https://github.com/g-truc/glm/blob/efec5db081e3aad807d0731e172ac597f6a39447/glm/gtx/fast_square_root.hpp#L93) if needed.