### PR TITLE
fix: isOrthogonal for a zero matrix

### DIFF
--- a/glm/gtx/matrix_query.inl
+++ b/glm/gtx/matrix_query.inl
@@ -97,16 +97,22 @@ namespace glm
 	GLM_FUNC_QUALIFIER bool isOrthogonal(mat<C, R, T, Q> const& m, T const& epsilon)
 	{
 		bool result = true;
-		for(length_t i(0); result && i < m.length() - 1; ++i)
-		for(length_t j(i + 1); result && j < m.length(); ++j)
-			result = areOrthonormal(m[i], m[j], epsilon);
+		for(length_t i(0); result && i < m.length(); ++i)
+		{
+			result = isNormalized(m[i], epsilon);
+			for(length_t j(i + 1); result && j < m.length(); ++j)
+				result = abs(dot(m[i], m[j])) <= epsilon;
+		}
 
 		if(result)
 		{
 			mat<C, R, T, Q> tmp = transpose(m);
-			for(length_t i(0); result && i < m.length() - 1 ; ++i)
-			for(length_t j(i + 1); result && j < m.length(); ++j)
-				result = areOrthonormal(tmp[i], tmp[j], epsilon);
+			for(length_t i(0); result && i < m.length(); ++i)
+			{
+				result = isNormalized(tmp[i], epsilon);
+				for(length_t j(i + 1); result && j < m.length(); ++j)
+					result = abs(dot(tmp[i], tmp[j])) <= epsilon;
+			}
 		}
 		return result;
 	}

--- a/glm/gtx/matrix_query.inl
+++ b/glm/gtx/matrix_query.inl
@@ -99,14 +99,14 @@ namespace glm
 		bool result = true;
 		for(length_t i(0); result && i < m.length() - 1; ++i)
 		for(length_t j(i + 1); result && j < m.length(); ++j)
-			result = areOrthogonal(m[i], m[j], epsilon);
+			result = areOrthonormal(m[i], m[j], epsilon);
 
 		if(result)
 		{
 			mat<C, R, T, Q> tmp = transpose(m);
 			for(length_t i(0); result && i < m.length() - 1 ; ++i)
 			for(length_t j(i + 1); result && j < m.length(); ++j)
-				result = areOrthogonal(tmp[i], tmp[j], epsilon);
+				result = areOrthonormal(tmp[i], tmp[j], epsilon);
 		}
 		return result;
 	}

--- a/test/gtx/gtx_matrix_query.cpp
+++ b/test/gtx/gtx_matrix_query.cpp
@@ -45,8 +45,14 @@ int test_isOrthogonal()
 {
 	int Error(0);
 
-	bool TestA = glm::isOrthogonal(glm::mat4(1), 0.00001f);
-	Error += TestA ? 0 : 1;
+	{
+		bool TestA = glm::isOrthogonal(glm::mat4(1), 0.00001f);
+		Error += TestA ? 0 : 1;
+	}
+	{
+		bool TestA = glm::isOrthogonal(glm::mat4(0), 0.00001f);
+		Error += TestA ? 1 : 0;
+	}
 
 	return Error;
 }


### PR DESCRIPTION
An orthogonal matrix is a real square matrix whose columns and rows are orthonormal vectors.

However, the isOrthogonal function returns true for a zero matrix.

I fixed it.

Please check the commits.
