### PR TITLE
fix: glm_vec4_refract

### DIFF
--- a/glm/simd/geometric.h
+++ b/glm/simd/geometric.h
@@ -105,14 +105,14 @@ GLM_FUNC_QUALIFIER __m128 glm_vec4_refract(glm_vec4 I, glm_vec4 N, glm_vec4 eta)
 	glm_vec4 const dot0 = glm_vec4_dot(N, I);
 	glm_vec4 const mul0 = _mm_mul_ps(eta, eta);
 	glm_vec4 const mul1 = _mm_mul_ps(dot0, dot0);
-	glm_vec4 const sub0 = _mm_sub_ps(_mm_set1_ps(1.0f), mul0);
-	glm_vec4 const sub1 = _mm_sub_ps(_mm_set1_ps(1.0f), mul1);
-	glm_vec4 const mul2 = _mm_mul_ps(sub0, sub1);
+	glm_vec4 const sub0 = _mm_sub_ps(_mm_set1_ps(1.0f), mul1);
+	glm_vec4 const mul2 = _mm_mul_ps(mul0, sub0);
+	glm_vec4 const sub1 = _mm_sub_ps(_mm_set1_ps(1.0f), mul2);
 
-	if(_mm_movemask_ps(_mm_cmplt_ss(mul2, _mm_set1_ps(0.0f))) == 0)
+	if(_mm_movemask_ps(_mm_cmplt_ps(sub1, _mm_set1_ps(0.0f))) == 0x0F)
 		return _mm_set1_ps(0.0f);
 
-	glm_vec4 const sqt0 = _mm_sqrt_ps(mul2);
+	glm_vec4 const sqt0 = _mm_sqrt_ps(sub1);
 	glm_vec4 const mad0 = glm_vec4_fma(eta, dot0, sqt0);
 	glm_vec4 const mul4 = _mm_mul_ps(mad0, N);
 	glm_vec4 const mul5 = _mm_mul_ps(eta, I);


### PR DESCRIPTION
glm_vec4_refract incorrectly computes `k`. Per GLSL:

```
k = 1.0 - eta * eta * (1.0 - dot(N, I) * dot(N, I))
```

However, stepping through the [function](https://github.com/g-truc/glm/blob/efec5db081e3aad807d0731e172ac597f6a39447/glm/simd/geometric.h#L105-L110):

```cpp
	glm_vec4 const dot0 = glm_vec4_dot(N, I);                  // dot(N, I)
	glm_vec4 const mul0 = _mm_mul_ps(eta, eta);                // eta * eta
	glm_vec4 const mul1 = _mm_mul_ps(dot0, dot0);              // dot(N, I) * dot(N, I)
	glm_vec4 const sub0 = _mm_sub_ps(_mm_set1_ps(1.0f), mul0); // 1.0 - eta * eta
	glm_vec4 const sub1 = _mm_sub_ps(_mm_set1_ps(1.0f), mul1); // 1.0 - dot(N, I) * dot(N, I)
	glm_vec4 const mul2 = _mm_mul_ps(sub0, sub1);              // k = (1.0 - eta * eta) * (1.0 - dot(N, I) * dot(N, I))
```

Which is incorrect. Additionally, the `_mm_movemask_ps` logic is confusing (`_mm_cmplt_ss` only sets the lowest element while `_mm_movemask_ps` creates a mask from all four elements). 

This PR cleans up these issues.