### PR TITLE
Fixed generation of static libraries

### DIFF
--- a/glm/CMakeLists.txt
+++ b/glm/CMakeLists.txt
@@ -53,7 +53,7 @@ target_include_directories(glm INTERFACE
 
 install(TARGETS glm EXPORT glm)
 
-if(BUILD_STATIC_LIBS)
+if(NOT BUILD_SHARED_LIBS)
 add_library(glm_static STATIC ${ROOT_TEXT} ${ROOT_MD} ${ROOT_NAT}
 	${ROOT_SOURCE}    ${ROOT_INLINE}    ${ROOT_HEADER}
 	${CORE_SOURCE}    ${CORE_INLINE}    ${CORE_HEADER}


### PR DESCRIPTION
BUILD_STATIC_LIBS is used in CMakeLists.txt, but that variable does not exist. I could not generate static library until I changed it to "NOT BUILD_SHARED_LIBS".
![image](https://user-images.githubusercontent.com/87949029/217899733-549c9701-94d0-4eb8-8fb1-3ee1f985c997.png)