### PR TITLE
gtx_matrix_decompose: Add glm::recompose()

### DIFF
--- a/glm/gtx/matrix_decompose.hpp
+++ b/glm/gtx/matrix_decompose.hpp
@@ -40,6 +40,12 @@ namespace glm
 		mat<4, 4, T, Q> const& modelMatrix,
 		vec<3, T, Q> & scale, qua<T, Q> & orientation, vec<3, T, Q> & translation, vec<3, T, Q> & skew, vec<4, T, Q> & perspective);
 
+	// Recomposes a model matrix from a previously-decomposed matrix
+	template <typename T, qualifier Q>
+	GLM_FUNC_DECL mat<4, 4, T, Q> recompose(
+		vec<3, T, Q> const& scale, qua<T, Q> const& orientation, vec<3, T, Q> const& translation,
+		vec<3, T, Q> const& skew, vec<4, T, Q> const& perspective);
+
 	/// @}
 }//namespace glm
 

--- a/glm/gtx/matrix_decompose.inl
+++ b/glm/gtx/matrix_decompose.inl
@@ -2,6 +2,7 @@
 
 #include "../gtc/constants.hpp"
 #include "../gtc/epsilon.hpp"
+#include "../gtx/transform.hpp"
 
 namespace glm{
 namespace detail
@@ -188,5 +189,46 @@ namespace detail
 		} // End if <= 0
 
 		return true;
+	}
+
+	// Recomposes a model matrix from a previously-decomposed matrix
+	// http://www.opensource.apple.com/source/WebCore/WebCore-514/platform/graphics/transforms/TransformationMatrix.cpp
+	// https://stackoverflow.com/a/75573092/1047040
+	template <typename T, qualifier Q>
+	GLM_FUNC_DECL mat<4, 4, T, Q> recompose(
+		vec<3, T, Q> const& scale, qua<T, Q> const& orientation, vec<3, T, Q> const& translation,
+		vec<3, T, Q> const& skew, vec<4, T, Q> const& perspective)
+	{
+		glm::mat4 m = glm::mat4(1.f);
+
+		m[0][3] = perspective.x;
+		m[1][3] = perspective.y;
+		m[2][3] = perspective.z;
+		m[3][3] = perspective.w;
+
+		m *= glm::translate(translation);
+		m *= glm::mat4_cast(orientation);
+
+		if (skew.x) {
+			glm::mat4 tmp { 1.f };
+			tmp[2][1] = skew.x;
+			m *= tmp;
+		}
+
+		if (skew.y) {
+			glm::mat4 tmp { 1.f };
+			tmp[2][0] = skew.y;
+			m *= tmp;
+		}
+
+		if (skew.z) {
+			glm::mat4 tmp { 1.f };
+			tmp[1][0] = skew.z;
+			m *= tmp;
+		}
+
+		m *= glm::scale(scale);
+
+		return m;
 	}
 }//namespace glm

--- a/test/gtx/gtx_matrix_decompose.cpp
+++ b/test/gtx/gtx_matrix_decompose.cpp
@@ -15,5 +15,7 @@ int main()
 
 	glm::decompose(Matrix, Scale, Orientation, Translation, Skew, Perspective);
 
+	glm::mat4 Out = glm::recompose(Scale, Orientation, Translation, Skew, Perspective);
+
 	return Error;
 }


### PR DESCRIPTION
This implements `glm::recompose()` based on the `TransformationMatrix::recompose()` from WebKit, to go together with the already-existing `glm::decompose()`.

See also: https://stackoverflow.com/questions/54043989/glmdecompose-and-then-compose-back-again