### PR TITLE
Fix: CUDA compiler error on constexpr abs function

### DIFF
--- a/glm/detail/compute_common.hpp
+++ b/glm/detail/compute_common.hpp
@@ -28,7 +28,7 @@ namespace detail
 	template<>
 	struct compute_abs<float, true>
 	{
-		GLM_FUNC_QUALIFIER GLM_CONSTEXPR static float call(float x)
+		GLM_FUNC_QUALIFIER static float call(float x)
 		{
 			return fabsf(x);
 		}


### PR DESCRIPTION
Hi,

I came across this compiler error when using GLM with CUDA on Windows if compiler option `/Zc:__cplusplus` is used.

```txt

1>\glm\glm\detail\compute_common.hpp(31): error C3615: constexpr function 'glm::detail::compute_abs<float,true>::call' cannot result in a constant expression
1>\glm\glm\detail\compute_common.hpp(33): note: failure was caused by call of undefined function or one not declared 'constexpr'
1>\glm\glm\detail\compute_common.hpp(33): note: see usage of 'fabsf'

```

### Analysis

There is one annoying fact about Microsoft Visual Compiler is that it does not define the macro `__cplusplus` properly according to the standard, while GLM relies on the value of this macro to detect compiler features, for instance if the language standard supports `constexpr`.

While GLM can automatically correct that and still be able to detect this correctly when compiling directly on MSVC, it will not be able to do so when use with CUDA NVCC, and will consider this compiler does not support `constexpr` even if it should. This can be demonstrated with a simple code:

```cpp

#include <cuda_runtime.h>

#include <glm/detail/setup.hpp> // where `GLM_CONSTEXPR` is defined

#include <iostream>

GLM_CONSTEXPR static void dummy() {
	std::cout << "This should not compile if `GLM_CONSTEXPR` is defined as `constexpr`";
}

__host__ int main() {
	dummy();

	return 0;
}

```

Compiling using NVCC is successful while on MSVC it returns failure with the following error message:

```txt

error C3615: constexpr function 'dummy' cannot result in a constant expression

```

This implies that GLM is not `constexpr` when compiling with NVCC on Windows. At some point I want to use `constexpr`, and we can specify this option in the command line to force MSVC to emit C++ standard information to the macro `__cplusplus`.

```sh

-Xcompiler="/Zc:__cplusplus"

```

Now GLM can use `constexpr` regardless of whether we are compiling from NVCC or MSVC, but compilation fails with the error message (see the beginning of this post).

### Solution

The underlying problem is this function:

https://github.com/g-truc/glm/blob/efec5db081e3aad807d0731e172ac597f6a39447/glm/detail/compute_common.hpp#L27-L36

See [CUDA documentation on `fabsf`](https://docs.nvidia.com/cuda/cuda-math-api/group__CUDA__MATH__SINGLE.html#group__CUDA__MATH__SINGLE_1gb00f8593e1bfb1985526020fbec4e0fc), which is not defined as `constexpr`, so `GLM_CONSTEXPR` should be removed from the function qualifier.

TBH I have no idea why this only happens on Windows, I do use GLM and CUDA on Linux where the compilers define `__cplusplus` properly following the standard, so it should behave the same as having `/Zc:__cplusplus` on MSVC. However I have never come across any error like this before. But in any case, it is correct to remove `constexpr` from this function.