### PR TITLE
Fix docs, incorrect and inconsistent handiness descriptions 

### DIFF
--- a/glm/ext/matrix_clip_space.hpp
+++ b/glm/ext/matrix_clip_space.hpp
@@ -136,7 +136,7 @@ namespace glm
 	GLM_FUNC_DECL mat<4, 4, T, defaultp> ortho(
 		T left, T right, T bottom, T top, T zNear, T zFar);
 
-	/// Creates a left handed frustum matrix.
+	/// Creates a left-handed frustum matrix.
 	/// The near and far clip planes correspond to z normalized device coordinates of 0 and +1 respectively. (Direct3D clip volume definition)
 	///
 	/// @tparam T A floating-point scalar type
@@ -144,7 +144,7 @@ namespace glm
 	GLM_FUNC_DECL mat<4, 4, T, defaultp> frustumLH_ZO(
 		T left, T right, T bottom, T top, T near, T far);
 
-	/// Creates a left handed frustum matrix.
+	/// Creates a left-handed frustum matrix.
 	/// The near and far clip planes correspond to z normalized device coordinates of -1 and +1 respectively. (OpenGL clip volume definition)
 	///
 	/// @tparam T A floating-point scalar type
@@ -152,7 +152,7 @@ namespace glm
 	GLM_FUNC_DECL mat<4, 4, T, defaultp> frustumLH_NO(
 		T left, T right, T bottom, T top, T near, T far);
 
-	/// Creates a right handed frustum matrix.
+	/// Creates a right-handed frustum matrix.
 	/// The near and far clip planes correspond to z normalized device coordinates of 0 and +1 respectively. (Direct3D clip volume definition)
 	///
 	/// @tparam T A floating-point scalar type
@@ -160,7 +160,7 @@ namespace glm
 	GLM_FUNC_DECL mat<4, 4, T, defaultp> frustumRH_ZO(
 		T left, T right, T bottom, T top, T near, T far);
 
-	/// Creates a right handed frustum matrix.
+	/// Creates a right-handed frustum matrix.
 	/// The near and far clip planes correspond to z normalized device coordinates of -1 and +1 respectively. (OpenGL clip volume definition)
 	///
 	/// @tparam T A floating-point scalar type
@@ -184,7 +184,7 @@ namespace glm
 	GLM_FUNC_DECL mat<4, 4, T, defaultp> frustumNO(
 		T left, T right, T bottom, T top, T near, T far);
 
-	/// Creates a left handed frustum matrix.
+	/// Creates a left-handed frustum matrix.
 	/// If GLM_FORCE_DEPTH_ZERO_TO_ONE is defined, the near and far clip planes correspond to z normalized device coordinates of 0 and +1 respectively. (Direct3D clip volume definition)
 	/// Otherwise, the near and far clip planes correspond to z normalized device coordinates of -1 and +1 respectively. (OpenGL clip volume definition)
 	///
@@ -193,7 +193,7 @@ namespace glm
 	GLM_FUNC_DECL mat<4, 4, T, defaultp> frustumLH(
 		T left, T right, T bottom, T top, T near, T far);
 
-	/// Creates a right handed frustum matrix.
+	/// Creates a right-handed frustum matrix.
 	/// If GLM_FORCE_DEPTH_ZERO_TO_ONE is defined, the near and far clip planes correspond to z normalized device coordinates of 0 and +1 respectively. (Direct3D clip volume definition)
 	/// Otherwise, the near and far clip planes correspond to z normalized device coordinates of -1 and +1 respectively. (OpenGL clip volume definition)
 	///
@@ -212,7 +212,7 @@ namespace glm
 		T left, T right, T bottom, T top, T near, T far);
 
 
-	/// Creates a matrix for a right handed, symmetric perspective-view frustum.
+	/// Creates a matrix for a right-handed, symmetric perspective-view frustum.
 	/// The near and far clip planes correspond to z normalized device coordinates of 0 and +1 respectively. (Direct3D clip volume definition)
 	///
 	/// @param fovy Specifies the field of view angle, in degrees, in the y direction. Expressed in radians.
@@ -225,7 +225,7 @@ namespace glm
 	GLM_FUNC_DECL mat<4, 4, T, defaultp> perspectiveRH_ZO(
 		T fovy, T aspect, T near, T far);
 
-	/// Creates a matrix for a right handed, symmetric perspective-view frustum.
+	/// Creates a matrix for a right-handed, symmetric perspective-view frustum.
 	/// The near and far clip planes correspond to z normalized device coordinates of -1 and +1 respectively. (OpenGL clip volume definition)
 	///
 	/// @param fovy Specifies the field of view angle, in degrees, in the y direction. Expressed in radians.
@@ -238,7 +238,7 @@ namespace glm
 	GLM_FUNC_DECL mat<4, 4, T, defaultp> perspectiveRH_NO(
 		T fovy, T aspect, T near, T far);
 
-	/// Creates a matrix for a left handed, symmetric perspective-view frustum.
+	/// Creates a matrix for a left-handed, symmetric perspective-view frustum.
 	/// The near and far clip planes correspond to z normalized device coordinates of 0 and +1 respectively. (Direct3D clip volume definition)
 	///
 	/// @param fovy Specifies the field of view angle, in degrees, in the y direction. Expressed in radians.
@@ -251,7 +251,7 @@ namespace glm
 	GLM_FUNC_DECL mat<4, 4, T, defaultp> perspectiveLH_ZO(
 		T fovy, T aspect, T near, T far);
 
-	/// Creates a matrix for a left handed, symmetric perspective-view frustum.
+	/// Creates a matrix for a left-handed, symmetric perspective-view frustum.
 	/// The near and far clip planes correspond to z normalized device coordinates of -1 and +1 respectively. (OpenGL clip volume definition)
 	///
 	/// @param fovy Specifies the field of view angle, in degrees, in the y direction. Expressed in radians.
@@ -290,7 +290,7 @@ namespace glm
 	GLM_FUNC_DECL mat<4, 4, T, defaultp> perspectiveNO(
 		T fovy, T aspect, T near, T far);
 
-	/// Creates a matrix for a right handed, symmetric perspective-view frustum.
+	/// Creates a matrix for a right-handed, symmetric perspective-view frustum.
 	/// If GLM_FORCE_DEPTH_ZERO_TO_ONE is defined, the near and far clip planes correspond to z normalized device coordinates of 0 and +1 respectively. (Direct3D clip volume definition)
 	/// Otherwise, the near and far clip planes correspond to z normalized device coordinates of -1 and +1 respectively. (OpenGL clip volume definition)
 	///
@@ -304,7 +304,7 @@ namespace glm
 	GLM_FUNC_DECL mat<4, 4, T, defaultp> perspectiveRH(
 		T fovy, T aspect, T near, T far);
 
-	/// Creates a matrix for a left handed, symmetric perspective-view frustum.
+	/// Creates a matrix for a left-handed, symmetric perspective-view frustum.
 	/// If GLM_FORCE_DEPTH_ZERO_TO_ONE is defined, the near and far clip planes correspond to z normalized device coordinates of 0 and +1 respectively. (Direct3D clip volume definition)
 	/// Otherwise, the near and far clip planes correspond to z normalized device coordinates of -1 and +1 respectively. (OpenGL clip volume definition)
 	///
@@ -416,7 +416,7 @@ namespace glm
 	GLM_FUNC_DECL mat<4, 4, T, defaultp> perspectiveFovNO(
 		T fov, T width, T height, T near, T far);
 
-	/// Builds a right handed perspective projection matrix based on a field of view.
+	/// Builds a right-handed perspective projection matrix based on a field of view.
 	/// If GLM_FORCE_DEPTH_ZERO_TO_ONE is defined, the near and far clip planes correspond to z normalized device coordinates of 0 and +1 respectively. (Direct3D clip volume definition)
 	/// Otherwise, the near and far clip planes correspond to z normalized device coordinates of -1 and +1 respectively. (OpenGL clip volume definition)
 	///
@@ -431,7 +431,7 @@ namespace glm
 	GLM_FUNC_DECL mat<4, 4, T, defaultp> perspectiveFovRH(
 		T fov, T width, T height, T near, T far);
 
-	/// Builds a left handed perspective projection matrix based on a field of view.
+	/// Builds a left-handed perspective projection matrix based on a field of view.
 	/// If GLM_FORCE_DEPTH_ZERO_TO_ONE is defined, the near and far clip planes correspond to z normalized device coordinates of 0 and +1 respectively. (Direct3D clip volume definition)
 	/// Otherwise, the near and far clip planes correspond to z normalized device coordinates of -1 and +1 respectively. (OpenGL clip volume definition)
 	///
@@ -460,7 +460,7 @@ namespace glm
 	GLM_FUNC_DECL mat<4, 4, T, defaultp> perspectiveFov(
 		T fov, T width, T height, T near, T far);
 
-	/// Creates a matrix for a left handed, symmetric perspective-view frustum with far plane at infinite.
+	/// Creates a matrix for a left-handed, symmetric perspective-view frustum with far plane at infinite.
 	///
 	/// @param fovy Specifies the field of view angle, in degrees, in the y direction. Expressed in radians.
 	/// @param aspect Specifies the aspect ratio that determines the field of view in the x direction. The aspect ratio is the ratio of x (width) to y (height).
@@ -471,7 +471,7 @@ namespace glm
 	GLM_FUNC_DECL mat<4, 4, T, defaultp> infinitePerspectiveLH(
 		T fovy, T aspect, T near);
 
-	/// Creates a matrix for a right handed, symmetric perspective-view frustum with far plane at infinite.
+	/// Creates a matrix for a right-handed, symmetric perspective-view frustum with far plane at infinite.
 	///
 	/// @param fovy Specifies the field of view angle, in degrees, in the y direction. Expressed in radians.
 	/// @param aspect Specifies the aspect ratio that determines the field of view in the x direction. The aspect ratio is the ratio of x (width) to y (height).

--- a/glm/ext/matrix_clip_space.hpp
+++ b/glm/ext/matrix_clip_space.hpp
@@ -53,7 +53,7 @@ namespace glm
 	GLM_FUNC_DECL mat<4, 4, T, defaultp> orthoLH_ZO(
 		T left, T right, T bottom, T top, T zNear, T zFar);
 
-	/// Creates a matrix for an orthographic parallel viewing volume using right-handed coordinates.
+	/// Creates a matrix for an orthographic parallel viewing volume using left-handed coordinates.
 	/// The near and far clip planes correspond to z normalized device coordinates of -1 and +1 respectively. (OpenGL clip volume definition)
 	///
 	/// @tparam T A floating-point scalar type
@@ -63,7 +63,7 @@ namespace glm
 	GLM_FUNC_DECL mat<4, 4, T, defaultp> orthoLH_NO(
 		T left, T right, T bottom, T top, T zNear, T zFar);
 
-	/// Creates a matrix for an orthographic parallel viewing volume, using left-handed coordinates.
+	/// Creates a matrix for an orthographic parallel viewing volume, using right-handed coordinates.
 	/// The near and far clip planes correspond to z normalized device coordinates of 0 and +1 respectively. (Direct3D clip volume definition)
 	///
 	/// @tparam T A floating-point scalar type


### PR DESCRIPTION
Just some handiness were swapped.
Since I was already editing the file, decided to apply a common spelling for _left-handed_ and _right-handed_ on the entire file.