### PR TITLE
gcc x64 build warning fix around type casting size_t to int

### DIFF
--- a/glm/detail/func_integer.inl
+++ b/glm/detail/func_integer.inl
@@ -362,7 +362,7 @@ namespace detail
 	{
 		GLM_STATIC_ASSERT(std::numeric_limits<T>::is_integer, "'findMSB' only accept integer values");
 
-		return detail::compute_findMSB_vec<L, T, Q, sizeof(T) * 8>::call(v);
+		return detail::compute_findMSB_vec<L, T, Q, static_cast<int>(sizeof(T) * 8)>::call(v);
 	}
 }//namespace glm
 


### PR DESCRIPTION
I found some warning about type casting inside func_integer.inl around

```
....
template<length_t L, typename T, qualifier Q>
	GLM_FUNC_QUALIFIER vec<L, int, Q> findMSB(vec<L, T, Q> const& v)
	{
		GLM_STATIC_ASSERT(std::numeric_limits<T>::is_integer, "'findMSB' only accept integer values");

		return detail::compute_findMSB_vec<L, T, Q, sizeof(T) * 8>::call(v);
	} 
...
```
**detail::compute_findMSB_vec** template has last parameter of type **int** but type of expression **sizeof(T) * 8** is **size_t** which equals to **unsigned long long** on 64 bit arch... so this way we have warning here

```
/home/user/projects/3dparty/glm/glm/detail/func_integer.inl: In function ‘glm::vec<L, int, Q> glm::findMSB(const glm::vec<L, T, Q>&)’:
/home/user/projects/3dparty/glm/glm/detail/func_integer.inl:365:78: warning: conversion from ‘long unsigned int’ to ‘int’ may change value [-Wconversion]
```

My fix is pretty simple - i just add static_cast to int

```
template<length_t L, typename T, qualifier Q>
GLM_FUNC_QUALIFIER vec<L, int, Q> findMSB(vec<L, T, Q> const& v)
{
	GLM_STATIC_ASSERT(std::numeric_limits<T>::is_integer, "'findMSB' only accept integer values");

	return detail::compute_findMSB_vec<L, T, Q, static_cast<int>(sizeof(T) * 8)>::call(v);
}
```

