### PR TITLE
Apply `static_cast` before calling `detail::mask` in `bitfieldInsert`

### DIFF
--- a/glm/detail/func_integer.inl
+++ b/glm/detail/func_integer.inl
@@ -270,7 +270,7 @@ namespace detail
 	{
 		GLM_STATIC_ASSERT(std::numeric_limits<T>::is_integer, "'bitfieldInsert' only accept integer values");
 
-		T const Mask = static_cast<T>(detail::mask(Bits) << Offset);
+		T const Mask = detail::mask(static_cast<T>(Bits)) << Offset;
 		return (Base & ~Mask) | ((Insert << static_cast<T>(Offset)) & Mask);
 	}
 


### PR DESCRIPTION
I found that `bitfieldInsert` did not work properly for 64 bit integer types. 
This was because `detail::mask` was called with 32-bit integer which is not sufficient for holding a 64 bit mask. 

I swapped the order of the `static_cast` and `detail::mask` calls to ensure that we get a 64-bit mask in case of a 64 bit base.