### PR TITLE
Update cmake version to prevent deprecation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 3.2 FATAL_ERROR)
-cmake_policy(VERSION 3.2)
+cmake_minimum_required(VERSION 3.6 FATAL_ERROR)
+cmake_policy(VERSION 3.6)
 
 
 file(READ "glm/detail/setup.hpp" GLM_SETUP_FILE)


### PR DESCRIPTION
The "latest" cmake (3.27) warns, that cmake 3.5 or lower will soon not be supported anymore. 
I compiled and ran the code with a higher cmake version and it still compiles and runs fine. Feel free to further increase the cmake version if necessary. 