### PR TITLE
fix ray-triangle intersection for small floats

### DIFF
--- a/glm/gtx/intersect.inl
+++ b/glm/gtx/intersect.inl
@@ -45,7 +45,7 @@ namespace glm
 
 		vec<3, T, Q> Perpendicular(0);
 
-		if(det > std::numeric_limits<T>::epsilon())
+		if(det > 0.0f)
 		{
 			// calculate distance from vert0 to ray origin
 			vec<3, T, Q> const dist = orig - vert0;
@@ -63,7 +63,7 @@ namespace glm
 			if((baryPosition.y < static_cast<T>(0)) || ((baryPosition.x + baryPosition.y) > det))
 				return false;
 		}
-		else if(det < -std::numeric_limits<T>::epsilon())
+		else if(det < 0.0f)
 		{
 			// calculate distance from vert0 to ray origin
 			vec<3, T, Q> const dist = orig - vert0;


### PR DESCRIPTION
In case of small floats that are around the zero (+- epsilon), the intersection function always returns false