### PR TITLE
Remove the SYCL hacks

### DIFF
--- a/glm/detail/setup.hpp
+++ b/glm/detail/setup.hpp
@@ -584,48 +584,6 @@
 #endif
 
 ///////////////////////////////////////////////////////////////////////////////////
-// SYCL
-
-#if GLM_COMPILER==GLM_COMPILER_SYCL
-
-#include <CL/sycl.hpp>
-#include <limits>
-
-namespace glm {
-namespace std {
-	// Import SYCL's functions into the namespace glm::std to force their usages.
-	// It's important to use the math built-in function (sin, exp, ...)
-	// of SYCL instead the std ones.
-	using namespace cl::sycl;
-
-	///////////////////////////////////////////////////////////////////////////////
-	// Import some "harmless" std's stuffs used by glm into
-	// the new glm::std namespace.
-	template<typename T>
-	using numeric_limits = ::std::numeric_limits<T>;
-
-	using ::std::size_t;
-
-	using ::std::uint8_t;
-	using ::std::uint16_t;
-	using ::std::uint32_t;
-	using ::std::uint64_t;
-
-	using ::std::int8_t;
-	using ::std::int16_t;
-	using ::std::int32_t;
-	using ::std::int64_t;
-
-	using ::std::make_unsigned;
-	///////////////////////////////////////////////////////////////////////////////
-} //namespace std
-} //namespace glm
-
-#endif
-
-///////////////////////////////////////////////////////////////////////////////////
-
-///////////////////////////////////////////////////////////////////////////////////
 // Length type: all length functions returns a length_t type.
 // When GLM_FORCE_SIZE_T_LENGTH is defined, length_t is a typedef of size_t otherwise
 // length_t is a typedef of int like GLSL defines it.

--- a/glm/simd/platform.h
+++ b/glm/simd/platform.h
@@ -83,9 +83,6 @@
 #define GLM_COMPILER_CUDA90			0x10000004
 #define GLM_COMPILER_CUDA_RTC			0x10000100
 
-// SYCL
-#define GLM_COMPILER_SYCL			0x00300000
-
 // Clang
 #define GLM_COMPILER_CLANG			0x20000000
 #define GLM_COMPILER_CLANG34		0x20000050
@@ -142,10 +139,6 @@
 // HIP
 #elif defined(__HIP__)
 #	define GLM_COMPILER GLM_COMPILER_HIP
-
-// SYCL
-#elif defined(__SYCL_DEVICE_ONLY__)
-#	define GLM_COMPILER GLM_COMPILER_SYCL
 
 // Clang
 #elif defined(__clang__)

--- a/readme.md
+++ b/readme.md
@@ -15,7 +15,6 @@ This library works perfectly with *[OpenGL](https://www.opengl.org)* but it also
 - [*Apple Clang 6.0*](https://developer.apple.com/library/mac/documentation/CompilerTools/Conceptual/LLVMCompilerOverview/index.html) and higher
 - [*Visual C++*](http://www.visualstudio.com/) 2013 and higher
 - [*CUDA*](https://developer.nvidia.com/about-cuda) 9.0 and higher (experimental)
-- [*SYCL*](https://www.khronos.org/sycl/) (experimental: only [ComputeCpp](https://codeplay.com/products/computesuite/computecpp) implementation has been tested).
 - Any C++11 compiler
 
 For more information about *GLM*, please have a look at the [manual](manual.md) and the [API reference documentation](http://glm.g-truc.net/0.9.8/api/index.html).


### PR DESCRIPTION
This reverts PR #914 which introduced a hacky way to replace all `std` namespace maths function calls with `sycl` namespace ones.

Presumably the original intention was to use GLM functions in SYCL device code (e.g. on GPUs) and force it to use the maths implementations optimised for the target device. However, this has been very limited in scope since the start because GLM relies heavily on function pointers which are illegal to use inside SYCL device code. So a lot of GLM cannot be used this way in any case.

The hacky solution shadowing `std` namespace with `glm::std` is problematic in many ways. One was that it required re-introducing all `std` symbols used across GLM codebase back to `glm::std`. The list of these symbols is difficult to maintain over time without extensive CI testing and unsurprisingly it got broken. Any code just including (some of) GLM headers now no longer compiles with SYCL compilers even if GLM is only used on the host side (CPU code).

Remove this hack to allow SYCL programs using GLM on the host side to compile.

The original hack was tested against the ComputeCpp compiler which is now phased out in favour of [Intel's DPC++](https://www.intel.com/content/www/us/en/developer/tools/oneapi/dpc-compiler.html). Remove also the mention of ComputeCpp from README. The statement about "any C++11 compiler" still covers the host code compilation with DPC++.

This PR fixes the compilation and execution of the GLM test suite with the DPC++ SYCL compiler (`icpx`):
```
$ CXX=icpx cmake -DCMAKE_CXX_FLAGS="-fsycl -fno-fast-math" ../glm
$ cmake --build .
$ ctest
```
as well as example programs like:
```
$ cat test.cpp 
#include <glm/glm.hpp>
#include <glm/ext.hpp>
int main(){} 
$ icpx -fsycl -I../glm test.cpp
```