### PR TITLE
Optimize cmake targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,30 +16,58 @@ set(GLM_VERSION ${GLM_VERSION_MAJOR}.${GLM_VERSION_MINOR}.${GLM_VERSION_PATCH}.$
 project(glm VERSION ${GLM_VERSION} LANGUAGES CXX)
 message(STATUS "GLM: Version " ${GLM_VERSION})
 
+set(GLM_IS_MASTER_PROJECT OFF)
+if (${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_CURRENT_SOURCE_DIR})
+	set(GLM_IS_MASTER_PROJECT ON)
+endif()
+
+option(GLM_BUILD_LIBRARY "Build dynamic/static library" ON)
+option(GLM_BUILD_TESTS "Build the test programs" ${GLM_IS_MASTER_PROJECT})
+option(GLM_BUILD_INSTALL "Generate the install target" ${GLM_IS_MASTER_PROJECT})
+
+include(GNUInstallDirs)
+
 add_subdirectory(glm)
-add_library(glm::glm ALIAS glm)
 
-if(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_CURRENT_SOURCE_DIR})
-
-	include(CPack)
-	install(DIRECTORY glm DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} PATTERN "CMakeLists.txt" EXCLUDE)
-	install(EXPORT glm FILE glmConfig.cmake DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/glm NAMESPACE glm::)
-	include(CMakePackageConfigHelpers)
-	write_basic_package_version_file("glmConfigVersion.cmake" COMPATIBILITY AnyNewerVersion)
-	install(FILES ${CMAKE_CURRENT_BINARY_DIR}/glmConfigVersion.cmake DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/glm)
-
+if (GLM_BUILD_TESTS)
 	include(CTest)
-	if(BUILD_TESTING)
-		add_subdirectory(test)
-	endif()
+	add_subdirectory(test)
+endif()
 
-endif(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_CURRENT_SOURCE_DIR})
+if (GLM_BUILD_INSTALL)
+	include(CPack)
 
-if (NOT TARGET uninstall)
-configure_file(cmake/cmake_uninstall.cmake.in
-               cmake_uninstall.cmake IMMEDIATE @ONLY)
+	install(TARGETS glm-header-only glm EXPORT glm)
+	install(
+		DIRECTORY glm
+		DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+		PATTERN "CMakeLists.txt" EXCLUDE
+	)
+	install(
+		EXPORT glm
+		NAMESPACE glm::
+		DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/glm"
+		FILE glmConfig.cmake
+	)
+	include(CMakePackageConfigHelpers)
+	write_basic_package_version_file(
+		"${CMAKE_CURRENT_BINARY_DIR}/glmConfigVersion.cmake"
+		COMPATIBILITY AnyNewerVersion
+	)
+	install(
+		FILES "${CMAKE_CURRENT_BINARY_DIR}/glmConfigVersion.cmake"
+		DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/glm"
+	)
 
-add_custom_target(uninstall
-                  "${CMAKE_COMMAND}" -P
-                  "${CMAKE_BINARY_DIR}/cmake_uninstall.cmake")
+	configure_file(
+		"${CMAKE_CURRENT_SOURCE_DIR}/cmake/cmake_uninstall.cmake.in"
+		"${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake"
+		IMMEDIATE @ONLY
+	)
+
+	add_custom_target(
+		uninstall
+		"${CMAKE_COMMAND}" -P
+		"${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake"
+	)
 endif()

--- a/glm/CMakeLists.txt
+++ b/glm/CMakeLists.txt
@@ -1,6 +1,3 @@
-option(BUILD_SHARED_LIBS "Build shared library" ON)
-option(BUILD_STATIC_LIBS "Build static library" ON)
-
 file(GLOB ROOT_SOURCE *.cpp)
 file(GLOB ROOT_INLINE *.inl)
 file(GLOB ROOT_HEADER *.hpp)
@@ -45,37 +42,28 @@ source_group("SIMD Files" FILES ${SIMD_SOURCE})
 source_group("SIMD Files" FILES ${SIMD_INLINE})
 source_group("SIMD Files" FILES ${SIMD_HEADER})
 
-add_library(glm INTERFACE)
+add_library(glm-header-only INTERFACE)
+add_library(glm::glm-header-only ALIAS glm-header-only)
 
-include(GNUInstallDirs)
-
-target_include_directories(glm INTERFACE
-	$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
-	$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+target_include_directories(glm-header-only INTERFACE
+	"$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>"
+	"$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>"
 )
 
-install(TARGETS glm EXPORT glm)
-
-if(BUILD_STATIC_LIBS)
-add_library(glm_static STATIC ${ROOT_TEXT} ${ROOT_MD} ${ROOT_NAT}
-	${ROOT_SOURCE}    ${ROOT_INLINE}    ${ROOT_HEADER}
-	${CORE_SOURCE}    ${CORE_INLINE}    ${CORE_HEADER}
-	${EXT_SOURCE}     ${EXT_INLINE}     ${EXT_HEADER}
-	${GTC_SOURCE}     ${GTC_INLINE}     ${GTC_HEADER}
-	${GTX_SOURCE}     ${GTX_INLINE}     ${GTX_HEADER}
-	${SIMD_SOURCE}    ${SIMD_INLINE}    ${SIMD_HEADER})
-	target_link_libraries(glm_static PUBLIC glm)
-	add_library(glm::glm_static ALIAS glm_static)
-endif()
-
-if(BUILD_SHARED_LIBS)
-add_library(glm_shared SHARED ${ROOT_TEXT} ${ROOT_MD} ${ROOT_NAT}
-	${ROOT_SOURCE}    ${ROOT_INLINE}    ${ROOT_HEADER}
-	${CORE_SOURCE}    ${CORE_INLINE}    ${CORE_HEADER}
-	${EXT_SOURCE}     ${EXT_INLINE}     ${EXT_HEADER}
-	${GTC_SOURCE}     ${GTC_INLINE}     ${GTC_HEADER}
-	${GTX_SOURCE}     ${GTX_INLINE}     ${GTX_HEADER}
-	${SIMD_SOURCE}    ${SIMD_INLINE}    ${SIMD_HEADER})
-	target_link_libraries(glm_shared PUBLIC glm)
-	add_library(glm::glm_shared ALIAS glm_shared)
+if (GLM_BUILD_LIBRARY)
+	add_library(glm
+		${ROOT_TEXT}      ${ROOT_MD}        ${ROOT_NAT}
+		${ROOT_SOURCE}    ${ROOT_INLINE}    ${ROOT_HEADER}
+		${CORE_SOURCE}    ${CORE_INLINE}    ${CORE_HEADER}
+		${EXT_SOURCE}     ${EXT_INLINE}     ${EXT_HEADER}
+		${GTC_SOURCE}     ${GTC_INLINE}     ${GTC_HEADER}
+		${GTX_SOURCE}     ${GTX_INLINE}     ${GTX_HEADER}
+		${SIMD_SOURCE}    ${SIMD_INLINE}    ${SIMD_HEADER}
+	)
+	add_library(glm::glm ALIAS glm)
+	target_link_libraries(glm PUBLIC glm-header-only)
+else()
+	add_library(glm INTERFACE)
+	add_library(glm::glm ALIAS glm)
+	target_link_libraries(glm INTERFACE glm-header-only)
 endif()

--- a/readme.md
+++ b/readme.md
@@ -49,6 +49,40 @@ glm::mat4 camera(float Translate, glm::vec2 const& Rotate)
 | ------- | ------ |
 | [GitHub actions](https://github.com/g-truc/glm/actions)| [![.github/workflows/ci.yml](https://github.com/g-truc/glm/actions/workflows/ci.yml/badge.svg)](https://github.com/g-truc/glm/actions/workflows/ci.yml)
 
+## Build and Install
+
+```shell
+cd /path/to/glm
+cmake \
+    -DGLM_BUILD_TESTS=OFF \
+    -DBUILD_SHARED_LIBS=OFF \
+    -B build .
+cmake --build build -- all
+cmake --build build -- install
+```
+
+Passing `-DBUILD_SHARED_LIBS=ON` to build shared library
+
+And then in your `CMakeLists.txt`:
+
+```cmake
+find_package(glm CONFIG REQUIRED)
+target_link_libraries(main PRIVATE glm::glm)
+```
+
+If your perfer to use header-only version of GLM
+
+```cmake
+find_package(glm CONFIG REQUIRED)
+target_link_libraries(main PRIVATE glm::glm-header-only)
+```
+
+## Vcpkg
+
+```shell
+vcpkg install glm
+```
+
 ## Release notes
 
 ### [GLM 0.9.9.9](https://github.com/g-truc/glm/releases/tag/0.9.9.9) - 2024-01-XX


### PR DESCRIPTION
Allow the following usage

```cmake
find_package(glm CONFIG REQUIRED)
target_link_libraries(main PRIVATE glm::glm)

# Or use the header-only version
find_package(glm CONFIG REQUIRED)
target_link_libraries(main PRIVATE glm::glm-header-only)
```

Like most header-only library did. Such as `fmt` and `spdlog`.