### PR TITLE
Update manual.md

### DIFF
--- a/manual.md
+++ b/manual.md
@@ -180,7 +180,7 @@ GLM is a header-only library, and thus does not need to be compiled. We can use 
 #include <glm/glm.hpp>
 ```
 
-To extend the feature set supported by GLM and keeping the library as close to GLSL as possible, new features are implemented as extensions that can be included thought a separated header:
+To extend the feature set supported by GLM and keeping the library as close to GLSL as possible, new features are implemented as extensions that can be included through a separate header:
 
 ```cpp
 // Include all GLM core / GLSL features


### PR DESCRIPTION
Fixed spelling errors in part 1.1 of manual:
"thought" to "through"
"separated" to "separate"