### PR TITLE
Fix quat packing XYZW usage (GLM_FORCE_QUAT_DATA_WXYZ and GLM_FORCE_QUAT_DATA_XYZW)

### DIFF
--- a/glm/detail/type_quat.hpp
+++ b/glm/detail/type_quat.hpp
@@ -88,12 +88,7 @@ namespace glm
 		// -- Explicit basic constructors --
 
 		GLM_FUNC_DECL GLM_CONSTEXPR qua(T s, vec<3, T, Q> const& v);
-
-#		ifdef GLM_FORCE_QUAT_DATA_XYZW
-		GLM_FUNC_DECL GLM_CONSTEXPR qua(T x, T y, T z, T w);
-#		else
-		GLM_FUNC_DECL GLM_CONSTEXPR qua(T w, T x, T y, T z);
-#		endif
+		GLM_FUNC_DECL GLM_CONSTEXPR qua(T a, T b, T c, T d);
 
 		GLM_FUNC_DECL static GLM_CONSTEXPR qua<T, Q> wxyz(T w, T x, T y, T z);
 

--- a/glm/detail/type_quat.inl
+++ b/glm/detail/type_quat.inl
@@ -150,12 +150,8 @@ namespace detail
 	{}
 
 	template <typename T, qualifier Q>
-	GLM_CONSTEXPR qua<T, Q> qua<T, Q>::wxyz(T w, T x, T y, T z) {
-#	ifdef GLM_FORCE_QUAT_DATA_XYZW
-		return qua<T, Q>(x, y, z, w);
-#	else
-		return qua<T, Q>(w, x, y, z);
-#	endif
+	GLM_CONSTEXPR qua<T, Q> qua<T, Q>::wxyz(T a, T b, T c, T d) {
+		return qua<T, Q>(a, b, c, d);
 	}
 	
 	// -- Conversion constructors --

--- a/glm/detail/type_quat_simd.inl
+++ b/glm/detail/type_quat_simd.inl
@@ -161,26 +161,7 @@ namespace detail
 	{
 		static vec<4, float, Q> call(qua<float, Q> const& q, vec<4, float, Q> const& v)
 		{
-#			ifdef GLM_FORCE_QUAT_DATA_XYZW
-				__m128 const q_wwww = _mm_shuffle_ps(q.data, q.data, _MM_SHUFFLE(3, 3, 3, 3));
-				__m128 const q_swp0 = _mm_shuffle_ps(q.data, q.data, _MM_SHUFFLE(3, 0, 2, 1));
-				__m128 const q_swp1 = _mm_shuffle_ps(q.data, q.data, _MM_SHUFFLE(3, 1, 0, 2));
-				__m128 const v_swp0 = _mm_shuffle_ps(v.data, v.data, _MM_SHUFFLE(3, 0, 2, 1));
-				__m128 const v_swp1 = _mm_shuffle_ps(v.data, v.data, _MM_SHUFFLE(3, 1, 0, 2));
-
-				__m128 uv      = _mm_sub_ps(_mm_mul_ps(q_swp0, v_swp1), _mm_mul_ps(q_swp1, v_swp0));
-				__m128 uv_swp0 = _mm_shuffle_ps(uv, uv, _MM_SHUFFLE(3, 0, 2, 1));
-				__m128 uv_swp1 = _mm_shuffle_ps(uv, uv, _MM_SHUFFLE(3, 1, 0, 2));
-				__m128 uuv     = _mm_sub_ps(_mm_mul_ps(q_swp0, uv_swp1), _mm_mul_ps(q_swp1, uv_swp0));
-
-				__m128 const two = _mm_set1_ps(2.0f);
-				uv  = _mm_mul_ps(uv, _mm_mul_ps(q_wwww, two));
-				uuv = _mm_mul_ps(uuv, two);
-
-				vec<4, float, Q> Result;
-				Result.data = _mm_add_ps(v.data, _mm_add_ps(uv, uuv));
-				return Result;
-#			else
+#			ifdef GLM_FORCE_QUAT_DATA_WXYZ
 				__m128 const q_wwww = _mm_shuffle_ps(q.data, q.data, _MM_SHUFFLE(0, 0, 0, 0));
 				__m128 const q_swp0 = _mm_shuffle_ps(q.data, q.data, _MM_SHUFFLE(0, 1, 3, 2));
 				__m128 const q_swp1 = _mm_shuffle_ps(q.data, q.data, _MM_SHUFFLE(0, 2, 1, 3));
@@ -194,6 +175,25 @@ namespace detail
 
 				__m128 const two = _mm_set1_ps(2.0f);
 				uv = _mm_mul_ps(uv, _mm_mul_ps(q_wwww, two));
+				uuv = _mm_mul_ps(uuv, two);
+
+				vec<4, float, Q> Result;
+				Result.data = _mm_add_ps(v.data, _mm_add_ps(uv, uuv));
+				return Result;
+#			else
+				__m128 const q_wwww = _mm_shuffle_ps(q.data, q.data, _MM_SHUFFLE(3, 3, 3, 3));
+				__m128 const q_swp0 = _mm_shuffle_ps(q.data, q.data, _MM_SHUFFLE(3, 0, 2, 1));
+				__m128 const q_swp1 = _mm_shuffle_ps(q.data, q.data, _MM_SHUFFLE(3, 1, 0, 2));
+				__m128 const v_swp0 = _mm_shuffle_ps(v.data, v.data, _MM_SHUFFLE(3, 0, 2, 1));
+				__m128 const v_swp1 = _mm_shuffle_ps(v.data, v.data, _MM_SHUFFLE(3, 1, 0, 2));
+
+				__m128 uv      = _mm_sub_ps(_mm_mul_ps(q_swp0, v_swp1), _mm_mul_ps(q_swp1, v_swp0));
+				__m128 uv_swp0 = _mm_shuffle_ps(uv, uv, _MM_SHUFFLE(3, 0, 2, 1));
+				__m128 uv_swp1 = _mm_shuffle_ps(uv, uv, _MM_SHUFFLE(3, 1, 0, 2));
+				__m128 uuv     = _mm_sub_ps(_mm_mul_ps(q_swp0, uv_swp1), _mm_mul_ps(q_swp1, uv_swp0));
+
+				__m128 const two = _mm_set1_ps(2.0f);
+				uv  = _mm_mul_ps(uv, _mm_mul_ps(q_wwww, two));
 				uuv = _mm_mul_ps(uuv, two);
 
 				vec<4, float, Q> Result;

--- a/glm/gtx/matrix_decompose.inl
+++ b/glm/gtx/matrix_decompose.inl
@@ -173,10 +173,10 @@ namespace detail
 			j = Next[i];
 			k = Next[j];
 
-#           ifdef GLM_FORCE_QUAT_DATA_XYZW
-                int off = 0;
-#           else
+#           ifdef GLM_FORCE_QUAT_DATA_WXYZ
                 int off = 1;
+#           else
+                int off = 0;
 #           endif
 
 			root = sqrt(Row[i][i] - Row[j][j] - Row[k][k] + static_cast<T>(1.0));


### PR DESCRIPTION
By default quat used to be:
- data packed as `w, x, y, z`
- constructor as quat(`w, y, y, z`)
- `GLM_FORCE_QUAT_DATA_XYZW` to change the behaviour of both data/ctor

Now by default it's:
- data as `x, y, z, w`
- ctor is still `w, x, y, z`

And there is 2 flags that conflict between each other (`GLM_FORCE_QUAT_DATA_WXYZ` and `GLM_FORCE_QUAT_DATA_XYZW`)
For example decompose doesn't read the correct flag, so you'll get broken decompose for example.

For this PR, I assumed the default needs to be `x, y, z, w`(?) for both data/ctor, so I kept only `GLM_FORCE_QUAT_DATA_WXYZ`