### PR TITLE
Fix quat packing XYZW usage

### DIFF
--- a/glm/detail/type_quat.hpp
+++ b/glm/detail/type_quat.hpp
@@ -89,7 +89,7 @@ namespace glm
 
 		GLM_FUNC_DECL GLM_CONSTEXPR qua(T s, vec<3, T, Q> const& v);
 
-#		ifdef GLM_FORCE_QUAT_DATA_XYZW
+#		ifdef GLM_FORCE_QUAT_CTOR_XYZW
 		GLM_FUNC_DECL GLM_CONSTEXPR qua(T x, T y, T z, T w);
 #		else
 		GLM_FUNC_DECL GLM_CONSTEXPR qua(T w, T x, T y, T z);

--- a/glm/detail/type_quat.inl
+++ b/glm/detail/type_quat.inl
@@ -141,7 +141,11 @@ namespace detail
 	{}
 
 	template <typename T, qualifier Q>
+#		ifdef GLM_FORCE_QUAT_CTOR_XYZW
+	GLM_FUNC_QUALIFIER GLM_CONSTEXPR qua<T, Q>::qua(T _x, T _y, T _z, T _w)
+#		else
 	GLM_FUNC_QUALIFIER GLM_CONSTEXPR qua<T, Q>::qua(T _w, T _x, T _y, T _z)
+#		endif
 #		ifdef GLM_FORCE_QUAT_DATA_WXYZ
 			: w(_w), x(_x), y(_y), z(_z)
 #		else

--- a/glm/detail/type_quat_simd.inl
+++ b/glm/detail/type_quat_simd.inl
@@ -161,26 +161,7 @@ namespace detail
 	{
 		static vec<4, float, Q> call(qua<float, Q> const& q, vec<4, float, Q> const& v)
 		{
-#			ifdef GLM_FORCE_QUAT_DATA_XYZW
-				__m128 const q_wwww = _mm_shuffle_ps(q.data, q.data, _MM_SHUFFLE(3, 3, 3, 3));
-				__m128 const q_swp0 = _mm_shuffle_ps(q.data, q.data, _MM_SHUFFLE(3, 0, 2, 1));
-				__m128 const q_swp1 = _mm_shuffle_ps(q.data, q.data, _MM_SHUFFLE(3, 1, 0, 2));
-				__m128 const v_swp0 = _mm_shuffle_ps(v.data, v.data, _MM_SHUFFLE(3, 0, 2, 1));
-				__m128 const v_swp1 = _mm_shuffle_ps(v.data, v.data, _MM_SHUFFLE(3, 1, 0, 2));
-
-				__m128 uv      = _mm_sub_ps(_mm_mul_ps(q_swp0, v_swp1), _mm_mul_ps(q_swp1, v_swp0));
-				__m128 uv_swp0 = _mm_shuffle_ps(uv, uv, _MM_SHUFFLE(3, 0, 2, 1));
-				__m128 uv_swp1 = _mm_shuffle_ps(uv, uv, _MM_SHUFFLE(3, 1, 0, 2));
-				__m128 uuv     = _mm_sub_ps(_mm_mul_ps(q_swp0, uv_swp1), _mm_mul_ps(q_swp1, uv_swp0));
-
-				__m128 const two = _mm_set1_ps(2.0f);
-				uv  = _mm_mul_ps(uv, _mm_mul_ps(q_wwww, two));
-				uuv = _mm_mul_ps(uuv, two);
-
-				vec<4, float, Q> Result;
-				Result.data = _mm_add_ps(v.data, _mm_add_ps(uv, uuv));
-				return Result;
-#			else
+#			ifdef GLM_FORCE_QUAT_DATA_WXYZ
 				__m128 const q_wwww = _mm_shuffle_ps(q.data, q.data, _MM_SHUFFLE(0, 0, 0, 0));
 				__m128 const q_swp0 = _mm_shuffle_ps(q.data, q.data, _MM_SHUFFLE(0, 1, 3, 2));
 				__m128 const q_swp1 = _mm_shuffle_ps(q.data, q.data, _MM_SHUFFLE(0, 2, 1, 3));
@@ -194,6 +175,25 @@ namespace detail
 
 				__m128 const two = _mm_set1_ps(2.0f);
 				uv = _mm_mul_ps(uv, _mm_mul_ps(q_wwww, two));
+				uuv = _mm_mul_ps(uuv, two);
+
+				vec<4, float, Q> Result;
+				Result.data = _mm_add_ps(v.data, _mm_add_ps(uv, uuv));
+				return Result;
+#			else
+				__m128 const q_wwww = _mm_shuffle_ps(q.data, q.data, _MM_SHUFFLE(3, 3, 3, 3));
+				__m128 const q_swp0 = _mm_shuffle_ps(q.data, q.data, _MM_SHUFFLE(3, 0, 2, 1));
+				__m128 const q_swp1 = _mm_shuffle_ps(q.data, q.data, _MM_SHUFFLE(3, 1, 0, 2));
+				__m128 const v_swp0 = _mm_shuffle_ps(v.data, v.data, _MM_SHUFFLE(3, 0, 2, 1));
+				__m128 const v_swp1 = _mm_shuffle_ps(v.data, v.data, _MM_SHUFFLE(3, 1, 0, 2));
+
+				__m128 uv      = _mm_sub_ps(_mm_mul_ps(q_swp0, v_swp1), _mm_mul_ps(q_swp1, v_swp0));
+				__m128 uv_swp0 = _mm_shuffle_ps(uv, uv, _MM_SHUFFLE(3, 0, 2, 1));
+				__m128 uv_swp1 = _mm_shuffle_ps(uv, uv, _MM_SHUFFLE(3, 1, 0, 2));
+				__m128 uuv     = _mm_sub_ps(_mm_mul_ps(q_swp0, uv_swp1), _mm_mul_ps(q_swp1, uv_swp0));
+
+				__m128 const two = _mm_set1_ps(2.0f);
+				uv  = _mm_mul_ps(uv, _mm_mul_ps(q_wwww, two));
 				uuv = _mm_mul_ps(uuv, two);
 
 				vec<4, float, Q> Result;

--- a/glm/gtx/matrix_decompose.inl
+++ b/glm/gtx/matrix_decompose.inl
@@ -173,10 +173,10 @@ namespace detail
 			j = Next[i];
 			k = Next[j];
 
-#           ifdef GLM_FORCE_QUAT_DATA_XYZW
-                int off = 0;
-#           else
+#           ifdef GLM_FORCE_QUAT_DATA_WXYZ
                 int off = 1;
+#           else
+                int off = 0;
 #           endif
 
 			root = sqrt(Row[i][i] - Row[j][j] - Row[k][k] + static_cast<T>(1.0));


### PR DESCRIPTION
Round number 2 because I'm 100% sure the code is broken at the moment.

I don't care about the default by the way, my code works no matter the packing.
But OK, I'm assuming the default behaviour should be packed as XYZW and ctor as WXYZ (I guess that's the only thing people care, @xiaozhuai, @gottfriedleibniz)

The problems are still there:

- QUAT_DATA_XYZW does nothing right now, see the code in type_quat.inl (and it does nothing in type_quat.hpp)
- If you want to keep QUAT_DATA_XYZW then it should be renamed QUAT_CTOR_XYZW imo (also, do we really want to keep this flag)?
- decompose is 100% broken no matter what, it reads the ctor flag (_XYZW) instead of the packing (_WXYZ)
- same for `type_quat_simd.inl`