### PR TITLE
glm::io operator to modify filler + tweaks

### DIFF
--- a/glm/gtx/io.hpp
+++ b/glm/gtx/io.hpp
@@ -141,6 +141,14 @@ namespace glm
 			GLM_FUNC_DECL explicit delimeter(CTy /* left */, CTy /* right */, CTy /* separator */ = ',');
 		};
 
+		template<typename CTy>
+		struct filler
+		{
+			CTy value[2];
+
+			GLM_FUNC_DECL explicit filler(CTy /* Space */ = ' ', CTy /* Newline */ = '\n');
+		};
+
 		struct order
 		{
 			order_type value;
@@ -163,6 +171,8 @@ namespace glm
 		std::basic_ostream<CTy, CTr>& operator<<(std::basic_ostream<CTy, CTr>&, width const&);
 		template<typename CTy, typename CTr>
 		std::basic_ostream<CTy, CTr>& operator<<(std::basic_ostream<CTy, CTr>&, delimeter<CTy> const&);
+		template<typename CTy, typename CTr>
+		std::basic_ostream<CTy, CTr>& operator<<(std::basic_ostream<CTy, CTr>&, filler<CTy> const&);
 		template<typename CTy, typename CTr>
 		std::basic_ostream<CTy, CTr>& operator<<(std::basic_ostream<CTy, CTr>&, order const&);
 	}//namespace io

--- a/glm/gtx/io.hpp
+++ b/glm/gtx/io.hpp
@@ -123,14 +123,14 @@ namespace glm
 		{
 			unsigned value;
 
-			GLM_FUNC_DECL explicit precision(unsigned);
+			GLM_FUNC_DECL explicit precision(unsigned = 3);
 		};
 
 		struct width
 		{
 			unsigned value;
 
-			GLM_FUNC_DECL explicit width(unsigned);
+			GLM_FUNC_DECL explicit width(unsigned = 0);
 		};
 
 		template<typename CTy>
@@ -138,7 +138,7 @@ namespace glm
 		{
 			CTy value[3];
 
-			GLM_FUNC_DECL explicit delimeter(CTy /* left */, CTy /* right */, CTy /* separator */ = ',');
+			GLM_FUNC_DECL explicit delimeter(CTy /* left */ = "[", CTy /* right */ = "]", CTy /* separator */ = ',');
 		};
 
 		template<typename CTy>
@@ -146,14 +146,14 @@ namespace glm
 		{
 			CTy value[2];
 
-			GLM_FUNC_DECL explicit filler(CTy /* Space */ = ' ', CTy /* Newline */ = '\n');
+			GLM_FUNC_DECL explicit filler(CTy /* space */ = ' ', CTy /* newline */ = '\n');
 		};
 
 		struct order
 		{
 			order_type value;
 
-			GLM_FUNC_DECL explicit order(order_type);
+			GLM_FUNC_DECL explicit order(order_type = column_major);
 		};
 
 		// functions, inlined (inline)

--- a/glm/gtx/io.inl
+++ b/glm/gtx/io.inl
@@ -95,6 +95,14 @@ namespace io
 		value[2] = c;
 	}
 
+    template<typename CTy>
+    GLM_FUNC_QUALIFIER filler<CTy>::filler(CTy a, CTy b)
+        : value()
+    {
+        value[0] = a;
+        value[1] = b;
+    }
+
 	GLM_FUNC_QUALIFIER order::order(order_type a)
 		: value(a)
 	{}
@@ -144,6 +152,17 @@ namespace io
 		fmt.delim_left  = a.value[0];
 		fmt.delim_right = a.value[1];
 		fmt.separator   = a.value[2];
+
+		return os;
+	}
+
+	template<typename CTy, typename CTr>
+	GLM_FUNC_QUALIFIER  std::basic_ostream<CTy, CTr>& operator<<(std::basic_ostream<CTy, CTr>& os, filler<CTy> const& a)
+	{
+		format_punct<CTy> & fmt(const_cast<format_punct<CTy>&>(get_facet<format_punct<CTy> >(os)));
+
+		fmt.space  = a.value[0];
+		fmt.newline = a.value[1];
 
 		return os;
 	}

--- a/glm/gtx/io.inl
+++ b/glm/gtx/io.inl
@@ -266,7 +266,7 @@ namespace detail
 
 			if(fmt.formatted)
 			{
-				os << fmt.newline << fmt.delim_left;
+				os << /*fmt.newline <<*/ fmt.delim_left;
 
 				switch(fmt.order)
 				{
@@ -409,7 +409,7 @@ namespace detail
 
 			if(fmt.formatted)
 			{
-				os << fmt.newline << fmt.delim_left;
+				os << /*fmt.newline <<*/ fmt.delim_left;
 
 				switch(fmt.order)
 				{

--- a/glm/gtx/io.inl
+++ b/glm/gtx/io.inl
@@ -21,7 +21,7 @@ namespace io
 		: std::locale::facet(a)
 		, formatted(true)
 		, precision(3)
-		, width(1 + 4 + 1 + precision)
+		, width(4 + 1 + precision)
 		, separator(',')
 		, delim_left('[')
 		, delim_right(']')

--- a/glm/gtx/io.inl
+++ b/glm/gtx/io.inl
@@ -199,7 +199,7 @@ namespace detail
 				{
 					os << std::setw(static_cast<int>(fmt.width)) << a[i];
 					if(components-1 != i)
-						os << fmt.separator;
+						os << fmt.separator << fmt.space;
 				}
 
 				os << fmt.delim_right;


### PR DESCRIPTION
Hello!

I was using `glm::io` and found myself wanting to print matrices in a single line easily.
I saw very convinient operators for easily changing `precision`, `width`... but none for `space` and `newline`, hence this PR commits:

1. Added an operator to edit `space` and `newline` with a packed struct named `filler` (related to `std::setfill`), following the same structure as the struct `delimeter`.
2. Added default arguments for the structs, similar to `delimeter` optional last argument. Seems pretty useful to have them in order to restore the default behavior.
    * I set `precision=3` like `format_punct` does, but `width` depends on `precision` so I used `0 (std default)`. Would you prefer to stimate a default width like `format_punct` (e.g. supposing `precision=3` so `4+1+precision=8`)?
3. Skip initial newline when printing matrices. IMO seems more logical to let the end user do it, in my case I need this to be able to print matrices in a single line.
    * _Introduces differences with previous outputs!_ Quite noticeable, but consistent with vector behavior.
4. Add an space after separator insertion. This allows to have width=0 and keep an space between components for better visualization.
     * _Introduces differences with previous outputs!_ Potentially makes current components a single space wider.
5. Reduce initial width to compensate the introduced space after separator. This cancels out differences with previous default usage.

> Example of how to print a matrix in a single line (substitute newline for `','`):

```c++
#include "glm/gtx/io.hpp"
...
glm::mat4 m(1);
std::cout << " m = " << glm::io::width() << glm::io::precision(2) << glm::io::filler<char>(' ', ',') << m << std::endl;
// m = [[1.00, -0.00, 0.00, -0.00], [-0.00, 1.00, -0.00, 0.00], [0.00, -0.00, 1.00, -0.00], [-0.00, 0.00, -0.00, 1.00]]
```

I split the commits for simpler discussion/review/changes, let me know what you think.
I can squash them all in the end or whatever you prefer.

Regards!

