### PR TITLE
Fix compare that is always true

### DIFF
--- a/glm/gtx/string_cast.inl
+++ b/glm/gtx/string_cast.inl
@@ -22,7 +22,7 @@ namespace detail
 		std::size_t const STRING_BUFFER(4096);
 
 		assert(message != NULL);
-		assert(strlen(message) >= 0 && strlen(message) < STRING_BUFFER);
+		assert(strlen(message) < STRING_BUFFER);
 
 		char buffer[STRING_BUFFER];
 		va_list list;


### PR DESCRIPTION
strlen returns size_t which is unsigned so it is always >= 0. If the intention was that strlen(message) > 0 then the fix is something else.

Error with gcc 11.4.0:
`glm-src/glm/gtx/string_cast.inl:25:40: error: comparison of unsigned expression in ‘>= 0’ is always true [-Werror=type-limits]`
