### PR TITLE
Avoid warnings about comparisons being always true

### DIFF
--- a/glm/detail/setup.hpp
+++ b/glm/detail/setup.hpp
@@ -614,8 +614,10 @@
 
 #ifdef GLM_FORCE_SIZE_T_LENGTH
 #	define GLM_CONFIG_LENGTH_TYPE		GLM_LENGTH_SIZE_T
+#	define GLM_ASSERT_LENGTH(l, max) (assert ((l) < (max)))
 #else
 #	define GLM_CONFIG_LENGTH_TYPE		GLM_LENGTH_INT
+#	define GLM_ASSERT_LENGTH(l, max) (assert ((l) >= 0 && (l) < (max)))
 #endif
 
 namespace glm

--- a/glm/detail/type_mat2x2.inl
+++ b/glm/detail/type_mat2x2.inl
@@ -219,14 +219,14 @@ namespace glm
 	template<typename T, qualifier Q>
 	GLM_FUNC_QUALIFIER GLM_CONSTEXPR typename mat<2, 2, T, Q>::col_type& mat<2, 2, T, Q>::operator[](typename mat<2, 2, T, Q>::length_type i) GLM_NOEXCEPT
 	{
-		assert(i < this->length());
+		GLM_ASSERT_LENGTH(i, this->length());
 		return this->value[i];
 	}
 
 	template<typename T, qualifier Q>
 	GLM_FUNC_QUALIFIER GLM_CONSTEXPR typename mat<2, 2, T, Q>::col_type const& mat<2, 2, T, Q>::operator[](typename mat<2, 2, T, Q>::length_type i) const GLM_NOEXCEPT
 	{
-		assert(i < this->length());
+		GLM_ASSERT_LENGTH(i, this->length());
 		return this->value[i];
 	}
 

--- a/glm/detail/type_mat2x3.inl
+++ b/glm/detail/type_mat2x3.inl
@@ -219,14 +219,14 @@ namespace glm
 	template<typename T, qualifier Q>
 	GLM_FUNC_QUALIFIER GLM_CONSTEXPR typename mat<2, 3, T, Q>::col_type & mat<2, 3, T, Q>::operator[](typename mat<2, 3, T, Q>::length_type i) GLM_NOEXCEPT
 	{
-		assert(i < this->length());
+		GLM_ASSERT_LENGTH(i, this->length());
 		return this->value[i];
 	}
 
 	template<typename T, qualifier Q>
 	GLM_FUNC_QUALIFIER GLM_CONSTEXPR typename mat<2, 3, T, Q>::col_type const& mat<2, 3, T, Q>::operator[](typename mat<2, 3, T, Q>::length_type i) const GLM_NOEXCEPT
 	{
-		assert(i < this->length());
+		GLM_ASSERT_LENGTH(i, this->length());
 		return this->value[i];
 	}
 

--- a/glm/detail/type_mat2x4.inl
+++ b/glm/detail/type_mat2x4.inl
@@ -221,14 +221,14 @@ namespace glm
 	template<typename T, qualifier Q>
 	GLM_FUNC_QUALIFIER GLM_CONSTEXPR typename mat<2, 4, T, Q>::col_type & mat<2, 4, T, Q>::operator[](typename mat<2, 4, T, Q>::length_type i) GLM_NOEXCEPT
 	{
-		assert(i < this->length());
+		GLM_ASSERT_LENGTH(i, this->length());
 		return this->value[i];
 	}
 
 	template<typename T, qualifier Q>
 	GLM_FUNC_QUALIFIER GLM_CONSTEXPR typename mat<2, 4, T, Q>::col_type const& mat<2, 4, T, Q>::operator[](typename mat<2, 4, T, Q>::length_type i) const GLM_NOEXCEPT
 	{
-		assert(i < this->length());
+		GLM_ASSERT_LENGTH(i, this->length());
 		return this->value[i];
 	}
 

--- a/glm/detail/type_mat3x2.inl
+++ b/glm/detail/type_mat3x2.inl
@@ -238,14 +238,14 @@ namespace glm
 	template<typename T, qualifier Q>
 	GLM_FUNC_QUALIFIER GLM_CONSTEXPR typename mat<3, 2, T, Q>::col_type & mat<3, 2, T, Q>::operator[](typename mat<3, 2, T, Q>::length_type i) GLM_NOEXCEPT
 	{
-		assert(i < this->length());
+		GLM_ASSERT_LENGTH(i, this->length());
 		return this->value[i];
 	}
 
 	template<typename T, qualifier Q>
 	GLM_FUNC_QUALIFIER GLM_CONSTEXPR typename mat<3, 2, T, Q>::col_type const& mat<3, 2, T, Q>::operator[](typename mat<3, 2, T, Q>::length_type i) const GLM_NOEXCEPT
 	{
-		assert(i < this->length());
+		GLM_ASSERT_LENGTH(i, this->length());
 		return this->value[i];
 	}
 

--- a/glm/detail/type_mat3x3.inl
+++ b/glm/detail/type_mat3x3.inl
@@ -240,14 +240,14 @@ namespace glm
 	template<typename T, qualifier Q>
 	GLM_FUNC_QUALIFIER GLM_CONSTEXPR typename mat<3, 3, T, Q>::col_type & mat<3, 3, T, Q>::operator[](typename mat<3, 3, T, Q>::length_type i) GLM_NOEXCEPT
 	{
-		assert(i < this->length());
+		GLM_ASSERT_LENGTH(i, this->length());
 		return this->value[i];
 	}
 
 	template<typename T, qualifier Q>
 	GLM_FUNC_QUALIFIER GLM_CONSTEXPR typename mat<3, 3, T, Q>::col_type const& mat<3, 3, T, Q>::operator[](typename mat<3, 3, T, Q>::length_type i) const GLM_NOEXCEPT
 	{
-		assert(i < this->length());
+		GLM_ASSERT_LENGTH(i, this->length());
 		return this->value[i];
 	}
 

--- a/glm/detail/type_mat3x4.inl
+++ b/glm/detail/type_mat3x4.inl
@@ -244,14 +244,14 @@ namespace glm
 	template<typename T, qualifier Q>
 	GLM_FUNC_QUALIFIER GLM_CONSTEXPR typename mat<3, 4, T, Q>::col_type & mat<3, 4, T, Q>::operator[](typename mat<3, 4, T, Q>::length_type i) GLM_NOEXCEPT
 	{
-		assert(i < this->length());
+		GLM_ASSERT_LENGTH(i, this->length());
 		return this->value[i];
 	}
 
 	template<typename T, qualifier Q>
 	GLM_FUNC_QUALIFIER GLM_CONSTEXPR typename mat<3, 4, T, Q>::col_type const& mat<3, 4, T, Q>::operator[](typename mat<3, 4, T, Q>::length_type i) const GLM_NOEXCEPT
 	{
-		assert(i < this->length());
+		GLM_ASSERT_LENGTH(i, this->length());
 		return this->value[i];
 	}
 

--- a/glm/detail/type_mat4x2.inl
+++ b/glm/detail/type_mat4x2.inl
@@ -257,14 +257,14 @@ namespace glm
 	template<typename T, qualifier Q>
 	GLM_FUNC_QUALIFIER GLM_CONSTEXPR typename mat<4, 2, T, Q>::col_type & mat<4, 2, T, Q>::operator[](typename mat<4, 2, T, Q>::length_type i) GLM_NOEXCEPT
 	{
-		assert(i < this->length());
+		GLM_ASSERT_LENGTH(i, this->length());
 		return this->value[i];
 	}
 
 	template<typename T, qualifier Q>
 	GLM_FUNC_QUALIFIER GLM_CONSTEXPR typename mat<4, 2, T, Q>::col_type const& mat<4, 2, T, Q>::operator[](typename mat<4, 2, T, Q>::length_type i) const GLM_NOEXCEPT
 	{
-		assert(i < this->length());
+		GLM_ASSERT_LENGTH(i, this->length());
 		return this->value[i];
 	}
 

--- a/glm/detail/type_mat4x3.inl
+++ b/glm/detail/type_mat4x3.inl
@@ -257,14 +257,14 @@ namespace glm
 	template<typename T, qualifier Q>
 	GLM_FUNC_QUALIFIER GLM_CONSTEXPR typename mat<4, 3, T, Q>::col_type & mat<4, 3, T, Q>::operator[](typename mat<4, 3, T, Q>::length_type i) GLM_NOEXCEPT
 	{
-		assert(i < this->length());
+		GLM_ASSERT_LENGTH(i, this->length());
 		return this->value[i];
 	}
 
 	template<typename T, qualifier Q>
 	GLM_FUNC_QUALIFIER GLM_CONSTEXPR typename mat<4, 3, T, Q>::col_type const& mat<4, 3, T, Q>::operator[](typename mat<4, 3, T, Q>::length_type i) const GLM_NOEXCEPT
 	{
-		assert(i < this->length());
+		GLM_ASSERT_LENGTH(i, this->length());
 		return this->value[i];
 	}
 

--- a/glm/detail/type_mat4x4.inl
+++ b/glm/detail/type_mat4x4.inl
@@ -288,14 +288,14 @@ namespace glm
 	template<typename T, qualifier Q>
 	GLM_FUNC_QUALIFIER GLM_CONSTEXPR typename mat<4, 4, T, Q>::col_type & mat<4, 4, T, Q>::operator[](typename mat<4, 4, T, Q>::length_type i) GLM_NOEXCEPT
 	{
-		assert(i < this->length());
+		GLM_ASSERT_LENGTH(i, this->length());
 		return this->value[i];
 	}
 
 	template<typename T, qualifier Q>
 	GLM_FUNC_QUALIFIER GLM_CONSTEXPR typename mat<4, 4, T, Q>::col_type const& mat<4, 4, T, Q>::operator[](typename mat<4, 4, T, Q>::length_type i) const GLM_NOEXCEPT
 	{
-		assert(i < this->length());
+		GLM_ASSERT_LENGTH(i, this->length());
 		return this->value[i];
 	}
 

--- a/glm/detail/type_quat.inl
+++ b/glm/detail/type_quat.inl
@@ -74,7 +74,7 @@ namespace detail
 	template<typename T, qualifier Q>
 	GLM_FUNC_QUALIFIER GLM_CONSTEXPR T & qua<T, Q>::operator[](typename qua<T, Q>::length_type i)
 	{
-		assert(i >= 0 && i < this->length());
+		GLM_ASSERT_LENGTH(i, this->length());
 #		ifdef GLM_FORCE_QUAT_DATA_WXYZ
 			return (&w)[i];
 #		else
@@ -85,7 +85,7 @@ namespace detail
 	template<typename T, qualifier Q>
 	GLM_FUNC_QUALIFIER GLM_CONSTEXPR T const& qua<T, Q>::operator[](typename qua<T, Q>::length_type i) const
 	{
-		assert(i >= 0 && i < this->length());
+		GLM_ASSERT_LENGTH(i, this->length());
 #		ifdef GLM_FORCE_QUAT_DATA_WXYZ
 			return (&w)[i];
 #		else

--- a/glm/detail/type_vec2.inl
+++ b/glm/detail/type_vec2.inl
@@ -105,7 +105,7 @@ namespace glm
 	template<typename T, qualifier Q>
 	GLM_FUNC_QUALIFIER GLM_CONSTEXPR T & vec<2, T, Q>::operator[](typename vec<2, T, Q>::length_type i)
 	{
-		assert(i >= 0 && i < this->length());
+		GLM_ASSERT_LENGTH(i, this->length());
 		switch(i)
 		{
 		default:
@@ -119,7 +119,7 @@ namespace glm
 	template<typename T, qualifier Q>
 	GLM_FUNC_QUALIFIER GLM_CONSTEXPR T const& vec<2, T, Q>::operator[](typename vec<2, T, Q>::length_type i) const
 	{
-		assert(i >= 0 && i < this->length());
+		GLM_ASSERT_LENGTH(i, this->length());
 		switch(i)
 		{
 		default:

--- a/glm/detail/type_vec3.inl
+++ b/glm/detail/type_vec3.inl
@@ -169,7 +169,7 @@ namespace glm
 	template<typename T, qualifier Q>
 	GLM_FUNC_QUALIFIER GLM_CONSTEXPR T & vec<3, T, Q>::operator[](typename vec<3, T, Q>::length_type i)
 	{
-		assert(i >= 0 && i < this->length());
+		GLM_ASSERT_LENGTH(i, this->length());
 		switch(i)
 		{
 		default:
@@ -185,7 +185,7 @@ namespace glm
 	template<typename T, qualifier Q>
 	GLM_FUNC_QUALIFIER GLM_CONSTEXPR T const& vec<3, T, Q>::operator[](typename vec<3, T, Q>::length_type i) const
 	{
-		assert(i >= 0 && i < this->length());
+		GLM_ASSERT_LENGTH(i, this->length());
 		switch(i)
 		{
 		default:

--- a/glm/detail/type_vec4.inl
+++ b/glm/detail/type_vec4.inl
@@ -478,7 +478,7 @@ namespace detail
 	template<typename T, qualifier Q>
 	GLM_FUNC_QUALIFIER GLM_CONSTEXPR T& vec<4, T, Q>::operator[](typename vec<4, T, Q>::length_type i)
 	{
-		assert(i >= 0 && i < this->length());
+		GLM_ASSERT_LENGTH(i, this->length());
 		switch(i)
 		{
 		default:
@@ -496,7 +496,7 @@ namespace detail
 	template<typename T, qualifier Q>
 	GLM_FUNC_QUALIFIER GLM_CONSTEXPR T const& vec<4, T, Q>::operator[](typename vec<4, T, Q>::length_type i) const
 	{
-		assert(i >= 0 && i < this->length());
+		GLM_ASSERT_LENGTH(i, this->length());
 		switch(i)
 		{
 		default:


### PR DESCRIPTION
Depending on the signedness of length_t type we may either get warnings comparison of unsigned expression in ‘>= 0’ being always true or do insufficient checking by not checking if index is not negative.

Hide the index checking behind a macro that check the index properly.

This hides warnings like the following (I used `#define GLM_FORCE_SIZE_T_LENGTH`):

```
In file included from /usr/include/c++/13/cassert:44,
                 from ../subprojects/glm-1.0.0/glm/gtc/.././ext/../detail/setup.hpp:3,
                 from ../subprojects/glm-1.0.0/glm/gtc/.././ext/../detail/qualifier.hpp:3,
                 from ../subprojects/glm-1.0.0/glm/gtc/.././ext/../detail/type_vec4.hpp:6,
                 from ../subprojects/glm-1.0.0/glm/gtc/.././ext/../detail/type_mat4x4.hpp:6,
                 from ../subprojects/glm-1.0.0/glm/gtc/.././ext/matrix_double4x4.hpp:5,
                 from ../subprojects/glm-1.0.0/glm/gtc/../mat4x4.hpp:5,
                 from ../subprojects/glm-1.0.0/glm/gtc/matrix_transform.hpp:24,
                 from ../bin/next/main.cc:19:
../subprojects/glm-1.0.0/glm/gtc/.././ext/../detail/type_vec4.inl: In instantiation of ‘constexpr T& glm::vec<4, T, Q>::operator[](length_type) [with T = float; glm::qualifier Q = glm::packed_highp; length_type = long unsigned int]’:
../subprojects/glm-1.0.0/glm/gtc/../ext/matrix_clip_space.inl:7:12:   required from ‘glm::mat<4, 4, T, glm::packed_highp> glm::ortho(T, T, T, T) [with T = float]’
../bin/next/main.cc:643:34:   required from here
../subprojects/glm-1.0.0/glm/gtc/.././ext/../detail/type_vec4.inl:481:26: warning: comparison of unsigned expression in ‘>= 0’ is always true [-Wtype-limits]
  481 |                 assert(i >= 0 && i < this->length());
      |                        ~~^~~~
../subprojects/glm-1.0.0/glm/gtc/.././ext/../detail/type_vec4.inl: In instantiation of ‘constexpr const T& glm::vec<4, T, Q>::operator[](length_type) const [with T = float; glm::qualifier Q = glm::packed_highp; length_type = long unsigned int]’:
../subprojects/glm-1.0.0/glm/gtc/.././ext/../detail/type_mat4x4.inl:561:50:   required from ‘constexpr typename glm::mat<4, 4, T, Q>::col_type glm::operator*(const mat<4, 4, T, Q>&, const typename mat<4, 4, T, Q>::row_type&) [with T = float; qualifier Q = glm::packed_highp; typename mat<4, 4, T, Q>::col_type = vec<4, float, glm::packed_highp>; typename mat<4, 4, T, Q>::row_type = vec<4, float, glm::packed_highp>]’
../bin/next/main.cc:700:32:   required from here
../subprojects/glm-1.0.0/glm/gtc/.././ext/../detail/type_vec4.inl:499:26: warning: comparison of unsigned expression in ‘>= 0’ is always true [-Wtype-limits]
  499 |                 assert(i >= 0 && i < this->length());
      |                        ~~^~~~
```