### PR TITLE
Update number_precision.hpp - number_precision.inl has been deleted

### DIFF
--- a/glm/gtx/number_precision.hpp
+++ b/glm/gtx/number_precision.hpp
@@ -42,4 +42,3 @@ namespace glm{
 	/// @}
 }//namespace glm
 
-#include "number_precision.inl"


### PR DESCRIPTION
number_precision.inl has been deleted as it was empty. The include in number_precision.hpp causes an error for anything using it