### PR TITLE
Update hash.hpp to detect msvc

### DIFF
--- a/glm/gtx/hash.hpp
+++ b/glm/gtx/hash.hpp
@@ -40,8 +40,18 @@
 #include "../mat4x3.hpp"
 #include "../mat4x4.hpp"
 
-#if __cplusplus < 201103L
-#pragma message("GLM_GTX_hash requires C++11 standard library support")
+#if defined(_MSC_VER)
+    // MSVC uses _MSVC_LANG instead of __cplusplus
+    #if _MSVC_LANG < 201103L
+        #pragma message("GLM_GTX_hash requires C++11 standard library support")
+    #endif
+#elif defined(__GNUC__) || defined(__clang__)
+    // GNU and Clang use __cplusplus
+    #if __cplusplus < 201103L
+        #pragma message("GLM_GTX_hash requires C++11 standard library support")
+    #endif
+#else
+    #error "Unknown compiler"
 #endif
 
 #if GLM_LANG & GLM_LANG_CXX11


### PR DESCRIPTION
this causes errors when building on windows with cl:
```
[proc] Executing command: "C:\Program Files\CMake\bin\cmake.EXE" --build c:/open/Github/Vulk/build --config Debug --target PipelineBuilder -j 66 --
[build] MSBuild version 17.8.3+195e7f5a3 for .NET Framework
[build] 
[build]   Checking File Globs
[build]   Vulk.cpp
[build]   GLM_GTX_hash requires C++11 standard library support
[build]   VulkActor.cpp
[build]   GLM_GTX_hash requires C++11 standard library support
[build]   VulkCamera.cpp
[build]   GLM_GTX_hash requires C++11 standard library support
...
```

This change appears to fix it:
```
[proc] Executing command: "C:\Program Files\CMake\bin\cmake.EXE" --build c:/open/Github/Vulk/build --config Debug --target PipelineBuilder -j 66 --
[build] MSBuild version 17.8.3+195e7f5a3 for .NET Framework
[build] 
[build]   Checking File Globs
[build]   Vulk.cpp
[build]   VulkActor.cpp
[build]   VulkCamera.cpp
```

check out https://github.com/abrady/Vulk if you want to repro.