### PR TITLE
Fix -Wall Compilation #1276

### DIFF
--- a/glm/gtc/bitfield.inl
+++ b/glm/gtc/bitfield.inl
@@ -231,7 +231,7 @@ namespace detail
 	{
 		GLM_STATIC_ASSERT(std::numeric_limits<genIUType>::is_integer, "'mask' accepts only integer values");
 
-		return Bits >= sizeof(genIUType) * 8 ? ~static_cast<genIUType>(0) : (static_cast<genIUType>(1) << Bits) - static_cast<genIUType>(1);
+		return Bits >= static_cast<genIUType>(sizeof(genIUType) * 8) ? ~static_cast<genIUType>(0) : (static_cast<genIUType>(1) << Bits) - static_cast<genIUType>(1);
 	}
 
 #if GLM_COMPILER & GLM_COMPILER_CLANG

--- a/glm/gtc/packing.inl
+++ b/glm/gtc/packing.inl
@@ -7,6 +7,7 @@
 #include "../vec3.hpp"
 #include "../vec4.hpp"
 #include "../detail/type_half.hpp"
+#include "type_ptr.hpp"
 #include <cstring>
 #include <limits>
 
@@ -295,14 +296,14 @@ namespace detail
 		{
 			int16 const Unpack(detail::toFloat16(v.x));
 			u16vec1 Packed;
-			memcpy(&Packed, &Unpack, sizeof(Packed));
+			memcpy(value_ptr(Packed), &Unpack, sizeof(Packed));
 			return Packed;
 		}
 
 		GLM_FUNC_QUALIFIER static vec<1, float, Q> unpack(vec<1, uint16, Q> const& v)
 		{
 			i16vec1 Unpack;
-			memcpy(&Unpack, &v, sizeof(Unpack));
+			memcpy(value_ptr(Unpack), value_ptr(v), sizeof(Unpack));
 			return vec<1, float, Q>(detail::toFloat32(v.x));
 		}
 	};
@@ -314,14 +315,14 @@ namespace detail
 		{
 			vec<2, int16, Q> const Unpack(detail::toFloat16(v.x), detail::toFloat16(v.y));
 			u16vec2 Packed;
-			memcpy(&Packed, &Unpack, sizeof(Packed));
+			memcpy(value_ptr(Packed), value_ptr(Unpack), sizeof(Packed));
 			return Packed;
 		}
 
 		GLM_FUNC_QUALIFIER static vec<2, float, Q> unpack(vec<2, uint16, Q> const& v)
 		{
 			i16vec2 Unpack;
-			memcpy(&Unpack, &v, sizeof(Unpack));
+			memcpy(value_ptr(Unpack), value_ptr(v), sizeof(Unpack));
 			return vec<2, float, Q>(detail::toFloat32(v.x), detail::toFloat32(v.y));
 		}
 	};
@@ -333,14 +334,14 @@ namespace detail
 		{
 			vec<3, int16, Q> const Unpack(detail::toFloat16(v.x), detail::toFloat16(v.y), detail::toFloat16(v.z));
 			u16vec3 Packed;
-			memcpy(&Packed, &Unpack, sizeof(Packed));
+			memcpy(value_ptr(Packed), value_ptr(Unpack), sizeof(Packed));
 			return Packed;
 		}
 
 		GLM_FUNC_QUALIFIER static vec<3, float, Q> unpack(vec<3, uint16, Q> const& v)
 		{
 			i16vec3 Unpack;
-			memcpy(&Unpack, &v, sizeof(Unpack));
+			memcpy(value_ptr(Unpack), &v, sizeof(Unpack));
 			return vec<3, float, Q>(detail::toFloat32(v.x), detail::toFloat32(v.y), detail::toFloat32(v.z));
 		}
 	};
@@ -352,14 +353,14 @@ namespace detail
 		{
 			vec<4, int16, Q> const Unpack(detail::toFloat16(v.x), detail::toFloat16(v.y), detail::toFloat16(v.z), detail::toFloat16(v.w));
 			u16vec4 Packed;
-			memcpy(&Packed, &Unpack, sizeof(Packed));
+			memcpy(value_ptr(Packed), value_ptr(Unpack), sizeof(Packed));
 			return Packed;
 		}
 
 		GLM_FUNC_QUALIFIER static vec<4, float, Q> unpack(vec<4, uint16, Q> const& v)
 		{
 			i16vec4 Unpack;
-			memcpy(&Unpack, &v, sizeof(Unpack));
+			memcpy(value_ptr(Unpack), &v, sizeof(Unpack));
 			return vec<4, float, Q>(detail::toFloat32(Unpack.x), detail::toFloat32(Unpack.y), detail::toFloat32(Unpack.z), detail::toFloat32(Unpack.w));
 		}
 	};
@@ -388,7 +389,7 @@ namespace detail
 	GLM_FUNC_QUALIFIER vec2 unpackUnorm2x8(uint16 p)
 	{
 		u8vec2 Unpack;
-		memcpy(&Unpack, &p, sizeof(Unpack));
+		memcpy(value_ptr(Unpack), &p, sizeof(Unpack));
 		return vec2(Unpack) * float(0.0039215686274509803921568627451); // 1 / 255
 	}
 
@@ -413,14 +414,14 @@ namespace detail
 	{
 		i8vec2 const Topack(round(clamp(v, -1.0f, 1.0f) * 127.0f));
 		uint16 Packed = 0;
-		memcpy(&Packed, &Topack, sizeof(Packed));
+		memcpy(&Packed, value_ptr(Topack), sizeof(Packed));
 		return Packed;
 	}
 
 	GLM_FUNC_QUALIFIER vec2 unpackSnorm2x8(uint16 p)
 	{
 		i8vec2 Unpack;
-		memcpy(&Unpack, &p, sizeof(Unpack));
+		memcpy(value_ptr(Unpack), &p, sizeof(Unpack));
 		return clamp(
 			vec2(Unpack) * 0.00787401574803149606299212598425f, // 1.0f / 127.0f
 			-1.0f, 1.0f);
@@ -448,7 +449,7 @@ namespace detail
 	GLM_FUNC_QUALIFIER vec4 unpackUnorm4x16(uint64 p)
 	{
 		u16vec4 Unpack;
-		memcpy(&Unpack, &p, sizeof(Unpack));
+		memcpy(value_ptr(Unpack), &p, sizeof(Unpack));
 		return vec4(Unpack) * 1.5259021896696421759365224689097e-5f; // 1.0 / 65535.0
 	}
 
@@ -473,14 +474,14 @@ namespace detail
 	{
 		i16vec4 const Topack(round(clamp(v ,-1.0f, 1.0f) * 32767.0f));
 		uint64 Packed = 0;
-		memcpy(&Packed, &Topack, sizeof(Packed));
+		memcpy(&Packed, value_ptr(Topack), sizeof(Packed));
 		return Packed;
 	}
 
 	GLM_FUNC_QUALIFIER vec4 unpackSnorm4x16(uint64 p)
 	{
 		i16vec4 Unpack;
-		memcpy(&Unpack, &p, sizeof(Unpack));
+		memcpy(value_ptr(Unpack), &p, sizeof(Unpack));
 		return clamp(
 			vec4(Unpack) * 3.0518509475997192297128208258309e-5f, //1.0f / 32767.0f,
 			-1.0f, 1.0f);
@@ -509,14 +510,14 @@ namespace detail
 			detail::toFloat16(v.z),
 			detail::toFloat16(v.w));
 		uint64 Packed = 0;
-		memcpy(&Packed, &Unpack, sizeof(Packed));
+		memcpy(&Packed, value_ptr(Unpack), sizeof(Packed));
 		return Packed;
 	}
 
 	GLM_FUNC_QUALIFIER glm::vec4 unpackHalf4x16(uint64 v)
 	{
 		i16vec4 Unpack;
-		memcpy(&Unpack, &v, sizeof(Unpack));
+		memcpy(value_ptr(Unpack), &v, sizeof(Unpack));
 		return vec4(
 			detail::toFloat32(Unpack.x),
 			detail::toFloat32(Unpack.y),
@@ -818,7 +819,7 @@ namespace detail
 	GLM_FUNC_QUALIFIER i8vec2 unpackInt2x8(int16 p)
 	{
 		i8vec2 Unpack;
-		memcpy(&Unpack, &p, sizeof(Unpack));
+		memcpy(value_ptr(Unpack), &p, sizeof(Unpack));
 		return Unpack;
 	}
 
@@ -832,7 +833,7 @@ namespace detail
 	GLM_FUNC_QUALIFIER u8vec2 unpackUint2x8(uint16 p)
 	{
 		u8vec2 Unpack;
-		memcpy(&Unpack, &p, sizeof(Unpack));
+		memcpy(value_ptr(Unpack), &p, sizeof(Unpack));
 		return Unpack;
 	}
 
@@ -846,7 +847,7 @@ namespace detail
 	GLM_FUNC_QUALIFIER i8vec4 unpackInt4x8(int32 p)
 	{
 		i8vec4 Unpack;
-		memcpy(&Unpack, &p, sizeof(Unpack));
+		memcpy(value_ptr(Unpack), &p, sizeof(Unpack));
 		return Unpack;
 	}
 
@@ -860,7 +861,7 @@ namespace detail
 	GLM_FUNC_QUALIFIER u8vec4 unpackUint4x8(uint32 p)
 	{
 		u8vec4 Unpack;
-		memcpy(&Unpack, &p, sizeof(Unpack));
+		memcpy(value_ptr(Unpack), &p, sizeof(Unpack));
 		return Unpack;
 	}
 
@@ -874,7 +875,7 @@ namespace detail
 	GLM_FUNC_QUALIFIER i16vec2 unpackInt2x16(int p)
 	{
 		i16vec2 Unpack;
-		memcpy(&Unpack, &p, sizeof(Unpack));
+		memcpy(value_ptr(Unpack), &p, sizeof(Unpack));
 		return Unpack;
 	}
 
@@ -888,7 +889,7 @@ namespace detail
 	GLM_FUNC_QUALIFIER i16vec4 unpackInt4x16(int64 p)
 	{
 		i16vec4 Unpack;
-		memcpy(&Unpack, &p, sizeof(Unpack));
+		memcpy(value_ptr(Unpack), &p, sizeof(Unpack));
 		return Unpack;
 	}
 
@@ -902,7 +903,7 @@ namespace detail
 	GLM_FUNC_QUALIFIER u16vec2 unpackUint2x16(uint p)
 	{
 		u16vec2 Unpack;
-		memcpy(&Unpack, &p, sizeof(Unpack));
+		memcpy(value_ptr(Unpack), &p, sizeof(Unpack));
 		return Unpack;
 	}
 
@@ -916,7 +917,7 @@ namespace detail
 	GLM_FUNC_QUALIFIER u16vec4 unpackUint4x16(uint64 p)
 	{
 		u16vec4 Unpack;
-		memcpy(&Unpack, &p, sizeof(Unpack));
+		memcpy(value_ptr(Unpack), &p, sizeof(Unpack));
 		return Unpack;
 	}
 
@@ -930,7 +931,7 @@ namespace detail
 	GLM_FUNC_QUALIFIER i32vec2 unpackInt2x32(int64 p)
 	{
 		i32vec2 Unpack;
-		memcpy(&Unpack, &p, sizeof(Unpack));
+		memcpy(value_ptr(Unpack), &p, sizeof(Unpack));
 		return Unpack;
 	}
 
@@ -944,7 +945,7 @@ namespace detail
 	GLM_FUNC_QUALIFIER u32vec2 unpackUint2x32(uint64 p)
 	{
 		u32vec2 Unpack;
-		memcpy(&Unpack, &p, sizeof(Unpack));
+		memcpy(value_ptr(Unpack), &p, sizeof(Unpack));
 		return Unpack;
 	}
 }//namespace glm

--- a/glm/gtc/type_ptr.inl
+++ b/glm/gtc/type_ptr.inl
@@ -8,6 +8,18 @@ namespace glm
 	/// @{
 
 	template<typename T, qualifier Q>
+	GLM_FUNC_QUALIFIER T const* value_ptr(vec<1, T, Q> const& v)
+	{
+		return &(v.x);
+	}
+
+	template<typename T, qualifier Q>
+	GLM_FUNC_QUALIFIER T* value_ptr(vec<1, T, Q>& v)
+	{
+		return &(v.x);
+	}
+
+	template<typename T, qualifier Q>
 	GLM_FUNC_QUALIFIER T const* value_ptr(vec<2, T, Q> const& v)
 	{
 		return &(v.x);

--- a/test/core/core_func_integer_bit_count.cpp
+++ b/test/core/core_func_integer_bit_count.cpp
@@ -176,7 +176,7 @@ static int pop9(unsigned x)
 	return static_cast<int>(y);
 }
 
-int errors;
+static int errors;
 static void error(int x, int y)
 {
 	errors = errors + 1;

--- a/test/core/core_func_integer_bit_count.cpp
+++ b/test/core/core_func_integer_bit_count.cpp
@@ -208,7 +208,7 @@ int main()
 	TimestampBeg = std::clock();
 	for (std::size_t k = 0; k < Count; ++k)
 	for (i = 0; i < n; i += 2) {
-		if (pop0(test[i]) != test[i+1]) error(test[i], pop0(test[i]));}
+		if (pop0(test[i]) != static_cast<int>(test[i+1])) error(test[i], pop0(test[i]));}
 	TimestampEnd = std::clock();
 
 	std::printf("pop0: %d clocks\n", static_cast<int>(TimestampEnd - TimestampBeg));
@@ -216,7 +216,7 @@ int main()
 	TimestampBeg = std::clock();
 	for (std::size_t k = 0; k < Count; ++k)
 	for (i = 0; i < n; i += 2) {
-		if (pop1(test[i]) != test[i+1]) error(test[i], pop1(test[i]));}
+		if (pop1(test[i]) != static_cast<int>(test[i+1])) error(test[i], pop1(test[i]));}
 	TimestampEnd = std::clock();
 
 	std::printf("pop1: %d clocks\n", static_cast<int>(TimestampEnd - TimestampBeg));
@@ -224,7 +224,7 @@ int main()
 	TimestampBeg = std::clock();
 	for (std::size_t k = 0; k < Count; ++k)
 	for (i = 0; i < n; i += 2) {
-		if (pop2(test[i]) != test[i+1]) error(test[i], pop2(test[i]));}
+		if (pop2(test[i]) != static_cast<int>(test[i+1])) error(test[i], pop2(test[i]));}
 	TimestampEnd = std::clock();
 
 	std::printf("pop2: %d clocks\n", static_cast<int>(TimestampEnd - TimestampBeg));
@@ -232,7 +232,7 @@ int main()
 	TimestampBeg = std::clock();
 	for (std::size_t k = 0; k < Count; ++k)
 	for (i = 0; i < n; i += 2) {
-		if (pop3(test[i]) != test[i+1]) error(test[i], pop3(test[i]));}
+		if (pop3(test[i]) != static_cast<int>(test[i+1])) error(test[i], pop3(test[i]));}
 	TimestampEnd = std::clock();
 
 	std::printf("pop3: %d clocks\n", static_cast<int>(TimestampEnd - TimestampBeg));
@@ -240,7 +240,7 @@ int main()
 	TimestampBeg = std::clock();
 	for (std::size_t k = 0; k < Count; ++k)
 	for (i = 0; i < n; i += 2) {
-		if (pop4(test[i]) != test[i+1]) error(test[i], pop4(test[i]));}
+		if (pop4(test[i]) != static_cast<int>(test[i+1])) error(test[i], pop4(test[i]));}
 	TimestampEnd = std::clock();
 
 	std::printf("pop4: %d clocks\n", static_cast<int>(TimestampEnd - TimestampBeg));
@@ -248,7 +248,7 @@ int main()
 	TimestampBeg = std::clock();
 	for (std::size_t k = 0; k < Count; ++k)
 	for (i = 0; i < n; i += 2) {
-		if (pop5(test[i]) != test[i+1]) error(test[i], pop5(test[i]));}
+		if (pop5(test[i]) != static_cast<int>(test[i+1])) error(test[i], pop5(test[i]));}
 	TimestampEnd = std::clock();
 
 	std::printf("pop5: %d clocks\n", static_cast<int>(TimestampEnd - TimestampBeg));
@@ -256,7 +256,7 @@ int main()
 	TimestampBeg = std::clock();
 	for (std::size_t k = 0; k < Count; ++k)
 	for (i = 0; i < n; i += 2) {
-		if (pop5a(test[i]) != test[i+1]) error(test[i], pop5a(test[i]));}
+		if (pop5a(test[i]) != static_cast<int>(test[i+1])) error(test[i], pop5a(test[i]));}
 	TimestampEnd = std::clock();
 
 	std::printf("pop5a: %d clocks\n", static_cast<int>(TimestampEnd - TimestampBeg));
@@ -264,7 +264,7 @@ int main()
 	TimestampBeg = std::clock();
 	for (std::size_t k = 0; k < Count; ++k)
 	for (i = 0; i < n; i += 2) {
-		if (pop6(test[i]) != test[i+1]) error(test[i], pop6(test[i]));}
+		if (pop6(test[i]) != static_cast<int>(test[i+1])) error(test[i], pop6(test[i]));}
 	TimestampEnd = std::clock();
 
 	std::printf("pop6: %d clocks\n", static_cast<int>(TimestampEnd - TimestampBeg));
@@ -273,7 +273,7 @@ int main()
 	for (std::size_t k = 0; k < Count; ++k)
 	for (i = 0; i < n; i += 2) {
 		if ((test[i] & 0xffffff00) == 0)
-		if (pop7(test[i]) != test[i+1]) error(test[i], pop7(test[i]));}
+		if (pop7(test[i]) != static_cast<int>(test[i+1])) error(test[i], pop7(test[i]));}
 	TimestampEnd = std::clock();
 
 	std::printf("pop7: %d clocks\n", static_cast<int>(TimestampEnd - TimestampBeg));
@@ -282,7 +282,7 @@ int main()
 	for (std::size_t k = 0; k < Count; ++k)
 	for (i = 0; i < n; i += 2) {
 		if ((test[i] & 0xffffff80) == 0)
-		if (pop8(test[i]) != test[i+1]) error(test[i], pop8(test[i]));}
+		if (pop8(test[i]) != static_cast<int>(test[i+1])) error(test[i], pop8(test[i]));}
 	TimestampEnd = std::clock();
 
 	std::printf("pop8: %d clocks\n", static_cast<int>(TimestampEnd - TimestampBeg));
@@ -291,7 +291,7 @@ int main()
 	for (std::size_t k = 0; k < Count; ++k)
 	for (i = 0; i < n; i += 2) {
 		if ((test[i] & 0xffff8000) == 0)
-		if (pop9(test[i]) != test[i+1]) error(test[i], pop9(test[i]));}
+		if (pop9(test[i]) != static_cast<int>(test[i+1])) error(test[i], pop9(test[i]));}
 	TimestampEnd = std::clock();
 
 	std::printf("pop9: %d clocks\n", static_cast<int>(TimestampEnd - TimestampBeg));

--- a/test/core/core_func_integer_find_lsb.cpp
+++ b/test/core/core_func_integer_find_lsb.cpp
@@ -45,7 +45,7 @@ static int ntz3(unsigned x)
 	if ((x & 0x000000FF) == 0) {n = n + 8; x = x >> 8;}
 	if ((x & 0x0000000F) == 0) {n = n + 4; x = x >> 4;}
 	if ((x & 0x00000003) == 0) {n = n + 2; x = x >> 2;}
-	return n - (x & 1);
+	return n - static_cast<int>(x & 1);
 }
 
 static int ntz4(unsigned x)
@@ -74,7 +74,7 @@ static int ntz4a(unsigned x)
 	y = x << 8;  if (y != 0) {n = n - 8;  x = y;}
 	y = x << 4;  if (y != 0) {n = n - 4;  x = y;}
 	y = x << 2;  if (y != 0) {n = n - 2;  x = y;}
-	n = n - ((x << 1) >> 31);
+	n = n - static_cast<int>((x << 1) >> 31);
 	return n;
 }
 
@@ -145,7 +145,8 @@ could then all run in parallel). */
 
 static int ntz7(unsigned x)
 {
-	unsigned y, bz, b4, b3, b2, b1, b0;
+	unsigned y;
+	int bz, b4, b3, b2, b1, b0;
 
 	y = x & -x;               // Isolate rightmost 1-bit.
 	bz = y ? 0 : 1;           // 1 if y = 0.
@@ -279,8 +280,8 @@ static int ntz11(unsigned int n) {
 #	pragma warning(pop)
 #endif
 
-int errors;
-static void error(int x, int y) {
+static int errors;
+static void error(unsigned x, int y) {
    errors = errors + 1;
    std::printf("Error for x = %08x, got %d\n", x, y);
 }
@@ -353,7 +354,7 @@ int main()
 	for(std::size_t k = 0; k < Count; ++k)
 	for(i = 0; i < n; i += 2)
 	{
-		m = test[i+1];
+		m = static_cast<int>(test[i+1]);
 		if(m > 8)
 			m = 8;
 		if(ntz5(static_cast<char>(test[i])) != m)

--- a/test/core/core_func_integer_find_lsb.cpp
+++ b/test/core/core_func_integer_find_lsb.cpp
@@ -312,7 +312,7 @@ int main()
 	TimestampBeg = std::clock();
 	for (std::size_t k = 0; k < Count; ++k)
 	for (i = 0; i < n; i += 2) {
-		if (ntz1(test[i]) != test[i+1]) error(test[i], ntz1(test[i]));}
+		if (ntz1(test[i]) != static_cast<int>(test[i+1])) error(test[i], ntz1(test[i]));}
 	TimestampEnd = std::clock();
 
 	std::printf("ntz1: %d clocks\n", static_cast<int>(TimestampEnd - TimestampBeg));
@@ -320,7 +320,7 @@ int main()
 	TimestampBeg = std::clock();
 	for (std::size_t k = 0; k < Count; ++k)
 	for (i = 0; i < n; i += 2) {
-		if (ntz2(test[i]) != test[i+1]) error(test[i], ntz2(test[i]));}
+		if (ntz2(test[i]) != static_cast<int>(test[i+1])) error(test[i], ntz2(test[i]));}
 	TimestampEnd = std::clock();
 
 	std::printf("ntz2: %d clocks\n", static_cast<int>(TimestampEnd - TimestampBeg));
@@ -328,7 +328,7 @@ int main()
 	TimestampBeg = std::clock();
 	for (std::size_t k = 0; k < Count; ++k)
 	for (i = 0; i < n; i += 2) {
-		if (ntz3(test[i]) != test[i+1]) error(test[i], ntz3(test[i]));}
+		if (ntz3(test[i]) != static_cast<int>(test[i+1])) error(test[i], ntz3(test[i]));}
 	TimestampEnd = std::clock();
 
 	std::printf("ntz3: %d clocks\n", static_cast<int>(TimestampEnd - TimestampBeg));
@@ -336,7 +336,7 @@ int main()
 	TimestampBeg = std::clock();
 	for (std::size_t k = 0; k < Count; ++k)
 	for (i = 0; i < n; i += 2) {
-		if (ntz4(test[i]) != test[i+1]) error(test[i], ntz4(test[i]));}
+		if (ntz4(test[i]) != static_cast<int>(test[i+1])) error(test[i], ntz4(test[i]));}
 	TimestampEnd = std::clock();
 
 	std::printf("ntz4: %d clocks\n", static_cast<int>(TimestampEnd - TimestampBeg));
@@ -344,7 +344,7 @@ int main()
 	TimestampBeg = std::clock();
 	for (std::size_t k = 0; k < Count; ++k)
 	for (i = 0; i < n; i += 2) {
-		if (ntz4a(test[i]) != test[i+1]) error(test[i], ntz4a(test[i]));}
+		if (ntz4a(test[i]) != static_cast<int>(test[i+1])) error(test[i], ntz4a(test[i]));}
 	TimestampEnd = std::clock();
 
 	std::printf("ntz4a: %d clocks\n", static_cast<int>(TimestampEnd - TimestampBeg));
@@ -366,7 +366,7 @@ int main()
 	TimestampBeg = std::clock();
 	for (std::size_t k = 0; k < Count; ++k)
 	for (i = 0; i < n; i += 2) {
-		if (ntz6(test[i]) != test[i+1]) error(test[i], ntz6(test[i]));}
+		if (ntz6(test[i]) != static_cast<int>(test[i+1])) error(test[i], ntz6(test[i]));}
 	TimestampEnd = std::clock();
 
 	std::printf("ntz6: %d clocks\n", static_cast<int>(TimestampEnd - TimestampBeg));
@@ -374,7 +374,7 @@ int main()
 	TimestampBeg = std::clock();
 	for (std::size_t k = 0; k < Count; ++k)
 	for (i = 0; i < n; i += 2) {
-		if (ntz6a(test[i]) != test[i+1]) error(test[i], ntz6a(test[i]));}
+		if (ntz6a(test[i]) != static_cast<int>(test[i+1])) error(test[i], ntz6a(test[i]));}
 	TimestampEnd = std::clock();
 
 	std::printf("ntz6a: %d clocks\n", static_cast<int>(TimestampEnd - TimestampBeg));
@@ -382,7 +382,7 @@ int main()
 	TimestampBeg = std::clock();
 	for (std::size_t k = 0; k < Count; ++k)
 	for (i = 0; i < n; i += 2) {
-		if (ntz7(test[i]) != test[i+1]) error(test[i], ntz7(test[i]));}
+		if (ntz7(test[i]) != static_cast<int>(test[i+1])) error(test[i], ntz7(test[i]));}
 	TimestampEnd = std::clock();
 
 	std::printf("ntz7: %d clocks\n", static_cast<int>(TimestampEnd - TimestampBeg));
@@ -390,7 +390,7 @@ int main()
 	TimestampBeg = std::clock();
 	for (std::size_t k = 0; k < Count; ++k)
 	for (i = 0; i < n; i += 2) {
-		if (ntz7_christophe(test[i]) != test[i+1]) error(test[i], ntz7(test[i]));}
+		if (ntz7_christophe(test[i]) != static_cast<int>(test[i+1])) error(test[i], ntz7(test[i]));}
 	TimestampEnd = std::clock();
 
 	std::printf("ntz7_christophe: %d clocks\n", static_cast<int>(TimestampEnd - TimestampBeg));
@@ -398,7 +398,7 @@ int main()
 	TimestampBeg = std::clock();
 	for (std::size_t k = 0; k < Count; ++k)
 	for (i = 0; i < n; i += 2) {
-		if (ntz8(test[i]) != test[i+1]) error(test[i], ntz8(test[i]));}
+		if (ntz8(test[i]) != static_cast<int>(test[i+1])) error(test[i], ntz8(test[i]));}
 	TimestampEnd = std::clock();
 
 	std::printf("ntz8: %d clocks\n", static_cast<int>(TimestampEnd - TimestampBeg));
@@ -406,7 +406,7 @@ int main()
 	TimestampBeg = std::clock();
 	for (std::size_t k = 0; k < Count; ++k)
 	for (i = 0; i < n; i += 2) {
-		if (ntz8a(test[i]) != test[i+1]) error(test[i], ntz8a(test[i]));}
+		if (ntz8a(test[i]) != static_cast<int>(test[i+1])) error(test[i], ntz8a(test[i]));}
 	TimestampEnd = std::clock();
 
 	std::printf("ntz8a: %d clocks\n", static_cast<int>(TimestampEnd - TimestampBeg));
@@ -414,7 +414,7 @@ int main()
 	TimestampBeg = std::clock();
 	for (std::size_t k = 0; k < Count; ++k)
 	for (i = 0; i < n; i += 2) {
-		if (ntz9(test[i]) != test[i+1]) error(test[i], ntz9(test[i]));}
+		if (ntz9(test[i]) != static_cast<int>(test[i+1])) error(test[i], ntz9(test[i]));}
 	TimestampEnd = std::clock();
 
 	std::printf("ntz9: %d clocks\n", static_cast<int>(TimestampEnd - TimestampBeg));
@@ -422,7 +422,7 @@ int main()
 	TimestampBeg = std::clock();
 	for (std::size_t k = 0; k < Count; ++k)
 	for (i = 0; i < n; i += 2) {
-		if (ntz10(test[i]) != test[i+1]) error(test[i], ntz10(test[i]));}
+		if (ntz10(test[i]) != static_cast<int>(test[i+1])) error(test[i], ntz10(test[i]));}
 	TimestampEnd = std::clock();
 
 	std::printf("ntz10: %d clocks\n", static_cast<int>(TimestampEnd - TimestampBeg));
@@ -430,7 +430,7 @@ int main()
 	TimestampBeg = std::clock();
 	for (std::size_t k = 0; k < Count; ++k)
 		for (i = 0; i < n; i += 2) {
-			if (ntz11(test[i]) != test[i + 1]) error(test[i], ntz11(test[i]));
+			if (ntz11(test[i]) != static_cast<int>(test[i + 1])) error(test[i], ntz11(test[i]));
 		}
 	TimestampEnd = std::clock();
 

--- a/test/core/core_func_integer_find_msb.cpp
+++ b/test/core/core_func_integer_find_msb.cpp
@@ -338,7 +338,7 @@ int main()
 	TimestampBeg = std::clock();
 	for (std::size_t k = 0; k < Count; ++k)
 	for (i = 0; i < n; i += 2) {
-		if (nlz1(test[i]) != test[i+1]) error(test[i], nlz1(test[i]));}
+		if (nlz1(test[i]) != static_cast<int>(test[i + 1])) error(test[i], nlz1(test[i]));}
 	TimestampEnd = std::clock();
 
 	std::printf("nlz1: %d clocks\n", static_cast<int>(TimestampEnd - TimestampBeg));
@@ -346,7 +346,7 @@ int main()
 	TimestampBeg = std::clock();
 	for (std::size_t k = 0; k < Count; ++k)
 	for (i = 0; i < n; i += 2) {
-		if (nlz1a(test[i]) != test[i+1]) error(test[i], nlz1a(test[i]));}
+		if (nlz1a(test[i]) != static_cast<int>(test[i + 1])) error(test[i], nlz1a(test[i]));}
 	TimestampEnd = std::clock();
 
 	std::printf("nlz1a: %d clocks\n", static_cast<int>(TimestampEnd - TimestampBeg));
@@ -354,7 +354,7 @@ int main()
 	TimestampBeg = std::clock();
 	for (std::size_t k = 0; k < Count; ++k)
 	for (i = 0; i < n; i += 2) {
-		if (nlz2(test[i]) != test[i+1]) error(test[i], nlz2(test[i]));}
+		if (nlz2(test[i]) != static_cast<int>(test[i + 1])) error(test[i], nlz2(test[i]));}
 	TimestampEnd = std::clock();
 
 	std::printf("nlz2: %d clocks\n", static_cast<int>(TimestampEnd - TimestampBeg));
@@ -362,7 +362,7 @@ int main()
 	TimestampBeg = std::clock();
 	for (std::size_t k = 0; k < Count; ++k)
 	for (i = 0; i < n; i += 2) {
-		if (nlz2a(test[i]) != test[i+1]) error(test[i], nlz2a(test[i]));}
+		if (nlz2a(test[i]) != static_cast<int>(test[i + 1])) error(test[i], nlz2a(test[i]));}
 	TimestampEnd = std::clock();
 
 	std::printf("nlz2a: %d clocks\n", static_cast<int>(TimestampEnd - TimestampBeg));
@@ -370,7 +370,7 @@ int main()
 	TimestampBeg = std::clock();
 	for (std::size_t k = 0; k < Count; ++k)
 	for (i = 0; i < n; i += 2) {
-		if (nlz3(test[i]) != test[i+1]) error(test[i], nlz3(test[i]));}
+		if (nlz3(test[i]) != static_cast<int>(test[i + 1])) error(test[i], nlz3(test[i]));}
 	TimestampEnd = std::clock();
 
 	std::printf("nlz3: %d clocks\n", static_cast<int>(TimestampEnd - TimestampBeg));
@@ -378,7 +378,7 @@ int main()
 	TimestampBeg = std::clock();
 	for (std::size_t k = 0; k < Count; ++k)
 	for (i = 0; i < n; i += 2) {
-		if (nlz4(test[i]) != test[i+1]) error(test[i], nlz4(test[i]));}
+		if (nlz4(test[i]) != static_cast<int>(test[i + 1])) error(test[i], nlz4(test[i]));}
 	TimestampEnd = std::clock();
 
 	std::printf("nlz4: %d clocks\n", static_cast<int>(TimestampEnd - TimestampBeg));
@@ -386,7 +386,7 @@ int main()
 	TimestampBeg = std::clock();
 	for (std::size_t k = 0; k < Count; ++k)
 	for (i = 0; i < n; i += 2) {
-		if (nlz5(test[i]) != test[i+1]) error(test[i], nlz5(test[i]));}
+		if (nlz5(test[i]) != static_cast<int>(test[i + 1])) error(test[i], nlz5(test[i]));}
 	TimestampEnd = std::clock();
 
 	std::printf("nlz5: %d clocks\n", static_cast<int>(TimestampEnd - TimestampBeg));
@@ -394,7 +394,7 @@ int main()
 	TimestampBeg = std::clock();
 	for (std::size_t k = 0; k < Count; ++k)
 	for (i = 0; i < n; i += 2) {
-		if (nlz6(test[i]) != test[i+1]) error(test[i], nlz6(test[i]));}
+		if (nlz6(test[i]) != static_cast<int>(test[i + 1])) error(test[i], nlz6(test[i]));}
 	TimestampEnd = std::clock();
 
 	std::printf("nlz6: %d clocks\n", static_cast<int>(TimestampEnd - TimestampBeg));
@@ -402,7 +402,7 @@ int main()
 	TimestampBeg = std::clock();
 	for (std::size_t k = 0; k < Count; ++k)
 	for (i = 0; i < n; i += 2) {
-		if (nlz7(test[i]) != test[i+1]) error(test[i], nlz7(test[i]));}
+		if (nlz7(test[i]) != static_cast<int>(test[i + 1])) error(test[i], nlz7(test[i]));}
 	TimestampEnd = std::clock();
 
 	std::printf("nlz7: %d clocks\n", static_cast<int>(TimestampEnd - TimestampBeg));
@@ -410,7 +410,7 @@ int main()
 	TimestampBeg = std::clock();
 	for (std::size_t k = 0; k < Count; ++k)
 	for (i = 0; i < n; i += 2) {
-		if (nlz8(test[i]) != test[i+1]) error(test[i], nlz8(test[i]));}
+		if (nlz8(test[i]) != static_cast<int>(test[i + 1])) error(test[i], nlz8(test[i]));}
 	TimestampEnd = std::clock();
 
 	std::printf("nlz8: %d clocks\n", static_cast<int>(TimestampEnd - TimestampBeg));
@@ -418,7 +418,7 @@ int main()
 	TimestampBeg = std::clock();
 	for (std::size_t k = 0; k < Count; ++k)
 	for (i = 0; i < n; i += 2) {
-		if (nlz9(test[i]) != test[i+1]) error(test[i], nlz9(test[i]));}
+		if (nlz9(test[i]) != static_cast<int>(test[i + 1])) error(test[i], nlz9(test[i]));}
 	TimestampEnd = std::clock();
 
 	std::printf("nlz9: %d clocks\n", static_cast<int>(TimestampEnd - TimestampBeg));
@@ -426,7 +426,7 @@ int main()
 	TimestampBeg = std::clock();
 	for (std::size_t k = 0; k < Count; ++k)
 	for (i = 0; i < n; i += 2) {
-		if (nlz10(test[i]) != test[i+1]) error(test[i], nlz10(test[i]));}
+		if (nlz10(test[i]) != static_cast<int>(test[i + 1])) error(test[i], nlz10(test[i]));}
 	TimestampEnd = std::clock();
 
 	std::printf("nlz10: %d clocks\n", static_cast<int>(TimestampEnd - TimestampBeg));
@@ -434,7 +434,7 @@ int main()
 	TimestampBeg = std::clock();
 	for (std::size_t k = 0; k < Count; ++k)
 	for (i = 0; i < n; i += 2) {
-		if (nlz10a(test[i]) != test[i+1]) error(test[i], nlz10a(test[i]));}
+		if (nlz10a(test[i]) != static_cast<int>(test[i + 1])) error(test[i], nlz10a(test[i]));}
 	TimestampEnd = std::clock();
 
 	std::printf("nlz10a: %d clocks\n", static_cast<int>(TimestampEnd - TimestampBeg));
@@ -442,7 +442,7 @@ int main()
 	TimestampBeg = std::clock();
 	for (std::size_t k = 0; k < Count; ++k)
 	for (i = 0; i < n; i += 2) {
-		if (nlz10b(test[i]) != test[i+1]) error(test[i], nlz10b(test[i]));}
+		if (nlz10b(test[i]) != static_cast<int>(test[i + 1])) error(test[i], nlz10b(test[i]));}
 	TimestampEnd = std::clock();
 
 	std::printf("nlz10b: %d clocks\n", static_cast<int>(TimestampEnd - TimestampBeg));

--- a/test/core/core_func_integer_find_msb.cpp
+++ b/test/core/core_func_integer_find_msb.cpp
@@ -39,7 +39,7 @@ static int nlz1a(unsigned x) {
    if ((x >> 24) == 0) {n = n + 8; x = x << 8;}
    if ((x >> 28) == 0) {n = n + 4; x = x << 4;}
    if ((x >> 30) == 0) {n = n + 2; x = x << 2;}
-   n = n - (x >> 31);
+   n = n - static_cast<int>(x >> 31);
    return n;
 }
 // On basic Risc, 12 to 20 instructions.
@@ -54,7 +54,7 @@ static int nlz2(unsigned x) {
    y = x >> 4;  if (y != 0) {n = n - 4;  x = y;}
    y = x >> 2;  if (y != 0) {n = n - 2;  x = y;}
    y = x >> 1;  if (y != 0) return n - 2;
-   return n - x;
+   return n - static_cast<int>(x);
 }
 
 // As above but coded as a loop for compactness:
@@ -69,15 +69,15 @@ static int nlz2a(unsigned x) {
       y = x >> c;  if (y != 0) {n = n - c;  x = y;}
       c = c >> 1;
    } while (c != 0);
-   return n - x;
+   return n - static_cast<int>(x);
 }
 
-static int nlz3(int x) {
+static int nlz3(unsigned x) {
    int y, n;
 
    n = 0;
-   y = x;
-L: if (x < 0) return n;
+   y = static_cast<int>(x);
+L: if (x > 0x7fffffff) return n;
    if (y == 0) return 32 - n;
    n = n + 1;
    x = x << 1;
@@ -98,19 +98,19 @@ static int nlz4(unsigned x) {
    n = 16 - m;          // is nonzero, set n = 0 and
    x = x >> m;          // shift x right 16.
                         // Now x is of the form 0000xxxx.
-   y = x - 0x100;       // If positions 8-15 are 0,
-   m = (y >> 16) & 8;   // add 8 to n and shift x left 8.
-   n = n + m;
+   y = static_cast<int>(x) - 0x100;
+   m = (y >> 16) & 8;   // If positions 8-15 are 0,
+   n = n + m;           // add 8 to n and shift x left 8.
    x = x << m;
 
-   y = x - 0x1000;      // If positions 12-15 are 0,
-   m = (y >> 16) & 4;   // add 4 to n and shift x left 4.
-   n = n + m;
+   y = static_cast<int>(x) - 0x1000;
+   m = (y >> 16) & 4;   // If positions 12-15 are 0,
+   n = n + m;           // add 4 to n and shift x left 4.
    x = x << m;
 
-   y = x - 0x4000;      // If positions 14-15 are 0,
-   m = (y >> 16) & 2;   // add 2 to n and shift x left 2.
-   n = n + m;
+   y = static_cast<int>(x) - 0x4000;
+   m = (y >> 16) & 2;   // If positions 14-15 are 0,
+   n = n + m;           // add 2 to n and shift x left 2.
    x = x << m;
 
    y = x >> 14;         // Set y = 0, 1, 2, or 3.
@@ -305,8 +305,8 @@ static int nlz10b(unsigned x)
 	return table[x >> 26];
 }
 
-int errors;
-static void error(int x, int y)
+static int errors;
+static void error(unsigned x, int y)
 {
 	errors = errors + 1;
 	std::printf("Error for x = %08x, got %d\n", x, y);

--- a/test/core/core_type_vec1.cpp
+++ b/test/core/core_type_vec1.cpp
@@ -176,6 +176,10 @@ static int test_constexpr()
 
 int main()
 {
+	// Suppress unused variable warnings
+	(void)g1;
+	(void)g2;
+
 	int Error = 0;
 
 	Error += test_size();

--- a/test/core/core_type_vec2.cpp
+++ b/test/core/core_type_vec2.cpp
@@ -400,6 +400,11 @@ static int test_swizzle()
 
 int main()
 {
+	// Suppress unused variable warnings
+	(void)g1;
+	(void)g2;
+	(void)g3;
+
 	int Error = 0;
 
 	Error += test_size();

--- a/test/core/core_type_vec3.cpp
+++ b/test/core/core_type_vec3.cpp
@@ -612,6 +612,11 @@ static int test_constexpr()
 
 int main()
 {
+	// Suppress unused variable warnings
+	(void)g1;
+	(void)g2;
+	(void)g3;
+
 	int Error = 0;
 
 	Error += test_vec3_ctor();

--- a/test/core/core_type_vec4.cpp
+++ b/test/core/core_type_vec4.cpp
@@ -770,6 +770,11 @@ static int test_simd_gen()
 */
 int main()
 {
+	// Suppress unused variable warnings
+	(void)g1;
+	(void)g2;
+	(void)g3;
+
 	int Error = 0;
 
 	//Error += test_simd_gen();

--- a/test/ext/ext_vec1.cpp
+++ b/test/ext/ext_vec1.cpp
@@ -154,6 +154,10 @@ static int test_constexpr()
 
 int main()
 {
+	// Suppress unused variable warnings
+	(void)g1;
+	(void)g2;
+
 	int Error = 0;
 
 	Error += test_vec1_size();

--- a/test/gtc/gtc_bitfield.cpp
+++ b/test/gtc/gtc_bitfield.cpp
@@ -34,7 +34,7 @@ namespace mask
 
 	static inline int mask_mix(int Bits)
 	{
-		return Bits >= sizeof(int) * 8 ? 0xffffffff : (static_cast<int>(1) << Bits) - static_cast<int>(1);
+		return Bits >= static_cast<int>(sizeof(int) * 8) ? 0xffffffff : (static_cast<int>(1) << Bits) - static_cast<int>(1);
 	}
 
 #if GLM_COMPILER & GLM_COMPILER_CLANG

--- a/test/gtx/gtx_easing.cpp
+++ b/test/gtx/gtx_easing.cpp
@@ -12,42 +12,70 @@ namespace
 		T r;
 
 		r = glm::linearInterpolation(a);
+		(void)r;
 
 		r = glm::quadraticEaseIn(a);
+		(void)r;
 		r = glm::quadraticEaseOut(a);
+		(void)r;
 		r = glm::quadraticEaseInOut(a);
+		(void)r;
 
 		r = glm::cubicEaseIn(a);
+		(void)r;
 		r = glm::cubicEaseOut(a);
+		(void)r;
 		r = glm::cubicEaseInOut(a);
+		(void)r;
 
 		r = glm::quarticEaseIn(a);
+		(void)r;
 		r = glm::quarticEaseOut(a);
+		(void)r;
 		r = glm::quinticEaseInOut(a);
+		(void)r;
 
 		r = glm::sineEaseIn(a);
+		(void)r;
 		r = glm::sineEaseOut(a);
+		(void)r;
 		r = glm::sineEaseInOut(a);
+		(void)r;
 
 		r = glm::circularEaseIn(a);
+		(void)r;
 		r = glm::circularEaseOut(a);
+		(void)r;
 		r = glm::circularEaseInOut(a);
+		(void)r;
 
 		r = glm::exponentialEaseIn(a);
+		(void)r;
 		r = glm::exponentialEaseOut(a);
+		(void)r;
 		r = glm::exponentialEaseInOut(a);
+		(void)r;
 
 		r = glm::elasticEaseIn(a);
+		(void)r;
 		r = glm::elasticEaseOut(a);
+		(void)r;
 		r = glm::elasticEaseInOut(a);
+		(void)r;
 
 		r = glm::backEaseIn(a);
+		(void)r;
 		r = glm::backEaseOut(a);
+		(void)r;
 		r = glm::backEaseInOut(a);
+		(void)r;
 
 		r = glm::bounceEaseIn(a);
+		(void)r;
 		r = glm::bounceEaseOut(a);
+		(void)r;
 		r = glm::bounceEaseInOut(a);
+		(void)r;
 	}
 }
 

--- a/test/gtx/gtx_fast_trigonometry.cpp
+++ b/test/gtx/gtx_fast_trigonometry.cpp
@@ -22,11 +22,11 @@ namespace fastCos
 		float result = 0.f;
 
 		const std::clock_t timestamp1 = std::clock();
-		for(float i = begin; i < end; i = NextFloat ? glm::nextFloat(i) : i += 0.1f)
+		for(float i = begin; i < end; i = NextFloat ? glm::nextFloat(i) : i + 0.1f)
 			result = glm::fastCos(i);
 
 		const std::clock_t timestamp2 = std::clock();
-		for(float i = begin; i < end; i = NextFloat ? glm::nextFloat(i) : i += 0.1f)
+		for(float i = begin; i < end; i = NextFloat ? glm::nextFloat(i) : i + 0.1f)
 			result = glm::cos(i);
 
 		const std::clock_t timestamp3 = std::clock();
@@ -58,11 +58,11 @@ namespace fastSin
 		float result = 0.f;
 
 		const std::clock_t timestamp1 = std::clock();
-		for(float i = begin; i < end; i = NextFloat ? glm::nextFloat(i) : i += 0.1f)
+		for(float i = begin; i < end; i = NextFloat ? glm::nextFloat(i) : i + 0.1f)
 			result = glm::fastSin(i);
 
 		const std::clock_t timestamp2 = std::clock();
-		for(float i = begin; i < end; i = NextFloat ? glm::nextFloat(i) : i += 0.1f)
+		for(float i = begin; i < end; i = NextFloat ? glm::nextFloat(i) : i + 0.1f)
 			result = glm::sin(i);
 
 		const std::clock_t timestamp3 = std::clock();
@@ -86,11 +86,11 @@ namespace fastTan
 		float result = 0.f;
 
 		const std::clock_t timestamp1 = std::clock();
-		for(float i = begin; i < end; i = NextFloat ? glm::nextFloat(i) : i += 0.1f)
+		for(float i = begin; i < end; i = NextFloat ? glm::nextFloat(i) : i + 0.1f)
 			result = glm::fastTan(i);
 
 		const std::clock_t timestamp2 = std::clock();
-		for (float i = begin; i < end; i = NextFloat ? glm::nextFloat(i) : i += 0.1f)
+		for (float i = begin; i < end; i = NextFloat ? glm::nextFloat(i) : i + 0.1f)
 			result = glm::tan(i);
 
 		const std::clock_t timestamp3 = std::clock();
@@ -114,11 +114,11 @@ namespace fastAcos
 		float result = 0.f;
 
 		const std::clock_t timestamp1 = std::clock();
-		for(float i = begin; i < end; i = NextFloat ? glm::nextFloat(i) : i += 0.1f)
+		for(float i = begin; i < end; i = NextFloat ? glm::nextFloat(i) : i + 0.1f)
 			result = glm::fastAcos(i);
 
 		const std::clock_t timestamp2 = std::clock();
-		for(float i = begin; i < end; i = NextFloat ? glm::nextFloat(i) : i += 0.1f)
+		for(float i = begin; i < end; i = NextFloat ? glm::nextFloat(i) : i + 0.1f)
 			result = glm::acos(i);
 
 		const std::clock_t timestamp3 = std::clock();
@@ -142,10 +142,10 @@ namespace fastAsin
 		const float end = glm::pi<float>();
 		float result = 0.f;
 		const std::clock_t timestamp1 = std::clock();
-		for(float i = begin; i < end; i = NextFloat ? glm::nextFloat(i) : i += 0.1f)
+		for(float i = begin; i < end; i = NextFloat ? glm::nextFloat(i) : i + 0.1f)
 			result = glm::fastAsin(i);
 		const std::clock_t timestamp2 = std::clock();
-		for(float i = begin; i < end; i = NextFloat ? glm::nextFloat(i) : i += 0.1f)
+		for(float i = begin; i < end; i = NextFloat ? glm::nextFloat(i) : i + 0.1f)
 			result = glm::asin(i);
 		const std::clock_t timestamp3 = std::clock();
 		const std::clock_t time_fast = timestamp2 - timestamp1;
@@ -167,10 +167,10 @@ namespace fastAtan
 		const float end = glm::pi<float>();
 		float result = 0.f;
 		const std::clock_t timestamp1 = std::clock();
-		for(float i = begin; i < end; i = NextFloat ? glm::nextFloat(i) : i += 0.1f)
+		for(float i = begin; i < end; i = NextFloat ? glm::nextFloat(i) : i + 0.1f)
 			result = glm::fastAtan(i);
 		const std::clock_t timestamp2 = std::clock();
-		for(float i = begin; i < end; i = NextFloat ? glm::nextFloat(i) : i += 0.1f)
+		for(float i = begin; i < end; i = NextFloat ? glm::nextFloat(i) : i + 0.1f)
 			result = glm::atan(i);
 		const std::clock_t timestamp3 = std::clock();
 		const std::clock_t time_fast = timestamp2 - timestamp1;


### PR DESCRIPTION
A PR to run C.I. on https://github.com/g-truc/glm/pull/1276 because I don't know how to do it differently...



In https://github.com/g-truc/glm/issues/1263 the compilation fails because of various compiler warnings that are treated as errors.
This PR eliminates (all) warnings when compiling with clang-15 and gcc-11.4.

Two notable changes that could work as standalone PR's:

In packing.inl the pointer to the data of vector types that is passed into memcpy calls is retrieved using the value_ptr() method, which is also semantically more precise.
In type_ptr.inl there was a declaration of value_ptr() for vec<1, T, Q> types missing.