### PR TITLE
Fix log2 func. qualifier

### DIFF
--- a/glm/detail/func_exponential.inl
+++ b/glm/detail/func_exponential.inl
@@ -14,7 +14,7 @@ namespace detail
 		using std::log2;
 #	else
 		template<typename genType>
-		genType log2(genType Value)
+		GLM_FUNC_QUALIFIER genType log2(genType Value)
 		{
 			return std::log(Value) * static_cast<genType>(1.4426950408889634073599246810019);
 		}


### PR DESCRIPTION
I just noticed that `glm::log2` does not compile in CUDA device code.
Apparently there was a `GLM_FUNC_QUALIFIER` missing.
All other functions that were defined in a similar way were already properly decorated.
