### PR TITLE
Fix Warning C4003 on Windows

### DIFF
--- a/glm/ext/quaternion_exponential.inl
+++ b/glm/ext/quaternion_exponential.inl
@@ -60,7 +60,7 @@ namespace glm
 			//VectorMagnitude to 0. here; we could use denorm_int() compiling a
 			//project with unsafe maths optimizations might make the comparison
 			//always false, even when VectorMagnitude is 0.
-			if (VectorMagnitude < std::numeric_limits<T>::min()) {
+			if (VectorMagnitude < (std::numeric_limits<T>::min)()) {
 				//Equivalent to raising a real number to a power
 				return qua<T, Q>::wxyz(pow(x.w, y), 0, 0, 0);
 			}

--- a/glm/ext/scalar_ulp.inl
+++ b/glm/ext/scalar_ulp.inl
@@ -199,7 +199,7 @@ namespace glm
 	GLM_FUNC_QUALIFIER float nextFloat(float x)
 	{
 #		if GLM_HAS_CXX11_STL
-			return std::nextafter(x, std::numeric_limits<float>::max());
+			return std::nextafter(x, (std::numeric_limits<float>::max)());
 #		elif((GLM_COMPILER & GLM_COMPILER_VC) || ((GLM_COMPILER & GLM_COMPILER_INTEL) && (GLM_PLATFORM & GLM_PLATFORM_WINDOWS)))
 			return detail::nextafterf(x, FLT_MAX);
 #		elif(GLM_PLATFORM & GLM_PLATFORM_ANDROID)
@@ -213,9 +213,9 @@ namespace glm
 	GLM_FUNC_QUALIFIER double nextFloat(double x)
 	{
 #		if GLM_HAS_CXX11_STL
-			return std::nextafter(x, std::numeric_limits<double>::max());
+			return std::nextafter(x, (std::numeric_limits<double>::max)());
 #		elif((GLM_COMPILER & GLM_COMPILER_VC) || ((GLM_COMPILER & GLM_COMPILER_INTEL) && (GLM_PLATFORM & GLM_PLATFORM_WINDOWS)))
-			return detail::nextafter(x, std::numeric_limits<double>::max());
+			return detail::nextafter(x, (std::numeric_limits<double>::max)());
 #		elif(GLM_PLATFORM & GLM_PLATFORM_ANDROID)
 			return __builtin_nextafter(x, DBL_MAX);
 #		else
@@ -238,7 +238,7 @@ namespace glm
 	GLM_FUNC_QUALIFIER float prevFloat(float x)
 	{
 #		if GLM_HAS_CXX11_STL
-			return std::nextafter(x, std::numeric_limits<float>::min());
+			return std::nextafter(x, (std::numeric_limits<float>::min)());
 #		elif((GLM_COMPILER & GLM_COMPILER_VC) || ((GLM_COMPILER & GLM_COMPILER_INTEL) && (GLM_PLATFORM & GLM_PLATFORM_WINDOWS)))
 			return detail::nextafterf(x, FLT_MIN);
 #		elif(GLM_PLATFORM & GLM_PLATFORM_ANDROID)
@@ -251,7 +251,7 @@ namespace glm
 	GLM_FUNC_QUALIFIER double prevFloat(double x)
 	{
 #		if GLM_HAS_CXX11_STL
-			return std::nextafter(x, std::numeric_limits<double>::min());
+			return std::nextafter(x, (std::numeric_limits<double>::min)());
 #		elif((GLM_COMPILER & GLM_COMPILER_VC) || ((GLM_COMPILER & GLM_COMPILER_INTEL) && (GLM_PLATFORM & GLM_PLATFORM_WINDOWS)))
 			return _nextafter(x, DBL_MIN);
 #		elif(GLM_PLATFORM & GLM_PLATFORM_ANDROID)

--- a/glm/gtc/packing.inl
+++ b/glm/gtc/packing.inl
@@ -688,7 +688,7 @@ namespace detail
 		GLM_STATIC_ASSERT(std::numeric_limits<uintType>::is_integer, "uintType must be an integer type");
 		GLM_STATIC_ASSERT(std::numeric_limits<floatType>::is_iec559, "floatType must be a floating point type");
 
-		return vec<L, uintType, Q>(round(clamp(v, static_cast<floatType>(0), static_cast<floatType>(1)) * static_cast<floatType>(std::numeric_limits<uintType>::max())));
+		return vec<L, uintType, Q>(round(clamp(v, static_cast<floatType>(0), static_cast<floatType>(1)) * static_cast<floatType>((std::numeric_limits<uintType>::max)())));
 	}
 
 	template<typename floatType, length_t L, typename uintType, qualifier Q>
@@ -697,7 +697,7 @@ namespace detail
 		GLM_STATIC_ASSERT(std::numeric_limits<uintType>::is_integer, "uintType must be an integer type");
 		GLM_STATIC_ASSERT(std::numeric_limits<floatType>::is_iec559, "floatType must be a floating point type");
 
-		return vec<L, floatType, Q>(v) * (static_cast<floatType>(1) / static_cast<floatType>(std::numeric_limits<uintType>::max()));
+		return vec<L, floatType, Q>(v) * (static_cast<floatType>(1) / static_cast<floatType>((std::numeric_limits<uintType>::max)()));
 	}
 
 	template<typename intType, length_t L, typename floatType, qualifier Q>
@@ -706,7 +706,7 @@ namespace detail
 		GLM_STATIC_ASSERT(std::numeric_limits<intType>::is_integer, "uintType must be an integer type");
 		GLM_STATIC_ASSERT(std::numeric_limits<floatType>::is_iec559, "floatType must be a floating point type");
 
-		return vec<L, intType, Q>(round(clamp(v , static_cast<floatType>(-1), static_cast<floatType>(1)) * static_cast<floatType>(std::numeric_limits<intType>::max())));
+		return vec<L, intType, Q>(round(clamp(v , static_cast<floatType>(-1), static_cast<floatType>(1)) * static_cast<floatType>((std::numeric_limits<intType>::max)())));
 	}
 
 	template<typename floatType, length_t L, typename intType, qualifier Q>
@@ -715,7 +715,7 @@ namespace detail
 		GLM_STATIC_ASSERT(std::numeric_limits<intType>::is_integer, "uintType must be an integer type");
 		GLM_STATIC_ASSERT(std::numeric_limits<floatType>::is_iec559, "floatType must be a floating point type");
 
-		return clamp(vec<L, floatType, Q>(v) * (static_cast<floatType>(1) / static_cast<floatType>(std::numeric_limits<intType>::max())), static_cast<floatType>(-1), static_cast<floatType>(1));
+		return clamp(vec<L, floatType, Q>(v) * (static_cast<floatType>(1) / static_cast<floatType>((std::numeric_limits<intType>::max)())), static_cast<floatType>(-1), static_cast<floatType>(1));
 	}
 
 	GLM_FUNC_QUALIFIER uint8 packUnorm2x4(vec2 const& v)

--- a/glm/gtc/random.inl
+++ b/glm/gtc/random.inl
@@ -22,7 +22,7 @@ namespace detail
 		GLM_FUNC_QUALIFIER static vec<1, uint8, P> call()
 		{
 			return vec<1, uint8, P>(
-				static_cast<uint8>(std::rand() % std::numeric_limits<uint8>::max()));
+				static_cast<uint8>(std::rand() % (std::numeric_limits<uint8>::max)()));
 		}
 	};
 
@@ -32,8 +32,8 @@ namespace detail
 		GLM_FUNC_QUALIFIER static vec<2, uint8, P> call()
 		{
 			return vec<2, uint8, P>(
-				std::rand() % std::numeric_limits<uint8>::max(),
-				std::rand() % std::numeric_limits<uint8>::max());
+				std::rand() % (std::numeric_limits<uint8>::max)(),
+				std::rand() % (std::numeric_limits<uint8>::max)());
 		}
 	};
 
@@ -43,9 +43,9 @@ namespace detail
 		GLM_FUNC_QUALIFIER static vec<3, uint8, P> call()
 		{
 			return vec<3, uint8, P>(
-				std::rand() % std::numeric_limits<uint8>::max(),
-				std::rand() % std::numeric_limits<uint8>::max(),
-				std::rand() % std::numeric_limits<uint8>::max());
+				std::rand() % (std::numeric_limits<uint8>::max)(),
+				std::rand() % (std::numeric_limits<uint8>::max)(),
+				std::rand() % (std::numeric_limits<uint8>::max)());
 		}
 	};
 
@@ -55,10 +55,10 @@ namespace detail
 		GLM_FUNC_QUALIFIER static vec<4, uint8, P> call()
 		{
 			return vec<4, uint8, P>(
-				std::rand() % std::numeric_limits<uint8>::max(),
-				std::rand() % std::numeric_limits<uint8>::max(),
-				std::rand() % std::numeric_limits<uint8>::max(),
-				std::rand() % std::numeric_limits<uint8>::max());
+				std::rand() % (std::numeric_limits<uint8>::max)(),
+				std::rand() % (std::numeric_limits<uint8>::max)(),
+				std::rand() % (std::numeric_limits<uint8>::max)(),
+				std::rand() % (std::numeric_limits<uint8>::max)());
 		}
 	};
 
@@ -178,7 +178,7 @@ namespace detail
 	{
 		GLM_FUNC_QUALIFIER static vec<L, float, Q> call(vec<L, float, Q> const& Min, vec<L, float, Q> const& Max)
 		{
-			return vec<L, float, Q>(compute_rand<L, uint32, Q>::call()) / static_cast<float>(std::numeric_limits<uint32>::max()) * (Max - Min) + Min;
+			return vec<L, float, Q>(compute_rand<L, uint32, Q>::call()) / static_cast<float>((std::numeric_limits<uint32>::max)()) * (Max - Min) + Min;
 		}
 	};
 
@@ -187,7 +187,7 @@ namespace detail
 	{
 		GLM_FUNC_QUALIFIER static vec<L, double, Q> call(vec<L, double, Q> const& Min, vec<L, double, Q> const& Max)
 		{
-			return vec<L, double, Q>(compute_rand<L, uint64, Q>::call()) / static_cast<double>(std::numeric_limits<uint64>::max()) * (Max - Min) + Min;
+			return vec<L, double, Q>(compute_rand<L, uint64, Q>::call()) / static_cast<double>((std::numeric_limits<uint64>::max)()) * (Max - Min) + Min;
 		}
 	};
 
@@ -196,7 +196,7 @@ namespace detail
 	{
 		GLM_FUNC_QUALIFIER static vec<L, long double, Q> call(vec<L, long double, Q> const& Min, vec<L, long double, Q> const& Max)
 		{
-			return vec<L, long double, Q>(compute_rand<L, uint64, Q>::call()) / static_cast<long double>(std::numeric_limits<uint64>::max()) * (Max - Min) + Min;
+			return vec<L, long double, Q>(compute_rand<L, uint64, Q>::call()) / static_cast<long double>((std::numeric_limits<uint64>::max)()) * (Max - Min) + Min;
 		}
 	};
 }//namespace detail

--- a/glm/gtc/ulp.inl
+++ b/glm/gtc/ulp.inl
@@ -8,7 +8,7 @@ namespace glm
 	GLM_FUNC_QUALIFIER float next_float(float x)
 	{
 #		if GLM_HAS_CXX11_STL
-		return std::nextafter(x, std::numeric_limits<float>::max());
+		return std::nextafter(x, (std::numeric_limits<float>::max)());
 #		elif((GLM_COMPILER & GLM_COMPILER_VC) || ((GLM_COMPILER & GLM_COMPILER_INTEL) && (GLM_PLATFORM & GLM_PLATFORM_WINDOWS)))
 		return detail::nextafterf(x, FLT_MAX);
 #		elif(GLM_PLATFORM & GLM_PLATFORM_ANDROID)
@@ -22,9 +22,9 @@ namespace glm
 	GLM_FUNC_QUALIFIER double next_float(double x)
 	{
 #		if GLM_HAS_CXX11_STL
-		return std::nextafter(x, std::numeric_limits<double>::max());
+		return std::nextafter(x, (std::numeric_limits<double>::max)());
 #		elif((GLM_COMPILER & GLM_COMPILER_VC) || ((GLM_COMPILER & GLM_COMPILER_INTEL) && (GLM_PLATFORM & GLM_PLATFORM_WINDOWS)))
-		return detail::nextafter(x, std::numeric_limits<double>::max());
+		return detail::nextafter(x, (std::numeric_limits<double>::max)());
 #		elif(GLM_PLATFORM & GLM_PLATFORM_ANDROID)
 		return __builtin_nextafter(x, DBL_MAX);
 #		else
@@ -47,7 +47,7 @@ namespace glm
 	GLM_FUNC_QUALIFIER float prev_float(float x)
 	{
 #		if GLM_HAS_CXX11_STL
-		return std::nextafter(x, std::numeric_limits<float>::min());
+		return std::nextafter(x, (std::numeric_limits<float>::min)());
 #		elif((GLM_COMPILER & GLM_COMPILER_VC) || ((GLM_COMPILER & GLM_COMPILER_INTEL) && (GLM_PLATFORM & GLM_PLATFORM_WINDOWS)))
 		return detail::nextafterf(x, FLT_MIN);
 #		elif(GLM_PLATFORM & GLM_PLATFORM_ANDROID)
@@ -60,7 +60,7 @@ namespace glm
 	GLM_FUNC_QUALIFIER double prev_float(double x)
 	{
 #		if GLM_HAS_CXX11_STL
-		return std::nextafter(x, std::numeric_limits<double>::min());
+		return std::nextafter(x, (std::numeric_limits<double>::min)());
 #		elif((GLM_COMPILER & GLM_COMPILER_VC) || ((GLM_COMPILER & GLM_COMPILER_INTEL) && (GLM_PLATFORM & GLM_PLATFORM_WINDOWS)))
 		return _nextafter(x, DBL_MIN);
 #		elif(GLM_PLATFORM & GLM_PLATFORM_ANDROID)

--- a/glm/gtx/common.inl
+++ b/glm/gtx/common.inl
@@ -34,7 +34,7 @@ namespace detail
 #		if GLM_HAS_CXX11_STL
 			return std::fpclassify(x) == FP_SUBNORMAL;
 #		else
-			return epsilonNotEqual(x, static_cast<T>(0), epsilon<T>()) && std::fabs(x) < std::numeric_limits<T>::min();
+			return epsilonNotEqual(x, static_cast<T>(0), epsilon<T>()) && std::fabs(x) < (std::numeric_limits<T>::min)();
 #		endif
 	}
 

--- a/glm/gtx/compatibility.inl
+++ b/glm/gtx/compatibility.inl
@@ -15,9 +15,9 @@ namespace glm
 			return _isfinite(x) != 0;
 #		else
 			if (std::numeric_limits<genType>::is_integer || std::denorm_absent == std::numeric_limits<genType>::has_denorm)
-				return std::numeric_limits<genType>::min() <= x && std::numeric_limits<genType>::max() >= x;
+				return (std::numeric_limits<genType>::min)() <= x && (std::numeric_limits<genType>::max)() >= x;
 			else
-				return -std::numeric_limits<genType>::max() <= x && std::numeric_limits<genType>::max() >= x;
+				return -(std::numeric_limits<genType>::max)() <= x && (std::numeric_limits<genType>::max)() >= x;
 #		endif
 	}
 

--- a/glm/gtx/component_wise.inl
+++ b/glm/gtx/component_wise.inl
@@ -16,8 +16,8 @@ namespace detail
 	{
 		GLM_FUNC_QUALIFIER static vec<L, floatType, Q> call(vec<L, T, Q> const& v)
 		{
-			floatType const Min = static_cast<floatType>(std::numeric_limits<T>::min());
-			floatType const Max = static_cast<floatType>(std::numeric_limits<T>::max());
+			floatType const Min = static_cast<floatType>((std::numeric_limits<T>::min)());
+			floatType const Max = static_cast<floatType>((std::numeric_limits<T>::max)());
 			return (vec<L, floatType, Q>(v) - Min) / (Max - Min) * static_cast<floatType>(2) - static_cast<floatType>(1);
 		}
 	};
@@ -27,7 +27,7 @@ namespace detail
 	{
 		GLM_FUNC_QUALIFIER static vec<L, floatType, Q> call(vec<L, T, Q> const& v)
 		{
-			return vec<L, floatType, Q>(v) / static_cast<floatType>(std::numeric_limits<T>::max());
+			return vec<L, floatType, Q>(v) / static_cast<floatType>((std::numeric_limits<T>::max)());
 		}
 	};
 
@@ -49,7 +49,7 @@ namespace detail
 	{
 		GLM_FUNC_QUALIFIER static vec<L, T, Q> call(vec<L, floatType, Q> const& v)
 		{
-			floatType const Max = static_cast<floatType>(std::numeric_limits<T>::max()) + static_cast<floatType>(0.5);
+			floatType const Max = static_cast<floatType>((std::numeric_limits<T>::max)()) + static_cast<floatType>(0.5);
 			vec<L, floatType, Q> const Scaled(v * Max);
 			vec<L, T, Q> const Result(Scaled - static_cast<floatType>(0.5));
 			return Result;
@@ -61,7 +61,7 @@ namespace detail
 	{
 		GLM_FUNC_QUALIFIER static vec<L, T, Q> call(vec<L, floatType, Q> const& v)
 		{
-			return vec<L, T, Q>(vec<L, floatType, Q>(v) * static_cast<floatType>(std::numeric_limits<T>::max()));
+			return vec<L, T, Q>(vec<L, floatType, Q>(v) * static_cast<floatType>(((std::numeric_limits<T>::max))()));
 		}
 	};
 

--- a/glm/gtx/float_normalize.inl
+++ b/glm/gtx/float_normalize.inl
@@ -7,7 +7,7 @@ namespace glm
 	template<length_t L, typename T, qualifier Q>
 	GLM_FUNC_QUALIFIER vec<L, float, Q> floatNormalize(vec<L, T, Q> const& v)
 	{
-		return vec<L, float, Q>(v) / static_cast<float>(std::numeric_limits<T>::max());
+		return vec<L, float, Q>(v) / static_cast<float>((std::numeric_limits<T>::max)());
 	}
 
 }//namespace glm


### PR DESCRIPTION
I get the following warning in windows when compiling my project (MSVC/cl.exe)

```
warning C4003: not enough arguments for function-like macro invocation 'min/max'
```

This commit wraps all occurrences of `std::numeric_limits<>::min/max` in brackets which resolves the warnings