### PR TITLE
Update GitHub Actions

### DIFF
--- a/.github/workflows/make_light_release.yml
+++ b/.github/workflows/make_light_release.yml
@@ -15,7 +15,7 @@ jobs:
       run: sudo apt-get update -y && sudo apt-get install -y zip p7zip
       
     - name: Check out repository code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       
     - name: Set env
       run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
@@ -29,13 +29,13 @@ jobs:
     - name: Create 7z archive
       run: 7z a glm-${{ env.RELEASE_VERSION }}.7z .
       
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: glm-${{ env.RELEASE_VERSION }}
         path: glm-${{ env.RELEASE_VERSION }}.*
         
     - name: Add to Release
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@v2
       with:
         files: |
           glm-${{ env.RELEASE_VERSION }}.zip


### PR DESCRIPTION
Fix the following warning:
> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, actions/upload-artifact@v3, softprops/action-gh-release@v1. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

https://github.com/g-truc/glm/actions/runs/8050790631