### PR TITLE
Fix typos

### DIFF
--- a/glm/ext/matrix_transform.hpp
+++ b/glm/ext/matrix_transform.hpp
@@ -126,7 +126,7 @@ namespace glm
 	///
 	/// @param eye Position of the camera
 	/// @param center Position where the camera is looking at
-	/// @param up Normalized up vector, how the camera is oriented. Typically (0, 0, 1)
+	/// @param up Normalized up vector, how the camera is oriented. Typically (0, 1, 0)
 	///
 	/// @tparam T A floating-point scalar type
 	/// @tparam Q A value from qualifier enum
@@ -140,7 +140,7 @@ namespace glm
 	///
 	/// @param eye Position of the camera
 	/// @param center Position where the camera is looking at
-	/// @param up Normalized up vector, how the camera is oriented. Typically (0, 0, 1)
+	/// @param up Normalized up vector, how the camera is oriented. Typically (0, 1, 0)
 	///
 	/// @tparam T A floating-point scalar type
 	/// @tparam Q A value from qualifier enum
@@ -154,7 +154,7 @@ namespace glm
 	///
 	/// @param eye Position of the camera
 	/// @param center Position where the camera is looking at
-	/// @param up Normalized up vector, how the camera is oriented. Typically (0, 0, 1)
+	/// @param up Normalized up vector, how the camera is oriented. Typically (0, 1, 0)
 	///
 	/// @tparam T A floating-point scalar type
 	/// @tparam Q A value from qualifier enum


### PR DESCRIPTION
Fixes typos in comments. The up vector is typically (0, 1, 0). 