### PR TITLE
optimize vector component access and use GLM_ASSERT_LENGTH in dual_quaternion

### DIFF
--- a/glm/detail/type_vec2.inl
+++ b/glm/detail/type_vec2.inl
@@ -106,28 +106,14 @@ namespace glm
 	GLM_FUNC_QUALIFIER GLM_CONSTEXPR T & vec<2, T, Q>::operator[](typename vec<2, T, Q>::length_type i)
 	{
 		GLM_ASSERT_LENGTH(i, this->length());
-		switch(i)
-		{
-		default:
-		case 0:
-			return x;
-		case 1:
-			return y;
-		}
+		return (&x)[i];
 	}
 
 	template<typename T, qualifier Q>
 	GLM_FUNC_QUALIFIER GLM_CONSTEXPR T const& vec<2, T, Q>::operator[](typename vec<2, T, Q>::length_type i) const
 	{
 		GLM_ASSERT_LENGTH(i, this->length());
-		switch(i)
-		{
-		default:
-		case 0:
-			return x;
-		case 1:
-			return y;
-		}
+		return (&x)[i];
 	}
 
 	// -- Unary arithmetic operators --

--- a/glm/detail/type_vec3.inl
+++ b/glm/detail/type_vec3.inl
@@ -171,32 +171,14 @@ namespace glm
 	GLM_FUNC_QUALIFIER GLM_CONSTEXPR T & vec<3, T, Q>::operator[](typename vec<3, T, Q>::length_type i)
 	{
 		GLM_ASSERT_LENGTH(i, this->length());
-		switch(i)
-		{
-		default:
-			case 0:
-		return x;
-			case 1:
-		return y;
-			case 2:
-		return z;
-		}
+		return (&x)[i];
 	}
 
 	template<typename T, qualifier Q>
 	GLM_FUNC_QUALIFIER GLM_CONSTEXPR T const& vec<3, T, Q>::operator[](typename vec<3, T, Q>::length_type i) const
 	{
 		GLM_ASSERT_LENGTH(i, this->length());
-		switch(i)
-		{
-		default:
-		case 0:
-			return x;
-		case 1:
-			return y;
-		case 2:
-			return z;
-		}
+		return (&x)[i];
 	}
 
 	// -- Unary arithmetic operators --

--- a/glm/detail/type_vec4.inl
+++ b/glm/detail/type_vec4.inl
@@ -362,36 +362,14 @@ namespace detail
 	GLM_FUNC_QUALIFIER GLM_CONSTEXPR T& vec<4, T, Q>::operator[](typename vec<4, T, Q>::length_type i)
 	{
 		GLM_ASSERT_LENGTH(i, this->length());
-		switch (i)
-		{
-		default:
-		case 0:
-			return x;
-		case 1:
-			return y;
-		case 2:
-			return z;
-		case 3:
-			return w;
-		}
+		return (&x)[i];
 	}
 
 	template<typename T, qualifier Q>
 	GLM_FUNC_QUALIFIER GLM_CONSTEXPR T const& vec<4, T, Q>::operator[](typename vec<4, T, Q>::length_type i) const
 	{
 		GLM_ASSERT_LENGTH(i, this->length());
-		switch (i)
-		{
-		default:
-		case 0:
-			return x;
-		case 1:
-			return y;
-		case 2:
-			return z;
-		case 3:
-			return w;
-		}
+		return (&x)[i];
 	}
 
 	// -- Unary arithmetic operators --

--- a/glm/gtx/dual_quaternion.inl
+++ b/glm/gtx/dual_quaternion.inl
@@ -10,14 +10,14 @@ namespace glm
 	template<typename T, qualifier Q>
 	GLM_FUNC_QUALIFIER typename tdualquat<T, Q>::part_type & tdualquat<T, Q>::operator[](typename tdualquat<T, Q>::length_type i)
 	{
-		assert(i >= 0 && i < this->length());
+		GLM_ASSERT_LENGTH(i, this->length());
 		return (&real)[i];
 	}
 
 	template<typename T, qualifier Q>
 	GLM_FUNC_QUALIFIER typename tdualquat<T, Q>::part_type const& tdualquat<T, Q>::operator[](typename tdualquat<T, Q>::length_type i) const
 	{
-		assert(i >= 0 && i < this->length());
+		GLM_ASSERT_LENGTH(i, this->length());
 		return (&real)[i];
 	}
 


### PR DESCRIPTION
the title says it all
the explanation for the optimization:
- accessing using a pointer is faster than a `switch/case` (which is also clearly visible if you ever try to RE some code that uses that `operator[]`)
- it's a single line
- this was technically already done in `type_quat` so i don't understand why it wasn't done in `type_vec`s

also `dual_quaternion` `operator[]` for some reason didn't use the `GLM_ASSERT_LENGTH` macro, so i fixed that.