### PR TITLE
typo in natvis name

### DIFF
--- a/util/glm.natvis
+++ b/util/glm.natvis
@@ -403,7 +403,7 @@
     </Expand>
   </Type>
 
-  <Type Name="glm::mat&lt;3,2*,*&gt;">
+  <Type Name="glm::mat&lt;3,2,*,*&gt;">
     <DisplayString>[{value[0]} {value[1]} {value[2]}]</DisplayString>
     <Expand HideRawView="1">
       <!-- display matrix in row major order - it makes more sense -->


### PR DESCRIPTION
Typo in natvis file causes error if parsed in VS2022. This PR fixes the wrong name spec.