### PR TITLE
Fix some warnings when compiling with MSVC on Windows

### DIFF
--- a/glm/ext/quaternion_exponential.inl
+++ b/glm/ext/quaternion_exponential.inl
@@ -60,7 +60,7 @@ namespace glm
 			//VectorMagnitude to 0. here; we could use denorm_int() compiling a
 			//project with unsafe maths optimizations might make the comparison
 			//always false, even when VectorMagnitude is 0.
-			if (VectorMagnitude < std::numeric_limits<T>::min()) {
+			if (VectorMagnitude < (std::numeric_limits<T>::min)()) {
 				//Equivalent to raising a real number to a power
 				return qua<T, Q>::wxyz(pow(x.w, y), 0, 0, 0);
 			}

--- a/glm/ext/scalar_common.hpp
+++ b/glm/ext/scalar_common.hpp
@@ -31,7 +31,7 @@ namespace glm
 	///
 	/// @see ext_scalar_common
 	template<typename T>
-	GLM_FUNC_DECL T min(T a, T b, T c);
+	GLM_FUNC_DECL T (min)(T a, T b, T c);
 
 	/// Returns the minimum component-wise values of 4 inputs
 	///
@@ -39,7 +39,7 @@ namespace glm
 	///
 	/// @see ext_scalar_common
 	template<typename T>
-	GLM_FUNC_DECL T min(T a, T b, T c, T d);
+	GLM_FUNC_DECL T (min)(T a, T b, T c, T d);
 
 	/// Returns the maximum component-wise values of 3 inputs
 	///
@@ -47,7 +47,7 @@ namespace glm
 	///
 	/// @see ext_scalar_common
 	template<typename T>
-	GLM_FUNC_DECL T max(T a, T b, T c);
+	GLM_FUNC_DECL T (max)(T a, T b, T c);
 
 	/// Returns the maximum component-wise values of 4 inputs
 	///
@@ -55,7 +55,7 @@ namespace glm
 	///
 	/// @see ext_scalar_common
 	template<typename T>
-	GLM_FUNC_DECL T max(T a, T b, T c, T d);
+	GLM_FUNC_DECL T (max)(T a, T b, T c, T d);
 
 	/// Returns the minimum component-wise values of 2 inputs. If one of the two arguments is NaN, the value of the other argument is returned.
 	///
@@ -64,7 +64,7 @@ namespace glm
 	/// @see <a href="http://en.cppreference.com/w/cpp/numeric/math/fmin">std::fmin documentation</a>
 	/// @see ext_scalar_common
 	template<typename T>
-	GLM_FUNC_DECL T fmin(T a, T b);
+	GLM_FUNC_DECL T (fmin)(T a, T b);
 
 	/// Returns the minimum component-wise values of 3 inputs. If one of the two arguments is NaN, the value of the other argument is returned.
 	///
@@ -73,7 +73,7 @@ namespace glm
 	/// @see <a href="http://en.cppreference.com/w/cpp/numeric/math/fmin">std::fmin documentation</a>
 	/// @see ext_scalar_common
 	template<typename T>
-	GLM_FUNC_DECL T fmin(T a, T b, T c);
+	GLM_FUNC_DECL T (fmin)(T a, T b, T c);
 
 	/// Returns the minimum component-wise values of 4 inputs. If one of the two arguments is NaN, the value of the other argument is returned.
 	///
@@ -82,7 +82,7 @@ namespace glm
 	/// @see <a href="http://en.cppreference.com/w/cpp/numeric/math/fmin">std::fmin documentation</a>
 	/// @see ext_scalar_common
 	template<typename T>
-	GLM_FUNC_DECL T fmin(T a, T b, T c, T d);
+	GLM_FUNC_DECL T (fmin)(T a, T b, T c, T d);
 
 	/// Returns the maximum component-wise values of 2 inputs. If one of the two arguments is NaN, the value of the other argument is returned.
 	///
@@ -91,7 +91,7 @@ namespace glm
 	/// @see <a href="http://en.cppreference.com/w/cpp/numeric/math/fmax">std::fmax documentation</a>
 	/// @see ext_scalar_common
 	template<typename T>
-	GLM_FUNC_DECL T fmax(T a, T b);
+	GLM_FUNC_DECL T (fmax)(T a, T b);
 
 	/// Returns the maximum component-wise values of 3 inputs. If one of the two arguments is NaN, the value of the other argument is returned.
 	///
@@ -100,7 +100,7 @@ namespace glm
 	/// @see <a href="http://en.cppreference.com/w/cpp/numeric/math/fmax">std::fmax documentation</a>
 	/// @see ext_scalar_common
 	template<typename T>
-	GLM_FUNC_DECL T fmax(T a, T b, T C);
+	GLM_FUNC_DECL T (fmax)(T a, T b, T C);
 
 	/// Returns the maximum component-wise values of 4 inputs. If one of the two arguments is NaN, the value of the other argument is returned.
 	///
@@ -109,7 +109,7 @@ namespace glm
 	/// @see <a href="http://en.cppreference.com/w/cpp/numeric/math/fmax">std::fmax documentation</a>
 	/// @see ext_scalar_common
 	template<typename T>
-	GLM_FUNC_DECL T fmax(T a, T b, T C, T D);
+	GLM_FUNC_DECL T (fmax)(T a, T b, T C, T D);
 
 	/// Returns min(max(x, minVal), maxVal) for each component in x. If one of the two arguments is NaN, the value of the other argument is returned.
 	///

--- a/glm/ext/scalar_common.inl
+++ b/glm/ext/scalar_common.inl
@@ -39,33 +39,33 @@ namespace glm
 #	endif
 
 	template<typename T>
-	GLM_FUNC_QUALIFIER T fmin(T a, T b, T c)
+	GLM_FUNC_QUALIFIER T (fmin)(T a, T b, T c)
 	{
 		GLM_STATIC_ASSERT(std::numeric_limits<T>::is_iec559 || GLM_CONFIG_UNRESTRICTED_FLOAT, "'fmin' only accept floating-point input");
 
 		if (isnan(a))
-			return fmin(b, c);
+			return (fmin)(b, c);
 		if (isnan(b))
-			return fmin(a, c);
+			return (fmin)(a, c);
 		if (isnan(c))
 			return min(a, b);
-		return min(a, b, c);
+		return (min)(a, b, c);
 	}
 
 	template<typename T>
-	GLM_FUNC_QUALIFIER T fmin(T a, T b, T c, T d)
+	GLM_FUNC_QUALIFIER T (fmin)(T a, T b, T c, T d)
 	{
 		GLM_STATIC_ASSERT(std::numeric_limits<T>::is_iec559 || GLM_CONFIG_UNRESTRICTED_FLOAT, "'fmin' only accept floating-point input");
 
 		if (isnan(a))
-			return fmin(b, c, d);
+			return (fmin)(b, c, d);
 		if (isnan(b))
-			return min(a, fmin(c, d));
+			return (min)(a, (fmin)(c, d));
 		if (isnan(c))
-			return fmin(min(a, b), d);
+			return (fmin)(min(a, b), d);
 		if (isnan(d))
-			return min(a, b, c);
-		return min(a, b, c, d);
+			return (min)(a, b, c);
+		return (min)(a, b, c, d);
 	}
 
 
@@ -73,44 +73,44 @@ namespace glm
 		using std::fmax;
 #	else
 		template<typename T>
-		GLM_FUNC_QUALIFIER T fmax(T a, T b)
+		GLM_FUNC_QUALIFIER T (fmax)(T a, T b)
 		{
 			GLM_STATIC_ASSERT(std::numeric_limits<T>::is_iec559 || GLM_CONFIG_UNRESTRICTED_FLOAT, "'fmax' only accept floating-point input");
 
 			if (isnan(a))
 				return b;
-			return max(a, b);
+			return (max)(a, b);
 		}
 #	endif
 
 	template<typename T>
-	GLM_FUNC_QUALIFIER T fmax(T a, T b, T c)
+	GLM_FUNC_QUALIFIER T (fmax)(T a, T b, T c)
 	{
 		GLM_STATIC_ASSERT(std::numeric_limits<T>::is_iec559 || GLM_CONFIG_UNRESTRICTED_FLOAT, "'fmax' only accept floating-point input");
 
 		if (isnan(a))
-			return fmax(b, c);
+			return (fmax)(b, c);
 		if (isnan(b))
-			return fmax(a, c);
+			return (fmax)(a, c);
 		if (isnan(c))
-			return max(a, b);
-		return max(a, b, c);
+			return (max)(a, b);
+		return (max)(a, b, c);
 	}
 
 	template<typename T>
-	GLM_FUNC_QUALIFIER T fmax(T a, T b, T c, T d)
+	GLM_FUNC_QUALIFIER T (fmax)(T a, T b, T c, T d)
 	{
 		GLM_STATIC_ASSERT(std::numeric_limits<T>::is_iec559 || GLM_CONFIG_UNRESTRICTED_FLOAT, "'fmax' only accept floating-point input");
 
 		if (isnan(a))
-			return fmax(b, c, d);
+			return (fmax)(b, c, d);
 		if (isnan(b))
-			return max(a, fmax(c, d));
+			return (max)(a, (fmax)(c, d));
 		if (isnan(c))
-			return fmax(max(a, b), d);
+			return (fmax)((max)(a, b), d);
 		if (isnan(d))
-			return max(a, b, c);
-		return max(a, b, c, d);
+			return (max)(a, b, c);
+		return (max)(a, b, c, d);
 	}
 
 	// fclamp
@@ -118,7 +118,7 @@ namespace glm
 	GLM_FUNC_QUALIFIER genType fclamp(genType x, genType minVal, genType maxVal)
 	{
 		GLM_STATIC_ASSERT(std::numeric_limits<genType>::is_iec559 || GLM_CONFIG_UNRESTRICTED_FLOAT, "'fclamp' only accept floating-point or integer inputs");
-		return fmin(fmax(x, minVal), maxVal);
+		return fmin((fmax)(x, minVal), maxVal);
 	}
 
 	template<typename genType>

--- a/glm/ext/scalar_common.inl
+++ b/glm/ext/scalar_common.inl
@@ -1,27 +1,27 @@
 namespace glm
 {
 	template<typename T>
-	GLM_FUNC_QUALIFIER T min(T a, T b, T c)
+	GLM_FUNC_QUALIFIER T (min)(T a, T b, T c)
 	{
-		return glm::min(glm::min(a, b), c);
+		return (glm::min)((glm::min)(a, b), c);
 	}
 
 	template<typename T>
-	GLM_FUNC_QUALIFIER T min(T a, T b, T c, T d)
+	GLM_FUNC_QUALIFIER T (min)(T a, T b, T c, T d)
 	{
-		return glm::min(glm::min(a, b), glm::min(c, d));
+		return (glm::min)((glm::min)(a, b), (glm::min)(c, d));
 	}
 
 	template<typename T>
-	GLM_FUNC_QUALIFIER T max(T a, T b, T c)
+	GLM_FUNC_QUALIFIER T (max)(T a, T b, T c)
 	{
-		return glm::max(glm::max(a, b), c);
+		return (glm::max)((glm::max)(a, b), c);
 	}
 
 	template<typename T>
-	GLM_FUNC_QUALIFIER T max(T a, T b, T c, T d)
+	GLM_FUNC_QUALIFIER T (max)(T a, T b, T c, T d)
 	{
-		return glm::max(glm::max(a, b), glm::max(c, d));
+		return (glm::max)((glm::max)(a, b), (glm::max)(c, d));
 	}
 
 #	if GLM_HAS_CXX11_STL

--- a/glm/gtx/component_wise.inl
+++ b/glm/gtx/component_wise.inl
@@ -16,8 +16,8 @@ namespace detail
 	{
 		GLM_FUNC_QUALIFIER static vec<L, floatType, Q> call(vec<L, T, Q> const& v)
 		{
-			floatType const Min = static_cast<floatType>(std::numeric_limits<T>::min());
-			floatType const Max = static_cast<floatType>(std::numeric_limits<T>::max());
+			floatType const Min = static_cast<floatType>((std::numeric_limits<T>::min)());
+			floatType const Max = static_cast<floatType>((std::numeric_limits<T>::max)());
 			return (vec<L, floatType, Q>(v) - Min) / (Max - Min) * static_cast<floatType>(2) - static_cast<floatType>(1);
 		}
 	};
@@ -27,7 +27,7 @@ namespace detail
 	{
 		GLM_FUNC_QUALIFIER static vec<L, floatType, Q> call(vec<L, T, Q> const& v)
 		{
-			return vec<L, floatType, Q>(v) / static_cast<floatType>(std::numeric_limits<T>::max());
+			return vec<L, floatType, Q>(v) / static_cast<floatType>((std::numeric_limits<T>::max)());
 		}
 	};
 
@@ -49,7 +49,7 @@ namespace detail
 	{
 		GLM_FUNC_QUALIFIER static vec<L, T, Q> call(vec<L, floatType, Q> const& v)
 		{
-			floatType const Max = static_cast<floatType>(std::numeric_limits<T>::max()) + static_cast<floatType>(0.5);
+			floatType const Max = static_cast<floatType>((std::numeric_limits<T>::max)()) + static_cast<floatType>(0.5);
 			vec<L, floatType, Q> const Scaled(v * Max);
 			vec<L, T, Q> const Result(Scaled - static_cast<floatType>(0.5));
 			return Result;
@@ -61,7 +61,7 @@ namespace detail
 	{
 		GLM_FUNC_QUALIFIER static vec<L, T, Q> call(vec<L, floatType, Q> const& v)
 		{
-			return vec<L, T, Q>(vec<L, floatType, Q>(v) * static_cast<floatType>(std::numeric_limits<T>::max()));
+			return vec<L, T, Q>(vec<L, floatType, Q>(v) * static_cast<floatType>((std::numeric_limits<T>::max)()));
 		}
 	};
 


### PR DESCRIPTION
This commit fixes some warnings when compiling with MSVC on windows. 

```
include\glm\ext\quaternion_exponential.inl(63,50): warning C4003: not enough arguments for function-like macro invocation 'min'
include\glm\ext\scalar_common.inl(52,10): warning C4002: too many arguments for function-like macro invocation 'min'
include\glm\gtx\component_wise.inl(19,73): warning C4003: not enough arguments for function-like macro invocation 'min'
include\glm\gtx\component_wise.inl(20,73): warning C4003: not enough arguments for function-like macro invocation 'max'
include\glm\gtx\component_wise.inl(30,84): warning C4003: not enough arguments for function-like macro invocation 'max'
include\glm\gtx\component_wise.inl(52,73): warning C4003: not enough arguments for function-like macro invocation 'max'
include\glm\gtx\component_wise.inl(64,97): warning C4003: not enough arguments for function-like macro invocation 'max'
```