### PR TITLE
Fix a wrong macro for tdualquat ctor

### DIFF
--- a/glm/gtx/dual_quaternion.hpp
+++ b/glm/gtx/dual_quaternion.hpp
@@ -54,7 +54,7 @@ namespace glm
 
 		// -- Implicit basic constructors --
 
-		GLM_DEFAULTED_FUNC_DECL GLM_CONSTEXPR tdualquat() GLM_DEFAULT;
+		GLM_DEFAULTED_DEFAULT_CTOR_DECL GLM_CONSTEXPR tdualquat() GLM_DEFAULT_CTOR;
 		GLM_DEFAULTED_FUNC_DECL GLM_CONSTEXPR tdualquat(tdualquat<T, Q> const& d) GLM_DEFAULT;
 		template<qualifier P>
 		GLM_CTOR_DECL tdualquat(tdualquat<T, P> const& d);


### PR DESCRIPTION
The previous PR #1144 forgot the macros of `tdualquat() GLM_DEFAULT` in `glm/gtx/dual_quaternion.hpp`