### PR TITLE
Remove Android-specific detection of GLM_HAS_CXX11_STL

### DIFF
--- a/glm/detail/setup.hpp
+++ b/glm/detail/setup.hpp
@@ -148,10 +148,7 @@
 // http://gcc.gnu.org/projects/cxx0x.html
 // http://msdn.microsoft.com/en-us/library/vstudio/hh567368(v=vs.120).aspx
 
-// Android has multiple STLs but C++11 STL detection doesn't always work #284 #564
-#if GLM_PLATFORM == GLM_PLATFORM_ANDROID && !defined(GLM_LANG_STL11_FORCED)
-#	define GLM_HAS_CXX11_STL 0
-#elif (GLM_COMPILER & GLM_COMPILER_CUDA_RTC) == GLM_COMPILER_CUDA_RTC
+#if (GLM_COMPILER & GLM_COMPILER_CUDA_RTC) == GLM_COMPILER_CUDA_RTC
 #	define GLM_HAS_CXX11_STL 0
 #elif (GLM_COMPILER & GLM_COMPILER_HIP)
 #	define GLM_HAS_CXX11_STL 0


### PR DESCRIPTION
Android NDK starting from r18 has libcxx, and it's the only STL available. (reference: https://developer.android.com/ndk/guides/cpp-support#cs)

r18 is ~6 years old at this point.
This check dates to ~8 years ago (predating r18) and was important at that time.

Right now, it can be clearly stated that given the C++11 requirement stated in README for GLM, as well as (unless you are building with very outdated toolchain) - all modern Android is built with NDK toolchain that is newer than r18 - this check can be removed, and all the functionality can by default delegate to general detection for STL compatibility.