### PR TITLE
Add support for sse4.2 when using msvc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -193,7 +193,7 @@ elseif(GLM_ENABLE_SIMD_SSE4_2)
 	elseif(CMAKE_CXX_COMPILER_ID MATCHES "Intel")
 		add_compile_options(/QxSSE4.2)
 	elseif((CMAKE_CXX_COMPILER_ID MATCHES "MSVC") AND NOT CMAKE_CL_64)
-		add_compile_options(/arch:SSE2) # VC doesn't support SSE4.2
+		add_compile_options(/arch:SSE4.2)
 	endif()
 	message(STATUS "GLM: SSE4.2 instruction set")
 


### PR DESCRIPTION
Until now the library have been using sse2 when enabling sse4.2 support in msvc, this pull request fixes that.