### PR TITLE
Fix module interface missing some gtx quaternion functions

### DIFF
--- a/glm/glm.cppm
+++ b/glm/glm.cppm
@@ -2634,6 +2634,9 @@ export namespace glm {
 		using glm::tanh;
 		using glm::third;
 		using glm::three_over_two_pi;
+		using glm::toMat3;
+		using glm::toMat4;
+		using glm::toQuat;
 		using glm::translate;
 		using glm::transpose;
 		using glm::triangleNormal;


### PR DESCRIPTION
Adds missing functions from `<glm/gtx/quaternion.hpp>` to c++20 module interface.