### PR TITLE
Specify CMake policy range to avoid deprecation warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,6 @@
-cmake_minimum_required(VERSION 3.6 FATAL_ERROR)
-cmake_policy(VERSION 3.6)
+# 3.6 is the actual minimun. 3.14 as the upper policy limit avoids CMake deprecation warnings.
+cmake_minimum_required(VERSION 3.6...3.14 FATAL_ERROR)
+cmake_policy(VERSION 3.6...3.14)
 
 file(READ "glm/detail/setup.hpp" GLM_SETUP_FILE)
 string(REGEX MATCH "#define[ ]+GLM_VERSION_MAJOR[ ]+([0-9]+)" _ ${GLM_SETUP_FILE})


### PR DESCRIPTION
Replace single minimum version with version range to suppress CMake 3.31
deprecation warnings.
This change:
- Avoids new deprecation warnings in CMake 3.31+ for versions < 3.10
- Maintains backward compatibility with existing build environments
- Adopts NEW policy behaviors for all policies up to CMake 3.14
- Does not increase the minimum required CMake version