### PR TITLE
GTX fast math improvements

### DIFF
--- a/glm/detail/func_exponential.inl
+++ b/glm/detail/func_exponential.inl
@@ -145,7 +145,7 @@ namespace detail
                  val.f = val.f * (1.5 - (x_half * val.f * val.f));
                  val.f = val.f * (1.5 - (x_half * val.f * val.f));
                  val.f = val.f * (1.5 - (x_half * val.f * val.f));
-                 return static_cast<T>(val.f);
+                 return static_cast<genType>(val.f);
         }
 
 	template<length_t L, typename T, qualifier Q>

--- a/glm/detail/func_exponential.inl
+++ b/glm/detail/func_exponential.inl
@@ -135,8 +135,18 @@ namespace detail
 	template<typename genType>
 	GLM_FUNC_QUALIFIER genType inversesqrt(genType x)
 	{
-		return static_cast<genType>(1) / sqrt(x);
-	}
+		 union __double64_t {
+ 	            double f;
+ 	            uint64_t n;
+                 } val = {static_cast<double>(x)};
+                 const double x_half = static_cast<double>(x*0.5);
+                 val.n = 0x5fe6eb50c7b537a9 - (val.n >> 1);
+                 val.f = val.f * (1.5 - (x_half * val.f * val.f));
+                 val.f = val.f * (1.5 - (x_half * val.f * val.f));
+                 val.f = val.f * (1.5 - (x_half * val.f * val.f));
+                 val.f = val.f * (1.5 - (x_half * val.f * val.f));
+                 return static_cast<T>(val.f);
+        }
 
 	template<length_t L, typename T, qualifier Q>
 	GLM_FUNC_QUALIFIER vec<L, T, Q> inversesqrt(vec<L, T, Q> const& x)

--- a/glm/gtx/fast_exponential.hpp
+++ b/glm/gtx/fast_exponential.hpp
@@ -15,6 +15,7 @@
 
 // Dependency:
 #include "../glm.hpp"
+#include "../gtc/constants.hpp"
 
 #ifndef GLM_ENABLE_EXPERIMENTAL
 #	error "GLM: GLM_GTX_fast_exponential is an experimental extension and may change in the future. Use #define GLM_ENABLE_EXPERIMENTAL before including it, if you really want to use it."

--- a/glm/gtx/fast_exponential.inl
+++ b/glm/gtx/fast_exponential.inl
@@ -66,7 +66,7 @@ namespace glm
                    //subdivide into half, take advantage this formula exp(x) = exp(x/2)^2 for better accuracy
 	           fractional = ((fractional * ln_two<T>()) * 0.5);
 	 
-	           //the code above can be used here since the fractional is always lower than 1.0
+	           //the code above is used here since the fractional is always lower than 1.0
                    const T x2 = fractional * fractional;
 		   const T x3 = x2 * fractional;
 	 	   const T x4 = x3 * fractional;
@@ -158,7 +158,7 @@ namespace glm
 	{
 		return fastLog(x) / static_cast<genType>(0.69314718055994530941723212145818);
 	    /*
-	    // ieee log2 function, bit slower than std::logb
+	    // ieee log2 function, bit slower than std::log
 #define __epsilon 0.0001
 #define __inv_ln2 1.4426950409 // 1.0 / log(ln)
            union __double64_t {

--- a/glm/gtx/fast_exponential.inl
+++ b/glm/gtx/fast_exponential.inl
@@ -38,6 +38,7 @@ namespace glm
 	template<typename T>
 	GLM_FUNC_QUALIFIER T fastExp(T x)
 	{
+	 /*
 		// This has a better looking and same performance in release mode than the following code. However, in debug mode it's slower.
 		// return 1.0f + x * (1.0f + x * 0.5f * (1.0f + x * 0.3333333333f * (1.0f + x * 0.25 * (1.0f + x * 0.2f))));
 		T x2 = x * x;
@@ -45,6 +46,66 @@ namespace glm
 		T x4 = x3 * x;
 		T x5 = x4 * x;
 		return T(1) + x + (x2 * T(0.5)) + (x3 * T(0.1666666667)) + (x4 * T(0.041666667)) + (x5 * T(0.008333333333));
+	*/
+
+        /*
+           ieee754 exponential with average error 1e-10, bit faster than std::exp
+           e^x = (x_exponent / ln(2)) * taylor_series(x-floor(x))
+        */
+                const double __ln2 = 0.693147180559945309417232121; //log(2)
+
+ 
+                 x /= __ln2; //convert to 2^x
+                 bool sign = x < 0; // handling negative values using reciprocal exp(x) = 1.0 / exp(-x)
+                 if(sign)
+                   x = -x;
+ 
+                 const uint16_t exponent = static_cast<uint16_t>(x);
+                 double fractional = x-exponent;
+
+                 double out = 1.0;
+                 uint64_t* bits = reinterpret_cast<uint64_t*>(&out);
+                 (*bits) += ((uint64_t)exponent) << 52; //the base of ieee float is 2 so just add into its exponent
+
+                 if(fractional >= 1e-4) {
+                      //you can replace your code above here since the value of "fractional" is lower than zero
+                      double exponential = 1.0;
+                      double iteration = 1.0;
+                      //subdivide it into half 5x, take advantage this formula "exp(x/2) = exp(x/2)^2" for accuracy
+                      fractional = ((((fractional * __ln2) * 0.5) * 0.5) * 0.5);
+
+                      //just remove this comment if you want more accurate 
+                      //fractional = (((((fractional * Math_LN2) * 0.5) * 0.5) * 0.5) * 0.5) * 0.5;
+
+                      //                  (pre computed reciprocals)
+                      iteration *= fractional * 1.0000000000000000; //1 / 1
+                      exponential += iteration;
+                      iteration *= fractional * 0.5000000000000000; //1 / 2
+                      exponential += iteration;
+                     /*
+                     //just remove this comment if you want more accurate 
+                     iteration *= fractional * 0.3333333333333333; //1 / 3
+                     exponential += iteration;
+                     iteration *= fractional * 0.2500000000000000; //1 / 4
+                     exponential += iteration;
+                     iteration *= fractional * 0.2000000000000000; //1 / 5
+                     exponential += iteration;
+                     iteration *= fractional * 0.1666666666666666; //1 / 6
+                     exponential += iteration;
+                     */
+                     //squared it 5x
+                     exponential *= exponential;
+                     exponential *= exponential;
+                     exponential *= exponential;
+                    /*
+                    //just remove this comment if you want more accurate 
+                    exponential *= exponential;
+                    exponential *= exponential;
+                    exponential *= exponential;
+                    */
+                    return static_cast<T>((sign) ? (1.0 / (out * exponential)) : (out * exponential));
+               }
+          return static_cast<T>((sign) ? (1.0/ out) : out);
 	}
 	/*  // Try to handle all values of float... but often shower than std::exp, glm::floor and the loop kill the performance
 	GLM_FUNC_QUALIFIER float fastExp(float x)

--- a/glm/gtx/fast_exponential.inl
+++ b/glm/gtx/fast_exponential.inl
@@ -34,7 +34,6 @@ namespace glm
 	}
 
 	// fastExp
-	// Note: This function provides accurate results only for value between -1 and 1, else avoid it.
 	template<typename T>
 	GLM_FUNC_QUALIFIER T fastExp(T x)
 	{
@@ -48,12 +47,11 @@ namespace glm
 		return T(1) + x + (x2 * T(0.5)) + (x3 * T(0.1666666667)) + (x4 * T(0.041666667)) + (x5 * T(0.008333333333));
 	*/
         /*
-         ieee exponential, it handle large and negative value
+         ieee exponential, it handles large and negative values
          e^x = (x_exponent / ln(2)) * taylor_series(x-floor(x))
         */
-#define __ln2 0.693147180559945 //log(ln)
 #define __epsilon 0.0001
-              x /= __ln2; //convert to 2^x
+              x /= ln_two<T>();
               bool sign = x < 0; //handling negative values exp(-x) = 1.0 / exp(abs(x))
               if(sign)
                  x = -x;
@@ -64,10 +62,9 @@ namespace glm
 	       uint64_t* bits = reinterpret_cast<uint64_t*>(&out);
 	       (*bits) += ((uint64_t)exponent) << 52; //the base of ieee float is 2, so just add whole number of x to exponent
 
-               //handling decimal numbers 
                if(fractional >= __epsilon) {
                    //subdivide into half, take advantage this formula exp(x) = exp(x/2)^2 for better accuracy
-	           fractional = ((fractional * __ln2) * 0.5);
+	           fractional = ((fractional * ln_two<T>()) * 0.5);
 	 
 	           //the code above can be used here since the fractional is always lower than 1.0
                    const T x2 = fractional * fractional;
@@ -78,7 +75,6 @@ namespace glm
 	 	   return static_cast<T>((sign) ? 1.0 / (out * (x*x)) : (out * (x*x)));
 	         }
                return static_cast<T>((sign) ? 1.0/ out : out);
-#undef __ln2
 #undef __epsilon
         }
 	/*  // Try to handle all values of float... but often shower than std::exp, glm::floor and the loop kill the performance

--- a/glm/gtx/fast_exponential.inl
+++ b/glm/gtx/fast_exponential.inl
@@ -148,7 +148,7 @@ namespace glm
 	GLM_FUNC_QUALIFIER genType fastExp2(genType x)
 	{
 		return fastExp(static_cast<genType>(0.69314718055994530941723212145818) * x);
-	}
+        }
 
 	template<length_t L, typename T, qualifier Q>
 	GLM_FUNC_QUALIFIER vec<L, T, Q> fastExp2(vec<L, T, Q> const& x)
@@ -161,7 +161,46 @@ namespace glm
 	GLM_FUNC_QUALIFIER genType fastLog2(genType x)
 	{
 		return fastLog(x) / static_cast<genType>(0.69314718055994530941723212145818);
-	}
+	    /*
+	    // ieee log2 function, bit slower than std::logb
+#define __epsilon 0.0001
+#define __inv_ln2 1.4426950409 // 1.0 / log(ln)
+           union __double64_t {
+  	    double f;
+  	    uint64_t n;
+           } val = {x};
+
+           //handle the value lower than 1.0
+           //const bool bb = ((val.n >> 52) & 0x7FF) < 1023;
+           const bool bb = val.f < 1.0;
+           x = 1.0 + (val.n & 0xFFFFFFFFFFFFF) / static_cast<double>((1LU << 52));
+
+           if(bb)
+             x = 1.0 / x;
+
+           if(x >= __epsilon) {
+             //fast log function
+             const genType y1 = (x - 1.0f) / (x + 1.0f);
+	     const genType y2 = y1 * y1;
+	     genType mx = 2.0 * y1 * (1.0f + y2 * (0.3333333333 + y2 * (0.2f + y2 * 0.1428571429)));
+             // newton raphson iteration, for accuracy and slow computation
+             //genType xp_tmp;
+             //xp_tmp = fastExp<genType>(mx);
+             //mx = mx - ((xp_tmp-x) / xp_tmp);
+             //xp_tmp = fastExp<genType>(mx);
+             //mx = mx - ((xp_tmp-x) / xp_tmp);
+             //xp_tmp = fastExp<genType>(mx);
+             //mx = mx - ((xp_tmp-x) / xp_tmp);
+             //xp_tmp = fastExp<genType>(mx);
+             //mx = mx - ((xp_tmp-x) / xp_tmp);
+             
+             return (bb) ? (-mx) : (mx * __inv_ln2 + genType(((val.n >> 52) & 0x7FF)-1023));
+           }
+          return genType(((val.n >> 52) & 0x7FF)-1023);
+#undef __epsilon
+#undef __inv_ln2
+        */
+        }
 
 	template<length_t L, typename T, qualifier Q>
 	GLM_FUNC_QUALIFIER vec<L, T, Q> fastLog2(vec<L, T, Q> const& x)

--- a/glm/gtx/fast_exponential.inl
+++ b/glm/gtx/fast_exponential.inl
@@ -124,16 +124,14 @@ namespace glm
 		return std::log(x);
         /*
          // fast ieee log
-		union __double64_t {
-			 	double f;
-			 	uint64_t n;
-		} val = {static_cast<double>(x)};
-		// x = 1.0 + (val.n & 0xFFFFFFFFFFFFF) / static_cast<double>((1LU << 52));
-		if(x < 1.0)
-		  return -(-x * (x*x * 0.5));
-		  x = (val.n & 0xFFFFFFFFFFFFF) * 0.0000000000000002;
-		  x = -x * (x*x * 0.5);
-	 return (((val.n >> 52) & 0x7FF)-1023) * 0.69314718055994 + x;
+	      union __double64_t {
+	        double f;
+	        uint64_t n;
+	      } val = {static_cast<double>(x)};
+	      if(x < 1.0)
+		 return -x;
+              x = (val.n & 0xFFFFFFFFFFFFF) * 0.0000000000000002;
+	      return static_cast<genType>((((val.n >> 52) & 0x7FF)-1023) * 0.69314718055994 + x);
         */
 	}
 

--- a/glm/gtx/fast_exponential.inl
+++ b/glm/gtx/fast_exponential.inl
@@ -122,6 +122,19 @@ namespace glm
 	GLM_FUNC_QUALIFIER genType fastLog(genType x)
 	{
 		return std::log(x);
+        /*
+         // fast ieee log
+		union __double64_t {
+			 	double f;
+			 	uint64_t n;
+		} val = {static_cast<double>(x)};
+		// x = 1.0 + (val.n & 0xFFFFFFFFFFFFF) / static_cast<double>((1LU << 52));
+		if(x < 1.0)
+		  return -(-x * (x*x * 0.5));
+		  x = (val.n & 0xFFFFFFFFFFFFF) * 0.0000000000000002;
+		  x = -x * (x*x * 0.5);
+	 return (((val.n >> 52) & 0x7FF)-1023) * 0.69314718055994 + x;
+        */
 	}
 
 	/* Slower than the VC7.1 function...

--- a/glm/gtx/fast_exponential.inl
+++ b/glm/gtx/fast_exponential.inl
@@ -7,6 +7,50 @@ namespace glm
 	GLM_FUNC_QUALIFIER genType fastPow(genType x, genType y)
 	{
 		return exp(y * log(x));
+        /*
+         // ieee pow 
+	      union __double64_t {
+		  double f;
+		  uint64_t n;
+               };
+ 
+              __double64_t mx = {static_cast<double>(x)};
+
+              genType lnx, px, vx;
+              if(x < 1.0)
+                lnx = -(-mx.f * (mx.f*mx.f * 0.5) - (mx.f*mx.f*mx.f * 0.3333333));
+              else {
+                 px = (mx.n & 0xFFFFFFFFFFFFF) * 0.0000000000000002;
+                 vx = (-px * (px*px * 0.5) - (px*px*px * 0.333333));
+                 lnx = static_cast<genType>( (((mx.n >> 52) & 0x7FF)-1023) * 0.69314718055994) + vx;
+               }
+ 
+               for(int i = 0; i < 4; i++) {
+ 	         const genType inx = lnx * 0.5 * 0.5 * 0.5;
+                 const genType x2 = inx * inx;
+	         const genType x3 = x2 * inx;
+	         const genType x4 = x3 * inx;
+	         const genType x5 = x4 * inx;
+	         genType expo = genType(1) + inx + (x2 * genType(0.5)) + (x3 * genType(0.1666666667)) + (x4 * genType(0.041666667)) + (x5 * genType(0.008333333333));
+                 expo *= expo;
+                 expo *= expo;
+                 expo *= expo;
+                 lnx = lnx-((expo-x)/expo);
+                }
+ 
+                genType in_expo_half = y * lnx * 1.4426950408889634 * 0.5;
+                genType my, final_exponent;
+                uint32_t whole = static_cast<uint32_t>(in_expo_half);
+	        const uint64_t integer_exponent = ((1023L+whole) << 52);
+	         my =(in_expo_half-whole)*0.69314718055994;
+	
+	        if(my)
+	          final_exponent = static_cast<genType>(*reinterpret_cast<const double*>(&integer_exponent) * (1.0 + my + (my*my * 0.5)));
+                else
+                  final_exponent = static_cast<genType>(*reinterpret_cast<const double*>(&integer_exponent));
+                final_exponent *= final_exponent;
+             return (y < genType(0.0)) ? (1.0/final_exponent) : final_exponent;
+        */
 	}
 
 	template<length_t L, typename T, qualifier Q>

--- a/glm/gtx/fast_exponential.inl
+++ b/glm/gtx/fast_exponential.inl
@@ -160,7 +160,7 @@ namespace glm
 	    /*
 	    // ieee log2 function, bit slower than std::log
 #define __epsilon 0.0001
-#define __inv_ln2 1.4426950409 // 1.0 / log(ln)
+#define __inv_ln2 1.4426950409 // 1.0 / ln(2)
            union __double64_t {
   	    double f;
   	    uint64_t n;

--- a/glm/gtx/fast_trigonometry.hpp
+++ b/glm/gtx/fast_trigonometry.hpp
@@ -14,6 +14,7 @@
 
 // Dependency:
 #include "../gtc/constants.hpp"
+#include "fast_square_root.hpp"
 
 #ifndef GLM_ENABLE_EXPERIMENTAL
 #	error "GLM: GLM_GTX_fast_trigonometry is an experimental extension and may change in the future. Use #define GLM_ENABLE_EXPERIMENTAL before including it, if you really want to use it."

--- a/glm/gtx/fast_trigonometry.inl
+++ b/glm/gtx/fast_trigonometry.inl
@@ -122,7 +122,7 @@ namespace detail
 	GLM_FUNC_QUALIFIER T fastAtan(T y, T x)
 	{
 		/*
-	        // it works, but it doesn't give an output between 91° and 269°
+	        // it works, but it doesn't mapped the value correctly when vec2 is between 91° and 269°
 	           T sgn = __sign(y) * __sign(x);
 	           return abs(fastAtan(y/x)) * sgn;
 	         */

--- a/glm/gtx/fast_trigonometry.inl
+++ b/glm/gtx/fast_trigonometry.inl
@@ -125,8 +125,19 @@ namespace detail
 	template<length_t L, typename T, qualifier Q>
 	GLM_FUNC_QUALIFIER vec<L, T, Q> fastAtan(vec<L, T, Q> const& y, vec<L, T, Q> const& x)
 	{
-		return detail::functor2<vec, L, T, Q>::call(fastAtan, y, x);
-	}
+	 //as the x gradually increasing until it becomes close to infinity,
+         //the output becomes farther to pi half
+         //so it needs a little bit of adjustment between tan(45°) - tan(89°)
+         if(x > 1.0)
+           return fastAcos(fastInverseSqrt(x * x + 1));
+         else if(x < -1.0)
+           return -fastAcos(fastInverseSqrt(x * x + 1));
+ 
+         bool negative = x < 0.0;
+         if(negative) x = -x;
+            return (negative) ?  -(x - (x * x * x * T(0.333333333333)) + (x * x * x * x * x * T(0.2)) - (x * x * x * x * x * x * x * T(0.1428571429)) + (x * x * x * x * x * x * x * x * x * T(0.111111111111)) - (x * x * x * x * x * x * x * x * x * x * x * T(0.0909090909)))
+             : x - (x * x * x * T(0.333333333333)) + (x * x * x * x * x * T(0.2)) - (x * x * x * x * x * x * x * T(0.1428571429)) + (x * x * x * x * x * x * x * x * x * T(0.111111111111)) - (x * x * x * x * x * x * x * x * x * x * x * T(0.0909090909));
+        }
 
 	template<typename T>
 	GLM_FUNC_QUALIFIER T fastAtan(T x)

--- a/glm/gtx/fast_trigonometry.inl
+++ b/glm/gtx/fast_trigonometry.inl
@@ -142,8 +142,19 @@ namespace detail
 	template<typename T>
 	GLM_FUNC_QUALIFIER T fastAtan(T x)
 	{
-		return x - (x * x * x * T(0.333333333333)) + (x * x * x * x * x * T(0.2)) - (x * x * x * x * x * x * x * T(0.1428571429)) + (x * x * x * x * x * x * x * x * x * T(0.111111111111)) - (x * x * x * x * x * x * x * x * x * x * x * T(0.0909090909));
-	}
+		//as the x gradually increasing until it becomes close to infinity,
+         //the output becomes farther to pi half
+         //so it needs a little bit of adjustment between tan(45°) - tan(89°)
+         if(x > 1.0)
+           return fastAcos(fastInverseSqrt(x * x + 1));
+         else if(x < -1.0)
+           return -fastAcos(fastInverseSqrt(x * x + 1));
+ 
+         bool negative = x < 0.0;
+         if(negative) x = -x;
+            return (negative) ?  -(x - (x * x * x * T(0.333333333333)) + (x * x * x * x * x * T(0.2)) - (x * x * x * x * x * x * x * T(0.1428571429)) + (x * x * x * x * x * x * x * x * x * T(0.111111111111)) - (x * x * x * x * x * x * x * x * x * x * x * T(0.0909090909)))
+             : x - (x * x * x * T(0.333333333333)) + (x * x * x * x * x * T(0.2)) - (x * x * x * x * x * x * x * T(0.1428571429)) + (x * x * x * x * x * x * x * x * x * T(0.111111111111)) - (x * x * x * x * x * x * x * x * x * x * x * T(0.0909090909));
+        }
 
 	template<length_t L, typename T, qualifier Q>
 	GLM_FUNC_QUALIFIER vec<L, T, Q> fastAtan(vec<L, T, Q> const& x)

--- a/glm/gtx/fast_trigonometry.inl
+++ b/glm/gtx/fast_trigonometry.inl
@@ -125,35 +125,24 @@ namespace detail
 	template<length_t L, typename T, qualifier Q>
 	GLM_FUNC_QUALIFIER vec<L, T, Q> fastAtan(vec<L, T, Q> const& y, vec<L, T, Q> const& x)
 	{
-	 //as the x gradually increasing until it becomes close to infinity,
-         //the output becomes farther to pi half
-         //so it needs a little bit of adjustment between tan(45°) - tan(89°)
-         if(x > 1.0)
-           return fastAcos(fastInverseSqrt(x * x + 1));
-         else if(x < -1.0)
-           return -fastAcos(fastInverseSqrt(x * x + 1));
- 
-         bool negative = x < 0.0;
-         if(negative) x = -x;
-            return (negative) ?  -(x - (x * x * x * T(0.333333333333)) + (x * x * x * x * x * T(0.2)) - (x * x * x * x * x * x * x * T(0.1428571429)) + (x * x * x * x * x * x * x * x * x * T(0.111111111111)) - (x * x * x * x * x * x * x * x * x * x * x * T(0.0909090909)))
-             : x - (x * x * x * T(0.333333333333)) + (x * x * x * x * x * T(0.2)) - (x * x * x * x * x * x * x * T(0.1428571429)) + (x * x * x * x * x * x * x * x * x * T(0.111111111111)) - (x * x * x * x * x * x * x * x * x * x * x * T(0.0909090909));
-        }
+	         return detail::functor2<vec, L, T, Q>::call(fastAtan, y, x);
+	}
 
 	template<typename T>
 	GLM_FUNC_QUALIFIER T fastAtan(T x)
 	{
 		//as the x gradually increasing until it becomes close to infinity,
-         //the output becomes farther to pi half
-         //so it needs a little bit of adjustment between tan(45°) - tan(89°)
-         if(x > 1.0)
-           return fastAcos(fastInverseSqrt(x * x + 1));
-         else if(x < -1.0)
-           return -fastAcos(fastInverseSqrt(x * x + 1));
+                //the output becomes farther to pi half
+                //so it needs a little bit of adjustment between tan(45°) - tan(89°)
+                if(x > 1.0)
+                    return fastAcos(fastInverseSqrt(x * x + 1));
+                 else if(x < -1.0)
+                    return -fastAcos(fastInverseSqrt(x * x + 1));
  
-         bool negative = x < 0.0;
-         if(negative) x = -x;
-            return (negative) ?  -(x - (x * x * x * T(0.333333333333)) + (x * x * x * x * x * T(0.2)) - (x * x * x * x * x * x * x * T(0.1428571429)) + (x * x * x * x * x * x * x * x * x * T(0.111111111111)) - (x * x * x * x * x * x * x * x * x * x * x * T(0.0909090909)))
-             : x - (x * x * x * T(0.333333333333)) + (x * x * x * x * x * T(0.2)) - (x * x * x * x * x * x * x * T(0.1428571429)) + (x * x * x * x * x * x * x * x * x * T(0.111111111111)) - (x * x * x * x * x * x * x * x * x * x * x * T(0.0909090909));
+                 bool negative = x < 0.0;
+                 if(negative) x = -x;
+                 return (negative) ?  -(x - (x * x * x * T(0.333333333333)) + (x * x * x * x * x * T(0.2)) - (x * x * x * x * x * x * x * T(0.1428571429)) + (x * x * x * x * x * x * x * x * x * T(0.111111111111)) - (x * x * x * x * x * x * x * x * x * x * x * T(0.0909090909)))
+                         : x - (x * x * x * T(0.333333333333)) + (x * x * x * x * x * T(0.2)) - (x * x * x * x * x * x * x * T(0.1428571429)) + (x * x * x * x * x * x * x * x * x * T(0.111111111111)) - (x * x * x * x * x * x * x * x * x * x * x * T(0.0909090909));
         }
 
 	template<length_t L, typename T, qualifier Q>

--- a/glm/gtx/fast_trigonometry.inl
+++ b/glm/gtx/fast_trigonometry.inl
@@ -152,7 +152,7 @@ namespace detail
 	template<typename T>
 	GLM_FUNC_QUALIFIER T fastAtan(T x)
 	{
-                //it needs a little bit of corrections between tan(45°) - tan(89°) for consistent output value
+                //correction between tan(45°) - tan(89°) for consistent output value
                 if(x > 1.0)
                     return fastAcos(fastInverseSqrt(x * x + 1));
                  else if(x < -1.0)

--- a/glm/gtx/fast_trigonometry.inl
+++ b/glm/gtx/fast_trigonometry.inl
@@ -79,6 +79,9 @@ namespace detail
 	template<typename T>
 	GLM_FUNC_QUALIFIER T fastTan(T x)
 	{
+                //correction between tan(51°) - tan(89°)
+		if(x >= 1.2348971565)
+		 return fastSin<T>(x)/fastCos<T>(x);
 		return x + (x * x * x * T(0.3333333333)) + (x * x * x * x * x * T(0.1333333333333)) + (x * x * x * x * x * x * x * T(0.0539682539));
 	}
 

--- a/glm/gtx/fast_trigonometry.inl
+++ b/glm/gtx/fast_trigonometry.inl
@@ -122,7 +122,7 @@ namespace detail
 	GLM_FUNC_QUALIFIER T fastAtan(T y, T x)
 	{
 		/*
-	        // correct vec2 mapping between 91° and 269°
+	        // incorrect vec2 mapping between 91° and 269°
 	           T sgn = sign(y) * sign(x);
 	           return abs(fastAtan(y/x)) * sgn;
 	         */
@@ -152,9 +152,7 @@ namespace detail
 	template<typename T>
 	GLM_FUNC_QUALIFIER T fastAtan(T x)
 	{
-		//as the x gradually increasing until it becomes close to infinity,
-                //the output becomes farther to pi half
-                //so it needs a little bit of adjustment between tan(45°) - tan(89°)
+                //it needs a little bit of corrections between tan(45°) - tan(89°) for consistent output value
                 if(x > 1.0)
                     return fastAcos(fastInverseSqrt(x * x + 1));
                  else if(x < -1.0)

--- a/glm/gtx/fast_trigonometry.inl
+++ b/glm/gtx/fast_trigonometry.inl
@@ -122,8 +122,8 @@ namespace detail
 	GLM_FUNC_QUALIFIER T fastAtan(T y, T x)
 	{
 		/*
-	        // it works, but it doesn't mapped the value correctly when vec2 is between 91° and 269°
-	           T sgn = __sign(y) * __sign(x);
+	        // correct vec2 mapping between 91° and 269°
+	           T sgn = sign(y) * sign(x);
 	           return abs(fastAtan(y/x)) * sgn;
 	         */
                  if(x > 0)

--- a/glm/gtx/fast_trigonometry.inl
+++ b/glm/gtx/fast_trigonometry.inl
@@ -118,9 +118,27 @@ namespace detail
 	template<typename T>
 	GLM_FUNC_QUALIFIER T fastAtan(T y, T x)
 	{
-		T sgn = sign(y) * sign(x);
-		return abs(fastAtan(y / x)) * sgn;
-	}
+		/*
+	        // it works, but it doesn't give an output between 91° and 269°
+	           T sgn = __sign(y) * __sign(x);
+	           return abs(fastAtan(y/x)) * sgn;
+	         */
+                 if(x > 0)
+                    return fastAtan(y / x);
+                 else if(x < 0) {
+                    if(y >= 0)
+                         return fastAtan(y / x) + 3.1415926535897; //pi 
+                    else
+                         return fastAtan(y / x) - 3.1415926535897; //pi
+                 } else {
+                   if(y > 0)
+                         return 1.5707963267948; //pi half
+                   else if(y < 0)
+                         return -1.5707963267948; //pi half
+                   else
+                         return 0.0;
+                }
+        }
 
 	template<length_t L, typename T, qualifier Q>
 	GLM_FUNC_QUALIFIER vec<L, T, Q> fastAtan(vec<L, T, Q> const& y, vec<L, T, Q> const& x)


### PR DESCRIPTION
I made an improvements in glm::fastAtan, glm::fastAtan(y, x), glm::fastTan, glm::fastExp to make their output consistent even with large input numbers 
and i changed glm::inversesqrt<genType>() to work even with doubles
