### PR TITLE
isfinite support for quaternions

### DIFF
--- a/glm/gtx/compatibility.hpp
+++ b/glm/gtx/compatibility.hpp
@@ -60,6 +60,7 @@ namespace glm
 	template<typename T, qualifier Q> GLM_FUNC_DECL vec<2, bool, Q> isfinite(const vec<2, T, Q>& x);				//!< \brief Test whether or not a scalar or each vector component is a finite value. (From GLM_GTX_compatibility)
 	template<typename T, qualifier Q> GLM_FUNC_DECL vec<3, bool, Q> isfinite(const vec<3, T, Q>& x);				//!< \brief Test whether or not a scalar or each vector component is a finite value. (From GLM_GTX_compatibility)
 	template<typename T, qualifier Q> GLM_FUNC_DECL vec<4, bool, Q> isfinite(const vec<4, T, Q>& x);				//!< \brief Test whether or not a scalar or each vector component is a finite value. (From GLM_GTX_compatibility)
+	template<typename T, qualifier Q> GLM_FUNC_DECL vec<4, bool, Q> isfinite(const qua<T, Q>& x);					//!< \brief Test whether or not a scalar or each vector component is a finite value. (From GLM_GTX_compatibility)
 
 	typedef bool						bool1;			//!< \brief boolean type with 1 component. (From GLM_GTX_compatibility extension)
 	typedef vec<2, bool, highp>			bool2;			//!< \brief boolean type with 2 components. (From GLM_GTX_compatibility extension)

--- a/glm/gtx/compatibility.inl
+++ b/glm/gtx/compatibility.inl
@@ -59,4 +59,15 @@ namespace glm
 			isfinite(x.w));
 	}
 
+	template<typename T, qualifier Q>
+	GLM_FUNC_QUALIFIER vec<4, bool, Q> isfinite(
+		qua<T, Q> const& x)
+	{
+		return vec<4, bool, Q>(
+			isfinite(x.x),
+			isfinite(x.y),
+			isfinite(x.z),
+			isfinite(x.w));
+	}
+
 }//namespace glm

--- a/test/gtx/gtx_compatibility.cpp
+++ b/test/gtx/gtx_compatibility.cpp
@@ -5,6 +5,9 @@ int main()
 {
 	int Error(0);
 
+	float Zero_f = 0.0;
+	double Zero_d = 0.0;
+
 	Error += glm::isfinite(1.0f) ? 0 : 1;
 	Error += glm::isfinite(1.0) ? 0 : 1;
 	Error += glm::isfinite(-1.0f) ? 0 : 1;
@@ -14,6 +17,32 @@ int main()
 	Error += glm::all(glm::isfinite(glm::dvec4(1.0))) ? 0 : 1;
 	Error += glm::all(glm::isfinite(glm::vec4(-1.0f))) ? 0 : 1;
 	Error += glm::all(glm::isfinite(glm::dvec4(-1.0))) ? 0 : 1;
+
+	Error += glm::all(glm::isfinite(glm::quat(1.0f, 1.0f, 1.0f, 1.0f))) ? 0 : 1;
+	Error += glm::all(glm::isfinite(glm::dquat(1.0, 1.0, 1.0, 1.0))) ? 0 : 1;
+	Error += glm::all(glm::isfinite(glm::quat(-1.0f, -1.0f, -1.0f, -1.0f))) ? 0 : 1;
+	Error += glm::all(glm::isfinite(glm::dquat(-1.0, -1.0, -1.0, -1.0))) ? 0 : 1;
+
+	Error += glm::isfinite(0.0f/Zero_f) ? 1 : 0;
+	Error += glm::isfinite(0.0/Zero_d) ? 1 : 0;
+	Error += glm::isfinite(1.0f/Zero_f) ? 1 : 0;
+	Error += glm::isfinite(1.0/Zero_d) ? 1 : 0;
+	Error += glm::isfinite(-1.0f/Zero_f) ? 1 : 0;
+	Error += glm::isfinite(-1.0/Zero_d) ? 1 : 0;
+
+	Error += glm::all(glm::isfinite(glm::vec4(0.0f/Zero_f))) ? 1 : 0;
+	Error += glm::all(glm::isfinite(glm::dvec4(0.0/Zero_d))) ? 1 : 0;
+	Error += glm::all(glm::isfinite(glm::vec4(1.0f/Zero_f))) ? 1 : 0;
+	Error += glm::all(glm::isfinite(glm::dvec4(1.0/Zero_d))) ? 1 : 0;
+	Error += glm::all(glm::isfinite(glm::vec4(-1.0f/Zero_f))) ? 1 : 0;
+	Error += glm::all(glm::isfinite(glm::dvec4(-1.0/Zero_d))) ? 1 : 0;
+
+	Error += glm::all(glm::isfinite(glm::quat(0.0f/Zero_f, 0.0f/Zero_f, 0.0f/Zero_f, 0.0f/Zero_f))) ? 1 : 0;
+	Error += glm::all(glm::isfinite(glm::dquat(0.0/Zero_d, 0.0/Zero_d, 0.0/Zero_d, 0.0/Zero_d))) ? 1 : 0;
+	Error += glm::all(glm::isfinite(glm::quat(1.0f/Zero_f, 1.0f/Zero_f, 1.0f/Zero_f, 1.0f/Zero_f))) ? 1 : 0;
+	Error += glm::all(glm::isfinite(glm::dquat(1.0/Zero_d, 1.0/Zero_d, 1.0/Zero_d, 1.0/Zero_d))) ? 1 : 0;
+	Error += glm::all(glm::isfinite(glm::quat(-1.0f/Zero_f, -1.0f/Zero_f, -1.0f/Zero_f, -1.0f/Zero_f))) ? 1 : 0;
+	Error += glm::all(glm::isfinite(glm::dquat(-1.0/Zero_d, -1.0/Zero_d, -1.0/Zero_d, -1.0/Zero_d))) ? 1 : 0;
 
 	return Error;
 }

--- a/test/gtx/gtx_compatibility.cpp
+++ b/test/gtx/gtx_compatibility.cpp
@@ -30,19 +30,19 @@ int main()
 	Error += glm::isfinite(-1.0f/Zero_f) ? 1 : 0;
 	Error += glm::isfinite(-1.0/Zero_d) ? 1 : 0;
 
-	Error += glm::all(glm::isfinite(glm::vec4(0.0f/Zero_f))) ? 1 : 0;
-	Error += glm::all(glm::isfinite(glm::dvec4(0.0/Zero_d))) ? 1 : 0;
-	Error += glm::all(glm::isfinite(glm::vec4(1.0f/Zero_f))) ? 1 : 0;
-	Error += glm::all(glm::isfinite(glm::dvec4(1.0/Zero_d))) ? 1 : 0;
-	Error += glm::all(glm::isfinite(glm::vec4(-1.0f/Zero_f))) ? 1 : 0;
-	Error += glm::all(glm::isfinite(glm::dvec4(-1.0/Zero_d))) ? 1 : 0;
+	Error += glm::any(glm::isfinite(glm::vec4(0.0f/Zero_f))) ? 1 : 0;
+	Error += glm::any(glm::isfinite(glm::dvec4(0.0/Zero_d))) ? 1 : 0;
+	Error += glm::any(glm::isfinite(glm::vec4(1.0f/Zero_f))) ? 1 : 0;
+	Error += glm::any(glm::isfinite(glm::dvec4(1.0/Zero_d))) ? 1 : 0;
+	Error += glm::any(glm::isfinite(glm::vec4(-1.0f/Zero_f))) ? 1 : 0;
+	Error += glm::any(glm::isfinite(glm::dvec4(-1.0/Zero_d))) ? 1 : 0;
 
-	Error += glm::all(glm::isfinite(glm::quat(0.0f/Zero_f, 0.0f/Zero_f, 0.0f/Zero_f, 0.0f/Zero_f))) ? 1 : 0;
-	Error += glm::all(glm::isfinite(glm::dquat(0.0/Zero_d, 0.0/Zero_d, 0.0/Zero_d, 0.0/Zero_d))) ? 1 : 0;
-	Error += glm::all(glm::isfinite(glm::quat(1.0f/Zero_f, 1.0f/Zero_f, 1.0f/Zero_f, 1.0f/Zero_f))) ? 1 : 0;
-	Error += glm::all(glm::isfinite(glm::dquat(1.0/Zero_d, 1.0/Zero_d, 1.0/Zero_d, 1.0/Zero_d))) ? 1 : 0;
-	Error += glm::all(glm::isfinite(glm::quat(-1.0f/Zero_f, -1.0f/Zero_f, -1.0f/Zero_f, -1.0f/Zero_f))) ? 1 : 0;
-	Error += glm::all(glm::isfinite(glm::dquat(-1.0/Zero_d, -1.0/Zero_d, -1.0/Zero_d, -1.0/Zero_d))) ? 1 : 0;
+	Error += glm::any(glm::isfinite(glm::quat(0.0f/Zero_f, 0.0f/Zero_f, 0.0f/Zero_f, 0.0f/Zero_f))) ? 1 : 0;
+	Error += glm::any(glm::isfinite(glm::dquat(0.0/Zero_d, 0.0/Zero_d, 0.0/Zero_d, 0.0/Zero_d))) ? 1 : 0;
+	Error += glm::any(glm::isfinite(glm::quat(1.0f/Zero_f, 1.0f/Zero_f, 1.0f/Zero_f, 1.0f/Zero_f))) ? 1 : 0;
+	Error += glm::any(glm::isfinite(glm::dquat(1.0/Zero_d, 1.0/Zero_d, 1.0/Zero_d, 1.0/Zero_d))) ? 1 : 0;
+	Error += glm::any(glm::isfinite(glm::quat(-1.0f/Zero_f, -1.0f/Zero_f, -1.0f/Zero_f, -1.0f/Zero_f))) ? 1 : 0;
+	Error += glm::any(glm::isfinite(glm::dquat(-1.0/Zero_d, -1.0/Zero_d, -1.0/Zero_d, -1.0/Zero_d))) ? 1 : 0;
 
 	return Error;
 }


### PR DESCRIPTION
Add `isfinite` support for quaterions to `gtx/compatibility.hpp`. It was already pulling in `gtc/quaternion.hpp` as a dependency, so no changes there.

Update the tests to cover quaternions and also negative cases (NaN and +/- Inf) based on similar tests for `isnan` and `isinf` in `core_func_common.cpp`.