### PR TITLE
Fix NEON bug in `convert_vec3_to_vec4W0` and reenable tests

### DIFF
--- a/glm/detail/func_common.inl
+++ b/glm/detail/func_common.inl
@@ -345,7 +345,7 @@ namespace detail
 		template<int c>
 		GLM_FUNC_QUALIFIER GLM_CONSTEXPR static vec<L, T, Q> call(vec<L, T, Q> const& a)
 		{
-			vec<L, T, Q> v(0.0f);
+			vec<L, T, Q> v(0);
 			for (int i = 0; i < L; ++i)
 				v[i] = a[c];
 			return v;

--- a/glm/detail/func_common_simd.inl
+++ b/glm/detail/func_common_simd.inl
@@ -553,7 +553,7 @@ namespace glm {
 			GLM_FUNC_QUALIFIER static vec<4, float, Q> call(vec<3, float, Q> const& a)
 			{
 				vec<4, float, Q> v;
-				static const uint32x4_t mask = { 0, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF };
+				static const uint32x4_t mask = { 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0 };
 				v.data = vbslq_f32(mask, a.data, vdupq_n_f32(0));
 				return v;
 			}

--- a/test/gtc/gtc_type_aligned.cpp
+++ b/test/gtc/gtc_type_aligned.cpp
@@ -1,6 +1,6 @@
 #include <glm/glm.hpp>
 
-#if GLM_CONFIG_ALIGNED_GENTYPES == GLM_ENABLE && !(GLM_ARCH & GLM_ARCH_NEON_BIT) // Fail on Github macOS latest C.I.
+#if GLM_CONFIG_ALIGNED_GENTYPES == GLM_ENABLE
 #include <glm/gtc/type_aligned.hpp>
 #include <glm/gtc/type_precision.hpp>
 #include <glm/ext/scalar_relational.hpp>


### PR DESCRIPTION
While testing #1353 on my Mac I incidentally got `gtc_type_aligned.cpp` to run 😅 

First issue is a compile error in `convert_splat`:

```
error: implicit conversion increases floating-point precision: 'float' to 'double'
```

Switching to a plain `0` constant seems to make things happy on my machine, though if that causes problems elsewhere we could use `{}` instead.

Next was a test failure in `test_copy_vec4_vec3` where `xyz0(vec3(1, 2, 3))` was returning `(0, 2, 3, 4)` instead of `(1, 2, 3, 0)`! This turned out to be a simple flipped mask order in `func_common_simd.inl`.

With these changes the tests now run and pass on my M1 Mac, and hopefully also CI.