### PR TITLE
Update qualifier.hpp

### DIFF
--- a/glm/detail/qualifier.hpp
+++ b/glm/detail/qualifier.hpp
@@ -141,7 +141,7 @@ namespace detail
 	template<>
 	struct storage<3, unsigned int, true>
 	{
-		typedef glm_i32vec4 type;
+		typedef glm_u32vec4 type;
 	};
 
 	template<>


### PR DESCRIPTION
Fix incorrect type for storage<3, unsigned int, true> in SSE2  
Previously defined as glm_i32vec4, now correctly set to glm_u32vec4.