### PR TITLE
Wrong return value for quat scalar mult and div simd

### DIFF
--- a/glm/detail/type_quat_simd.inl
+++ b/glm/detail/type_quat_simd.inl
@@ -113,7 +113,7 @@ namespace detail
 	{
 		static qua<float, Q> call(qua<float, Q> const& q, float s)
 		{
-			vec<4, float, Q> Result;
+			qua<float, Q> Result;
 			Result.data = _mm_mul_ps(q.data, _mm_set_ps1(s));
 			return Result;
 		}
@@ -137,7 +137,7 @@ namespace detail
 	{
 		static qua<float, Q> call(qua<float, Q> const& q, float s)
 		{
-			vec<4, float, Q> Result;
+			qua<float, Q> Result;
 			Result.data = _mm_div_ps(q.data, _mm_set_ps1(s));
 			return Result;
 		}


### PR DESCRIPTION
Wrong return value for quat scalar mult and div simd. It must be quat but is vec4