### PR TITLE
Fix `uSubBorrow` in `func_integer.inl`

### DIFF
--- a/glm/detail/func_integer.inl
+++ b/glm/detail/func_integer.inl
@@ -196,19 +196,19 @@ namespace detail
 	GLM_FUNC_QUALIFIER uint usubBorrow(uint const& x, uint const& y, uint & Borrow)
 	{
 		Borrow = x >= y ? static_cast<uint>(0) : static_cast<uint>(1);
-		if(y >= x)
-			return y - x;
+		if(x >= y)
+			return x - y;
 		else
-			return static_cast<uint>((static_cast<detail::int64>(1) << static_cast<detail::int64>(32)) + (static_cast<detail::int64>(y) - static_cast<detail::int64>(x)));
+			return static_cast<uint>((static_cast<detail::int64>(1) << static_cast<detail::int64>(32)) + (static_cast<detail::int64>(x) - static_cast<detail::int64>(y)));
 	}
 
 	template<length_t L, qualifier Q>
 	GLM_FUNC_QUALIFIER vec<L, uint, Q> usubBorrow(vec<L, uint, Q> const& x, vec<L, uint, Q> const& y, vec<L, uint, Q>& Borrow)
 	{
 		Borrow = mix(vec<L, uint, Q>(1), vec<L, uint, Q>(0), greaterThanEqual(x, y));
-		vec<L, uint, Q> const YgeX(y - x);
-		vec<L, uint, Q> const XgeY(vec<L, uint, Q>((static_cast<detail::int64>(1) << static_cast<detail::int64>(32)) + (vec<L, detail::int64, Q>(y) - vec<L, detail::int64, Q>(x))));
-		return mix(XgeY, YgeX, greaterThanEqual(y, x));
+		vec<L, uint, Q> const XgeY(x - y);
+		vec<L, uint, Q> const YgX(vec<L, uint, Q>((static_cast<detail::int64>(1) << static_cast<detail::int64>(32)) + (vec<L, detail::int64, Q>(x) - vec<L, detail::int64, Q>(y))));
+		return mix(YgX, XgeY, greaterThanEqual(x, y));
 	}
 
 	// umulExtended


### PR DESCRIPTION
Currently `uSubBorrow` is confused. It reports the borrow for `x-y` (so 1 if x < y, 0 otherwise) but returns the (cyclic if underflow) result of doing `y-x`. 

https://registry.khronos.org/OpenGL-Refpages/gl4/html/usubBorrow.xhtml states that `The value borrow is set to 0 if x ≥ y and to 1 otherwise`. That and the usual operand order for subtraction indicates that the current implementation is wrong. I simply fix this by making it return `x-y` when `x >= y` and `2^32 + x - y` otherwise