### PR TITLE
Add IWYU pragmas for provider header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,4 @@ build*
 /CMakeSettings.json
 .DS_Store
 *.swp
+/.cache

--- a/glm/ext.hpp
+++ b/glm/ext.hpp
@@ -13,6 +13,7 @@
 #	pragma message("GLM: All extensions included (not recommended)")
 #endif//GLM_MESSAGES
 
+// IWYU pragma: begin_exports
 #include "./ext/matrix_clip_space.hpp"
 #include "./ext/matrix_common.hpp"
 
@@ -265,3 +266,4 @@
 #	include "./gtx/range.hpp"
 #endif
 #endif//GLM_ENABLE_EXPERIMENTAL
+// IWYU pragma: end_exports

--- a/glm/glm.hpp
+++ b/glm/glm.hpp
@@ -112,6 +112,8 @@
 #include <cfloat>
 #include <limits>
 #include <cassert>
+
+// IWYU pragma: begin_exports
 #include "fwd.hpp"
 
 #include "vec2.hpp"
@@ -135,3 +137,4 @@
 #include "matrix.hpp"
 #include "vector_relational.hpp"
 #include "integer.hpp"
+// IWYU pragma: end_exports

--- a/glm/gtc/vec1.hpp
+++ b/glm/gtc/vec1.hpp
@@ -13,6 +13,7 @@
 #pragma once
 
 // Dependency:
+// IWYU pragma: begin_exports
 #include "../ext/vector_bool1.hpp"
 #include "../ext/vector_bool1_precision.hpp"
 #include "../ext/vector_float1.hpp"
@@ -23,6 +24,7 @@
 #include "../ext/vector_int1_sized.hpp"
 #include "../ext/vector_uint1.hpp"
 #include "../ext/vector_uint1_sized.hpp"
+// IWYU pragma: end_exports
 
 #if GLM_MESSAGES == GLM_ENABLE && !defined(GLM_EXT_INCLUDED)
 #	pragma message("GLM: GLM_GTC_vec1 extension included")

--- a/glm/mat2x2.hpp
+++ b/glm/mat2x2.hpp
@@ -2,8 +2,10 @@
 /// @file glm/mat2x2.hpp
 
 #pragma once
+// IWYU pragma: begin_exports
 #include "./ext/matrix_double2x2.hpp"
 #include "./ext/matrix_double2x2_precision.hpp"
 #include "./ext/matrix_float2x2.hpp"
 #include "./ext/matrix_float2x2_precision.hpp"
+// IWYU pragma: end_exports
 

--- a/glm/mat2x3.hpp
+++ b/glm/mat2x3.hpp
@@ -2,8 +2,10 @@
 /// @file glm/mat2x3.hpp
 
 #pragma once
+// IWYU pragma: begin_exports
 #include "./ext/matrix_double2x3.hpp"
 #include "./ext/matrix_double2x3_precision.hpp"
 #include "./ext/matrix_float2x3.hpp"
 #include "./ext/matrix_float2x3_precision.hpp"
+// IWYU pragma: end_exports
 

--- a/glm/mat2x4.hpp
+++ b/glm/mat2x4.hpp
@@ -2,8 +2,10 @@
 /// @file glm/mat2x4.hpp
 
 #pragma once
+// IWYU pragma: begin_exports
 #include "./ext/matrix_double2x4.hpp"
 #include "./ext/matrix_double2x4_precision.hpp"
 #include "./ext/matrix_float2x4.hpp"
 #include "./ext/matrix_float2x4_precision.hpp"
+// IWYU pragma: end_exports
 

--- a/glm/mat3x2.hpp
+++ b/glm/mat3x2.hpp
@@ -2,8 +2,10 @@
 /// @file glm/mat3x2.hpp
 
 #pragma once
+// IWYU pragma: begin_exports
 #include "./ext/matrix_double3x2.hpp"
 #include "./ext/matrix_double3x2_precision.hpp"
 #include "./ext/matrix_float3x2.hpp"
 #include "./ext/matrix_float3x2_precision.hpp"
+// IWYU pragma: end_exports
 

--- a/glm/mat3x3.hpp
+++ b/glm/mat3x3.hpp
@@ -2,7 +2,9 @@
 /// @file glm/mat3x3.hpp
 
 #pragma once
+// IWYU pragma: begin_exports
 #include "./ext/matrix_double3x3.hpp"
 #include "./ext/matrix_double3x3_precision.hpp"
 #include "./ext/matrix_float3x3.hpp"
 #include "./ext/matrix_float3x3_precision.hpp"
+// IWYU pragma: end_exports

--- a/glm/mat3x4.hpp
+++ b/glm/mat3x4.hpp
@@ -2,7 +2,9 @@
 /// @file glm/mat3x4.hpp
 
 #pragma once
+// IWYU pragma: begin_exports
 #include "./ext/matrix_double3x4.hpp"
 #include "./ext/matrix_double3x4_precision.hpp"
 #include "./ext/matrix_float3x4.hpp"
 #include "./ext/matrix_float3x4_precision.hpp"
+// IWYU pragma: end_exports

--- a/glm/mat4x2.hpp
+++ b/glm/mat4x2.hpp
@@ -2,8 +2,10 @@
 /// @file glm/mat4x2.hpp
 
 #pragma once
+// IWYU pragma: begin_exports
 #include "./ext/matrix_double4x2.hpp"
 #include "./ext/matrix_double4x2_precision.hpp"
 #include "./ext/matrix_float4x2.hpp"
 #include "./ext/matrix_float4x2_precision.hpp"
+// IWYU pragma: end_exports
 

--- a/glm/mat4x3.hpp
+++ b/glm/mat4x3.hpp
@@ -2,7 +2,9 @@
 /// @file glm/mat4x3.hpp
 
 #pragma once
+// IWYU pragma: begin_exports
 #include "./ext/matrix_double4x3.hpp"
 #include "./ext/matrix_double4x3_precision.hpp"
 #include "./ext/matrix_float4x3.hpp"
 #include "./ext/matrix_float4x3_precision.hpp"
+// IWYU pragma: end_exports

--- a/glm/mat4x4.hpp
+++ b/glm/mat4x4.hpp
@@ -2,8 +2,10 @@
 /// @file glm/mat4x4.hpp
 
 #pragma once
+// IWYU pragma: begin_exports
 #include "./ext/matrix_double4x4.hpp"
 #include "./ext/matrix_double4x4_precision.hpp"
 #include "./ext/matrix_float4x4.hpp"
 #include "./ext/matrix_float4x4_precision.hpp"
+// IWYU pragma: end_exports
 

--- a/glm/matrix.hpp
+++ b/glm/matrix.hpp
@@ -18,6 +18,7 @@
 #include "vec2.hpp"
 #include "vec3.hpp"
 #include "vec4.hpp"
+// IWYU pragma: begin_exports
 #include "mat2x2.hpp"
 #include "mat2x3.hpp"
 #include "mat2x4.hpp"
@@ -27,6 +28,7 @@
 #include "mat4x2.hpp"
 #include "mat4x3.hpp"
 #include "mat4x4.hpp"
+// IWYU pragma: end_exports
 
 namespace glm {
 namespace detail

--- a/glm/vec2.hpp
+++ b/glm/vec2.hpp
@@ -2,6 +2,7 @@
 /// @file glm/vec2.hpp
 
 #pragma once
+// IWYU pragma: begin_exports
 #include "./ext/vector_bool2.hpp"
 #include "./ext/vector_bool2_precision.hpp"
 #include "./ext/vector_float2.hpp"
@@ -12,3 +13,4 @@
 #include "./ext/vector_int2_sized.hpp"
 #include "./ext/vector_uint2.hpp"
 #include "./ext/vector_uint2_sized.hpp"
+// IWYU pragma: end_exports

--- a/glm/vec3.hpp
+++ b/glm/vec3.hpp
@@ -2,6 +2,7 @@
 /// @file glm/vec3.hpp
 
 #pragma once
+// IWYU pragma: begin_exports
 #include "./ext/vector_bool3.hpp"
 #include "./ext/vector_bool3_precision.hpp"
 #include "./ext/vector_float3.hpp"
@@ -12,3 +13,4 @@
 #include "./ext/vector_int3_sized.hpp"
 #include "./ext/vector_uint3.hpp"
 #include "./ext/vector_uint3_sized.hpp"
+// IWYU pragma: end_exports

--- a/glm/vec4.hpp
+++ b/glm/vec4.hpp
@@ -2,6 +2,7 @@
 /// @file glm/vec4.hpp
 
 #pragma once
+// IWYU pragma: begin_exports
 #include "./ext/vector_bool4.hpp"
 #include "./ext/vector_bool4_precision.hpp"
 #include "./ext/vector_float4.hpp"
@@ -12,4 +13,5 @@
 #include "./ext/vector_int4_sized.hpp"
 #include "./ext/vector_uint4.hpp"
 #include "./ext/vector_uint4_sized.hpp"
+// IWYU pragma: end_exports
 


### PR DESCRIPTION
This PR suggests adding [IWYU pragmas](https://github.com/include-what-you-use/include-what-you-use/blob/master/docs/IWYUPragmas.md#iwyu-pragma-begin_exportsend_exports) to the provider headers: `glm/glm.hpp`, `glm/ext.hpp` and the vector and matrix type headers. This allows these headers to be used as intended without warnings in projects with strict [clangd include diagnostics configuration](https://clangd.llvm.org/guides/include-cleaner).

PS: I also added the `.cache` dir clangd creates when using it in the repo to the gitignore file; if this feels too out of place for this PR, I can drop that commit of course. 
