### PR TITLE
Deprecate C++98 to 14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,27 +14,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest, windows-2022]
-        toolkit: [v143, v142, v141, v140]
-        std: [98, 11, 14, 17, 20]
+        os: [windows-latest]
+        toolkit: [v143, v142]
+        std: [17, 20]
         config: [Debug, Release]
         exclude:
-          - os: windows-2022
-            toolkit: v143
-          - os: windows-2022
-            toolkit: v142
-          - os: windows-latest
-            toolkit: v140
-          - os: windows-latest
-            toolkit: v141
-          - os: windows-2022
-            std: 20
-          - os: windows-2022
-            toolkit: v140
-            std: 17
-          - os: windows-2022
-            toolkit: v140
-            std: 14
+           - os: windows-latest
+             toolkit: v142
+             std: 17
+             config: Release
+        #   - os: windows-2022
+        #     toolkit: v142
 
     steps:
       - run: echo "🎉 The job was automatically triggered by a ${{ github.event_name }} event."
@@ -51,7 +41,7 @@ jobs:
       - name: CMake Version
         uses: lukka/get-cmake@latest
         with:
-          cmakeVersion: 3.22.1
+          cmakeVersion: 3.31.9
       - run: cmake --version
 
       - name: Run with automagic detection
@@ -108,19 +98,17 @@ jobs:
           cmake --build ./build_avx2_ext --config ${{matrix.config}}
           ctest --verbose -C ${{matrix.config}} --test-dir ./build_avx2_ext
 
-  ubuntu:
+  windows-arm:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, ubuntu-22.04]
-        std: [98, 11, 14, 17, 20]
+        os: [windows-11-arm]
+        std: [17, 20]
         config: [Debug, Release]
         exclude:
-          - os: ubuntu-22.04
-            std: 20
-          - os: ubuntu-latest
-            std: 98
+           - std: 17
+             config: Release
 
     steps:
       - run: echo "🎉 The job was automatically triggered by a ${{ github.event_name }} event."
@@ -137,7 +125,64 @@ jobs:
       - name: CMake Version
         uses: lukka/get-cmake@latest
         with:
-          cmakeVersion: 3.22.1
+          cmakeVersion: 3.31.9
+      - run: cmake --version
+      - name: Run with automagic detection
+        run: |
+          cmake -S. -B ./build_auto -DGLM_BUILD_TESTS=ON 
+          cmake --build ./build_auto --config ${{matrix.config}}
+          ctest --verbose -C ${{matrix.config}} --test-dir ./build_auto
+
+      - name: Run with GLM_FORCE_PURE
+        run: |
+          cmake -S. -B ./build_pure_std -DGLM_BUILD_TESTS=ON -DGLM_FORCE_PURE=ON -DGLM_ENABLE_CXX_${{matrix.std}}=ON
+          cmake --build ./build_pure_std --config ${{matrix.config}}
+          ctest --verbose -C ${{matrix.config}} --test-dir ./build_pure_std
+      - name: Run with GLM_FORCE_PURE and language extensions
+        run: |
+          cmake -S. -B ./build_pure_ext -DGLM_BUILD_TESTS=ON -DGLM_FORCE_PURE=ON -DGLM_ENABLE_CXX_${{matrix.std}}=ON -DGLM_ENABLE_LANG_EXTENSIONS=ON
+          cmake --build ./build_pure_ext --config ${{matrix.config}}
+          ctest --verbose -C ${{matrix.config}} --test-dir ./build_pure_ext
+
+      - name: Run with GLM_ENABLE_SIMD_NEON
+        run: |
+          cmake -S. -B ./build_neon_std -DGLM_BUILD_TESTS=ON -DGLM_ENABLE_SIMD_NEON=ON -DGLM_ENABLE_CXX_${{matrix.std}}=ON
+          cmake --build ./build_neon_std --config ${{matrix.config}}
+          ctest --verbose -C ${{matrix.config}} --test-dir ./build_neon_std
+      - name: Run with GLM_ENABLE_SIMD_NEON and language extensions
+        run: |
+          cmake -S. -B ./build_neon_ext -DGLM_BUILD_TESTS=ON -DGLM_ENABLE_SIMD_NEON=ON -DGLM_ENABLE_CXX_${{matrix.std}}=ON -DGLM_ENABLE_LANG_EXTENSIONS=ON
+          cmake --build ./build_neon_ext --config ${{matrix.config}}
+          ctest --verbose -C ${{matrix.config}} --test-dir ./build_neon_ext
+
+  ubuntu:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, ubuntu-22.04]
+        std: [17, 20]
+        config: [Debug, Release]
+        exclude:
+          - os: ubuntu-22.04
+            std: 20
+
+    steps:
+      - run: echo "🎉 The job was automatically triggered by a ${{ github.event_name }} event."
+      - run: echo "🐧 This job is now running on a ${{ runner.os }} server hosted by GitHub!"
+      - run: echo "🔎 The name of your branch is ${{ github.ref }} and your repository is ${{ github.repository }}."
+      - name: Check out repository code
+        uses: actions/checkout@v4
+      - run: echo "💡 The ${{ github.repository }} repository has been cloned to the runner."
+      - run: echo "🖥️ The workflow is now ready to test your code on the runner."
+      - name: List files in the repository
+        run: |
+          ls ${{ github.workspace }}
+      - run: echo "🍏 This job's status is ${{ job.status }}."
+      - name: CMake Version
+        uses: lukka/get-cmake@latest
+        with:
+          cmakeVersion: 3.31.9
       - run: cmake --version
       - name: Run with automagic detection
         run: |
@@ -189,14 +234,17 @@ jobs:
           cmake --build ./build_avx2_ext --config ${{matrix.config}}
           ctest --verbose -C ${{matrix.config}} --test-dir ./build_avx2_ext
 
-  macos-13:
+  ubuntu-arm:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-13]
-        std: [98, 11, 14, 17, 20]
+        os: [ubuntu-24.04-arm]
+        std: [17, 20]
         config: [Debug, Release]
+        exclude:
+           - std: 17
+             config: Release
 
     steps:
       - run: echo "🎉 The job was automatically triggered by a ${{ github.event_name }} event."
@@ -213,72 +261,7 @@ jobs:
       - name: CMake Version
         uses: lukka/get-cmake@latest
         with:
-          cmakeVersion: 3.22.1
-      - run: cmake --version
-      - name: Run with automagic detection
-        run: |
-          cmake -S. -B ./build_auto -DGLM_BUILD_TESTS=ON 
-          cmake --build ./build_auto --config ${{matrix.config}}
-          ctest --verbose -C ${{matrix.config}} --test-dir ./build_auto
-
-      - name: Run with GLM_FORCE_PURE
-        run: |
-          cmake -S. -B ./build_pure_std -DGLM_BUILD_TESTS=ON -DGLM_FORCE_PURE=ON -DGLM_ENABLE_CXX_${{matrix.std}}=ON
-          cmake --build ./build_pure_std --config ${{matrix.config}}
-          ctest --verbose -C ${{matrix.config}} --test-dir ./build_pure_std
-      - name: Run with GLM_FORCE_PURE and language extensions
-        run: |
-          cmake -S. -B ./build_pure_ext -DGLM_BUILD_TESTS=ON -DGLM_FORCE_PURE=ON -DGLM_ENABLE_CXX_${{matrix.std}}=ON -DGLM_ENABLE_LANG_EXTENSIONS=ON
-          cmake --build ./build_pure_ext --config ${{matrix.config}}
-          ctest --verbose -C ${{matrix.config}} --test-dir ./build_pure_ext
-
-      - name: Run with GLM_ENABLE_SIMD_SSE2
-        run: |
-          cmake -S. -B ./build_sse2_std -DGLM_BUILD_TESTS=ON -DGLM_ENABLE_SIMD_SSE2=ON -DGLM_ENABLE_CXX_${{matrix.std}}=ON
-          cmake --build ./build_sse2_std --config ${{matrix.config}}
-          ctest --verbose -C ${{matrix.config}} --test-dir ./build_sse2_std
-      - name: Run with GLM_ENABLE_SIMD_SSE2 and language extensions
-        run: |
-          cmake -S. -B ./build_sse2_ext -DGLM_BUILD_TESTS=ON -DGLM_ENABLE_SIMD_SSE2=ON -DGLM_ENABLE_CXX_${{matrix.std}}=ON -DGLM_ENABLE_LANG_EXTENSIONS=ON
-          cmake --build ./build_sse2_ext --config ${{matrix.config}}
-          ctest --verbose -C ${{matrix.config}} --test-dir ./build_sse2_ext
-
-      - name: Run with GLM_ENABLE_SIMD_AVX
-        run: |
-          cmake -S. -B ./build_avx1_std -DGLM_BUILD_TESTS=ON -DGLM_ENABLE_SIMD_AVX=ON -DGLM_ENABLE_CXX_${{matrix.std}}=ON
-          cmake --build ./build_avx1_std --config ${{matrix.config}}
-          ctest --verbose -C ${{matrix.config}} --test-dir ./build_avx1_std
-      - name: Run with GLM_ENABLE_SIMD_AVX and language extensions
-        run: |
-          cmake -S. -B ./build_avx1_ext -DGLM_BUILD_TESTS=ON -DGLM_ENABLE_SIMD_AVX=ON -DGLM_ENABLE_CXX_${{matrix.std}}=ON -DGLM_ENABLE_LANG_EXTENSIONS=ON
-          cmake --build ./build_avx1_ext --config ${{matrix.config}}
-          ctest --verbose -C ${{matrix.config}} --test-dir ./build_avx1_ext
-
-  macos-latest:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [macos-latest]
-        std: [98, 11, 14, 17, 20]
-        config: [Debug, Release]
-
-    steps:
-      - run: echo "🎉 The job was automatically triggered by a ${{ github.event_name }} event."
-      - run: echo "🐧 This job is now running on a ${{ runner.os }} server hosted by GitHub!"
-      - run: echo "🔎 The name of your branch is ${{ github.ref }} and your repository is ${{ github.repository }}."
-      - name: Check out repository code
-        uses: actions/checkout@v4
-      - run: echo "💡 The ${{ github.repository }} repository has been cloned to the runner."
-      - run: echo "🖥️ The workflow is now ready to test your code on the runner."
-      - name: List files in the repository
-        run: |
-          ls ${{ github.workspace }}
-      - run: echo "🍏 This job's status is ${{ job.status }}."
-      - name: CMake Version
-        uses: lukka/get-cmake@latest
-        with:
-          cmakeVersion: 3.22.1
+          cmakeVersion: 3.31.9
       - run: cmake --version
       - name: Run with automagic detection
         run: |
@@ -308,4 +291,125 @@ jobs:
           cmake --build ./build_neon_ext --config ${{matrix.config}}
           ctest --verbose -C ${{matrix.config}} --test-dir ./build_neon_ext
 
- 
+  macos:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-14, macos-latest]
+        std: [17, 20]
+        config: [Debug, Release]
+        exclude:
+           - std: 17
+             config: Release
+
+    steps:
+      - run: echo "🎉 The job was automatically triggered by a ${{ github.event_name }} event."
+      - run: echo "🐧 This job is now running on a ${{ runner.os }} server hosted by GitHub!"
+      - run: echo "🔎 The name of your branch is ${{ github.ref }} and your repository is ${{ github.repository }}."
+      - name: Check out repository code
+        uses: actions/checkout@v4
+      - run: echo "💡 The ${{ github.repository }} repository has been cloned to the runner."
+      - run: echo "🖥️ The workflow is now ready to test your code on the runner."
+      - name: List files in the repository
+        run: |
+          ls ${{ github.workspace }}
+      - run: echo "🍏 This job's status is ${{ job.status }}."
+      - name: CMake Version
+        uses: lukka/get-cmake@latest
+        with:
+          cmakeVersion: 3.31.9
+      - run: cmake --version
+      - name: Run with automagic detection
+        run: |
+          cmake -S. -B ./build_auto -DGLM_BUILD_TESTS=ON 
+          cmake --build ./build_auto --config ${{matrix.config}}
+          ctest --verbose -C ${{matrix.config}} --test-dir ./build_auto
+
+      - name: Run with GLM_FORCE_PURE
+        run: |
+          cmake -S. -B ./build_pure_std -DGLM_BUILD_TESTS=ON -DGLM_FORCE_PURE=ON -DGLM_ENABLE_CXX_${{matrix.std}}=ON
+          cmake --build ./build_pure_std --config ${{matrix.config}}
+          ctest --verbose -C ${{matrix.config}} --test-dir ./build_pure_std
+      - name: Run with GLM_FORCE_PURE and language extensions
+        run: |
+          cmake -S. -B ./build_pure_ext -DGLM_BUILD_TESTS=ON -DGLM_FORCE_PURE=ON -DGLM_ENABLE_CXX_${{matrix.std}}=ON -DGLM_ENABLE_LANG_EXTENSIONS=ON
+          cmake --build ./build_pure_ext --config ${{matrix.config}}
+          ctest --verbose -C ${{matrix.config}} --test-dir ./build_pure_ext
+
+      - name: Run with GLM_ENABLE_SIMD_NEON
+        run: |
+          cmake -S. -B ./build_neon_std -DGLM_BUILD_TESTS=ON -DGLM_ENABLE_SIMD_NEON=ON -DGLM_ENABLE_CXX_${{matrix.std}}=ON
+          cmake --build ./build_neon_std --config ${{matrix.config}}
+          ctest --verbose -C ${{matrix.config}} --test-dir ./build_neon_std
+      - name: Run with GLM_ENABLE_SIMD_NEON and language extensions
+        run: |
+          cmake -S. -B ./build_neon_ext -DGLM_BUILD_TESTS=ON -DGLM_ENABLE_SIMD_NEON=ON -DGLM_ENABLE_CXX_${{matrix.std}}=ON -DGLM_ENABLE_LANG_EXTENSIONS=ON
+          cmake --build ./build_neon_ext --config ${{matrix.config}}
+          ctest --verbose -C ${{matrix.config}} --test-dir ./build_neon_ext
+
+   # macos-intel:
+   #  runs-on: ${{ matrix.os }}
+   #  strategy:
+   #    fail-fast: false
+   #    matrix:
+   #      os: [macos-15-intel]
+   #      std: [17, 20]
+   #      config: [Debug, Release]
+
+   #  steps:
+   #    - run: echo "🎉 The job was automatically triggered by a ${{ github.event_name }} event."
+   #    - run: echo "🐧 This job is now running on a ${{ runner.os }} server hosted by GitHub!"
+   #    - run: echo "🔎 The name of your branch is ${{ github.ref }} and your repository is ${{ github.repository }}."
+   #    - name: Check out repository code
+   #      uses: actions/checkout@v4
+   #    - run: echo "💡 The ${{ github.repository }} repository has been cloned to the runner."
+   #    - run: echo "🖥️ The workflow is now ready to test your code on the runner."
+   #    - name: List files in the repository
+   #      run: |
+   #        ls ${{ github.workspace }}
+   #    - run: echo "🍏 This job's status is ${{ job.status }}."
+   #    - name: CMake Version
+   #      uses: lukka/get-cmake@latest
+   #      with:
+   #        cmakeVersion: 3.31.9
+   #    - run: cmake --version
+   #    - name: Run with automagic detection
+   #      run: |
+   #        cmake -S. -B ./build_auto -DGLM_BUILD_TESTS=ON 
+   #        cmake --build ./build_auto --config ${{matrix.config}}
+   #        ctest --verbose -C ${{matrix.config}} --test-dir ./build_auto
+
+   #    - name: Run with GLM_FORCE_PURE
+   #      run: |
+   #        cmake -S. -B ./build_pure_std -DGLM_BUILD_TESTS=ON -DGLM_FORCE_PURE=ON -DGLM_ENABLE_CXX_${{matrix.std}}=ON
+   #        cmake --build ./build_pure_std --config ${{matrix.config}}
+   #        ctest --verbose -C ${{matrix.config}} --test-dir ./build_pure_std
+   #    - name: Run with GLM_FORCE_PURE and language extensions
+   #      run: |
+   #        cmake -S. -B ./build_pure_ext -DGLM_BUILD_TESTS=ON -DGLM_FORCE_PURE=ON -DGLM_ENABLE_CXX_${{matrix.std}}=ON -DGLM_ENABLE_LANG_EXTENSIONS=ON
+   #        cmake --build ./build_pure_ext --config ${{matrix.config}}
+   #        ctest --verbose -C ${{matrix.config}} --test-dir ./build_pure_ext
+
+   #    - name: Run with GLM_ENABLE_SIMD_SSE2
+   #      run: |
+   #        cmake -S. -B ./build_sse2_std -DGLM_BUILD_TESTS=ON -DGLM_ENABLE_SIMD_SSE2=ON -DGLM_ENABLE_CXX_${{matrix.std}}=ON
+   #        cmake --build ./build_sse2_std --config ${{matrix.config}}
+   #        ctest --verbose -C ${{matrix.config}} --test-dir ./build_sse2_std
+   #    - name: Run with GLM_ENABLE_SIMD_SSE2 and language extensions
+   #      run: |
+   #        cmake -S. -B ./build_sse2_ext -DGLM_BUILD_TESTS=ON -DGLM_ENABLE_SIMD_SSE2=ON -DGLM_ENABLE_CXX_${{matrix.std}}=ON -DGLM_ENABLE_LANG_EXTENSIONS=ON
+   #        cmake --build ./build_sse2_ext --config ${{matrix.config}}
+   #        ctest --verbose -C ${{matrix.config}} --test-dir ./build_sse2_ext
+
+   #    - name: Run with GLM_ENABLE_SIMD_AVX
+   #      run: |
+   #        cmake -S. -B ./build_avx1_std -DGLM_BUILD_TESTS=ON -DGLM_ENABLE_SIMD_AVX=ON -DGLM_ENABLE_CXX_${{matrix.std}}=ON
+   #        cmake --build ./build_avx1_std --config ${{matrix.config}}
+   #        ctest --verbose -C ${{matrix.config}} --test-dir ./build_avx1_std
+   #    - name: Run with GLM_ENABLE_SIMD_AVX and language extensions
+   #      run: |
+   #        cmake -S. -B ./build_avx1_ext -DGLM_BUILD_TESTS=ON -DGLM_ENABLE_SIMD_AVX=ON -DGLM_ENABLE_CXX_${{matrix.std}}=ON -DGLM_ENABLE_LANG_EXTENSIONS=ON
+   #        cmake --build ./build_avx1_ext --config ${{matrix.config}}
+   #        ctest --verbose -C ${{matrix.config}} --test-dir ./build_avx1_ext
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,9 +164,9 @@ option(GLM_FORCE_PURE "Force 'pure' instructions" OFF)
 if(GLM_FORCE_PURE)
 	add_definitions(-DGLM_FORCE_PURE)
 
-	if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
-		add_compile_options(-mfpmath=387)
-	endif()
+#	if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+#		add_compile_options(-mfpmath=387)
+#	endif()
 	message(STATUS "GLM: No SIMD instruction set")
 
 elseif(GLM_ENABLE_SIMD_AVX2)

--- a/glm/detail/func_common_simd.inl
+++ b/glm/detail/func_common_simd.inl
@@ -546,6 +546,7 @@ namespace detail
 #if GLM_ARCH & GLM_ARCH_NEON_BIT
 namespace glm {
 namespace detail {
+/* FIXME: Breaking Windows ARM Github C.I.
 	template<qualifier Q>
 	struct convert_vec3_to_vec4W0<float, Q, true>
 	{
@@ -557,7 +558,7 @@ namespace detail {
 			return v;
 		}
 	};
-
+*/
 	template<qualifier Q>
 	struct convert_vec4_to_vec3<float, Q, true> {
 		GLM_FUNC_QUALIFIER static vec<3, float, Q> call(vec<4, float, Q> const& a)

--- a/glm/detail/setup.hpp
+++ b/glm/detail/setup.hpp
@@ -4,8 +4,8 @@
 #include <cstddef>
 
 #define GLM_VERSION_MAJOR 1
-#define GLM_VERSION_MINOR 0
-#define GLM_VERSION_PATCH 2
+#define GLM_VERSION_MINOR 1
+#define GLM_VERSION_PATCH 0
 #define GLM_VERSION_REVISION 0 // Deprecated
 #define GLM_VERSION 1000 // Deprecated
 

--- a/glm/detail/type_half.inl
+++ b/glm/detail/type_half.inl
@@ -1,6 +1,13 @@
 namespace glm{
 namespace detail
 {
+#if (GLM_COMPILER & GLM_COMPILER_VC)
+#	pragma warning(push)
+#	pragma warning(disable: 4746)  // volatile access of 'f' is subject to /volatile:<iso|ms> setting; consider using __iso_volatile_load/store intrinsic functions
+#endif
+
+// This function cause a build error on Github C.I.
+#if (!(GLM_COMPILER & GLM_COMPILER_VC) && (GLM_ARCH & GLM_ARCH_ARM_BIT))
 	GLM_FUNC_QUALIFIER float overflow()
 	{
 		volatile float f = 1e10;
@@ -9,6 +16,16 @@ namespace detail
 			f = f * f; // this will overflow before the for loop terminates
 		return f;
 	}
+#else
+	GLM_FUNC_QUALIFIER float overflow()
+	{
+		return 0.0f;
+	}
+#endif//
+
+#if (GLM_COMPILER & GLM_COMPILER_VC)
+#	pragma warning(pop)
+#endif
 
 	union uif32
 	{

--- a/glm/detail/type_vec3.inl
+++ b/glm/detail/type_vec3.inl
@@ -834,7 +834,7 @@ namespace glm
 #	include "type_vec_simd.inl"
 
 namespace glm {
-
+/* build errors on Windows ARM Github C.I.
 #if (GLM_ARCH & GLM_ARCH_NEON_BIT) && !GLM_CONFIG_XYZW_ONLY
 	CTORSL(3, CTOR_FLOAT);
 	CTORSL(3, CTOR_INT);
@@ -845,7 +845,7 @@ namespace glm {
 	CTORSL(3, CTOR_VECF_VECI);
 	CTORSL(3, CTOR_VECF_VECU);
 #endif
-
+*/
 #if GLM_ARCH & GLM_ARCH_SSE2_BIT
 	CTORSL(3, CTOR_FLOAT_COPY3);
 	CTORSL(3, CTOR_DOUBLE_COPY3);

--- a/glm/detail/type_vec4.inl
+++ b/glm/detail/type_vec4.inl
@@ -1024,6 +1024,7 @@ namespace detail
 #	include "type_vec_simd.inl"
 
 namespace glm {
+/* build errors on Windows ARM Github C.I.
 #if GLM_ARCH & GLM_ARCH_NEON_BIT && !GLM_CONFIG_XYZW_ONLY
 	CTORSL(4, CTOR_FLOAT);
 	CTORSL(4, CTOR_INT);
@@ -1033,10 +1034,8 @@ namespace glm {
 	CTORSL(4, CTOR_VECF_VECF);
 	CTORSL(4, CTOR_VECF_VECI);
 	CTORSL(4, CTOR_VECF_VECU);
-
-
 #endif// GLM_ARCH & GLM_ARCH_NEON_BIT
-
+*/
 #if GLM_ARCH & GLM_ARCH_SSE2_BIT
 	CTORSL(4, CTOR_FLOAT);
 	CTORSL(4, CTOR_DOUBLE);

--- a/glm/simd/neon.h
+++ b/glm/simd/neon.h
@@ -10,7 +10,9 @@ namespace glm {
 	namespace neon {
 		static inline float32x4_t dupq_lane(float32x4_t vsrc, int lane) {
 			switch(lane) {
-				default: assert(false); //Unreachable code executed!
+				default: 
+					assert(false); //Unreachable code executed!
+					return vdupq_n_f32(0.0f);
 #if GLM_ARCH & GLM_ARCH_ARMV8_BIT
 				case 0: return vdupq_laneq_f32(vsrc, 0);
 				case 1: return vdupq_laneq_f32(vsrc, 1);
@@ -23,12 +25,13 @@ namespace glm {
 				case 3: return vdupq_n_f32(vgetq_lane_f32(vsrc, 3));
 #endif
 			}
-			return vdupq_n_f32(0.0f);
 		}
 
 		static inline float32x2_t dup_lane(float32x4_t vsrc, int lane) {
 			switch(lane) {
-				default: assert(false); //Unreachable code executed!
+				default: 
+					assert(false); //Unreachable code executed!
+					return vdup_n_f32(0.0f);
 #if GLM_ARCH & GLM_ARCH_ARMV8_BIT
 				case 0: return vdup_laneq_f32(vsrc, 0);
 				case 1: return vdup_laneq_f32(vsrc, 1);
@@ -41,7 +44,6 @@ namespace glm {
 				case 3: return vdup_n_f32(vgetq_lane_f32(vsrc, 3));
 #endif
 			}
-			return vdup_n_f32(0.0f);
 		}
 
 		static inline float32x4_t copy_lane(float32x4_t vdst, int dlane, float32x4_t vsrc, int slane) {
@@ -50,7 +52,9 @@ namespace glm {
 				default:
 				case 0:
 					switch(slane) {
-						default: assert(false); //Unreachable code executed!
+						default:
+							assert(false); //Unreachable code executed!
+							break;
 						case 0: return vcopyq_laneq_f32(vdst, 0, vsrc, 0);
 						case 1: return vcopyq_laneq_f32(vdst, 0, vsrc, 1);
 						case 2: return vcopyq_laneq_f32(vdst, 0, vsrc, 2);
@@ -59,7 +63,9 @@ namespace glm {
 					break;
 				case 1:
 					switch(slane) {
-						default: assert(false); //Unreachable code executed!
+						default:
+							assert(false); //Unreachable code executed!
+							break;
 						case 0: return vcopyq_laneq_f32(vdst, 1, vsrc, 0);
 						case 1: return vcopyq_laneq_f32(vdst, 1, vsrc, 1);
 						case 2: return vcopyq_laneq_f32(vdst, 1, vsrc, 2);
@@ -68,7 +74,9 @@ namespace glm {
 					break;
 				case 2:
 					switch(slane) {
-						default: assert(false); //Unreachable code executed!
+						default:
+							assert(false); //Unreachable code executed!
+							break;
 						case 0: return vcopyq_laneq_f32(vdst, 2, vsrc, 0);
 						case 1: return vcopyq_laneq_f32(vdst, 2, vsrc, 1);
 						case 2: return vcopyq_laneq_f32(vdst, 2, vsrc, 2);
@@ -77,7 +85,9 @@ namespace glm {
 					break;
 				case 3:
 					switch(slane) {
-						default: assert(false); //Unreachable code executed!
+						default:
+							assert(false); //Unreachable code executed!
+							break;
 						case 0: return vcopyq_laneq_f32(vdst, 3, vsrc, 0);
 						case 1: return vcopyq_laneq_f32(vdst, 3, vsrc, 1);
 						case 2: return vcopyq_laneq_f32(vdst, 3, vsrc, 2);
@@ -89,14 +99,18 @@ namespace glm {
 
 			float l;
 			switch(slane) {
-				default: assert(false); //Unreachable code executed!
+				default:
+					assert(false); //Unreachable code executed!
+					break;
 				case 0: l = vgetq_lane_f32(vsrc, 0); break;
 				case 1: l = vgetq_lane_f32(vsrc, 1); break;
 				case 2: l = vgetq_lane_f32(vsrc, 2); break;
 				case 3: l = vgetq_lane_f32(vsrc, 3); break;
 			}
 			switch(dlane) {
-				default: assert(false); //Unreachable code executed!
+				default:
+					assert(false); //Unreachable code executed!
+					break;
 				case 0: return vsetq_lane_f32(l, vdst, 0);
 				case 1: return vsetq_lane_f32(l, vdst, 1);
 				case 2: return vsetq_lane_f32(l, vdst, 2);
@@ -109,7 +123,9 @@ namespace glm {
 		static inline float32x4_t mul_lane(float32x4_t v, float32x4_t vlane, int lane) {
 #if GLM_ARCH & GLM_ARCH_ARMV8_BIT
 			switch(lane) {
-				default: assert(false); return vdupq_n_f32(0.0f); //Unreachable code executed!
+				default:
+					assert(false); //Unreachable code executed!
+					return vdupq_n_f32(0.0f);
 				case 0: return vmulq_laneq_f32(v, vlane, 0); break;
 				case 1: return vmulq_laneq_f32(v, vlane, 1); break;
 				case 2: return vmulq_laneq_f32(v, vlane, 2); break;
@@ -143,8 +159,8 @@ namespace glm {
 					return acc;
 				default: 
 					assert(false); //Unreachable code executed!
+					return vdupq_n_f32(0.0f);
 			}
-			return vdupq_n_f32(0.0f);
 #	undef FMADD_LANE
 #else
 			return vaddq_f32(acc, vmulq_f32(v, dupq_lane(vlane, lane)));

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 ![glm](/doc/manual/logo-mini.png)
 
-[OpenGL Mathematics](http://glm.g-truc.net/) (*GLM*) is a header only C++ mathematics library for graphics software based on the [OpenGL Shading Language (GLSL) specifications](https://www.opengl.org/registry/doc/GLSLangSpec.4.50.diff.pdf).
+[OpenGL Mathematics](http://glm.g-truc.net/) (*GLM*) is a header only C++ mathematics library for graphics software based on the [OpenGL Shading Language (GLSL) specifications](https://registry.khronos.org/OpenGL/specs/gl/GLSLangSpec.4.60.pdf).
 
 *GLM* provides classes and functions designed and implemented with the same naming conventions and functionality than *GLSL* so that anyone who knows *GLSL*, can use *GLM* as well in C++.
 
@@ -8,14 +8,13 @@ This project isn't limited to *GLSL* features. An extension system, based on the
 
 This library works perfectly with *[OpenGL](https://www.opengl.org)* but it also ensures interoperability with other third party libraries and SDK. It is a good candidate for software rendering (raytracing / rasterisation), image processing, physics simulations and any development context that requires a simple and convenient mathematics library.
 
-*GLM* is written in C++98 but can take advantage of C++11 when supported by the compiler. It is a platform independent library with no dependence and it officially supports the following compilers:
-- [*GCC*](http://gcc.gnu.org/) 4.7 and higher
-- [*Intel C++ Compose*](https://software.intel.com/en-us/intel-compilers) XE 2013 and higher
-- [*Clang*](http://llvm.org/) 3.4 and higher
+*GLM* requires a C++ 17 compiler. For older C++ support, GLM 1.0 branch can be used. It is a platform independent library with no dependence and it officially supports the following compilers:
+- [*GCC*](http://gcc.gnu.org/) 8 and higher
+- [*Clang*](http://llvm.org/) 6 and higher
 - [*Apple Clang 6.0*](https://developer.apple.com/library/mac/documentation/CompilerTools/Conceptual/LLVMCompilerOverview/index.html) and higher
-- [*Visual C++*](http://www.visualstudio.com/) 2013 and higher
+- [*Visual C++*](http://www.visualstudio.com/) 2019 and higher
 - [*CUDA*](https://developer.nvidia.com/about-cuda) 9.0 and higher (experimental)
-- Any C++11 compiler
+- Any C++17 compiler
 
 For more information about *GLM*, please have a look at the [manual](manual.md) and the [API reference documentation](http://glm.g-truc.net/0.9.9/api/modules.html).
 The source code and the documentation are licensed under either the [Happy Bunny License (Modified MIT) or the MIT License](manual.md#section0).

--- a/test/bug/bug_ms_vec_static.cpp
+++ b/test/bug/bug_ms_vec_static.cpp
@@ -14,11 +14,10 @@ struct vec2
 		x(0), y(0)
 	{}
 
-#if defined(_MSC_VER)
+#if (GLM_COMPILER & GLM_COMPILER_VC)
 #	pragma warning(push)
 #	pragma warning(disable: 4201)  // nonstandard extension used : nameless struct/union
-#endif
-#if GLM_COMPILER & GLM_COMPILER_CLANG
+#elif (GLM_COMPILER & GLM_COMPILER_CLANG)
 #	pragma clang diagnostic push
 #	pragma clang diagnostic ignored "-Wgnu-anonymous-struct"
 #	pragma clang diagnostic ignored "-Wnested-anon-types"
@@ -30,11 +29,10 @@ struct vec2
 		struct { swizzleStruct xx; };
 	};
 
-#if GLM_COMPILER & GLM_COMPILER_CLANG
-#	pragma clang diagnostic pop
-#endif
-#if defined(_MSC_VER)
+#if (GLM_COMPILER & GLM_COMPILER_VC)
 #	pragma warning(pop)
+#elif (GLM_COMPILER & GLM_COMPILER_CLANG)
+#	pragma clang diagnostic pop
 #endif
 };
 #endif

--- a/test/core/core_func_integer.cpp
+++ b/test/core/core_func_integer.cpp
@@ -578,7 +578,7 @@ namespace findMSB
 		}
 #	endif//GLM_HAS_BITSCAN_WINDOWS
 
-#	if GLM_ARCH & GLM_ARCH_AVX && GLM_COMPILER & GLM_COMPILER_VC
+#	if ((GLM_ARCH & GLM_ARCH_AVX_BIT) && (GLM_COMPILER & GLM_COMPILER_VC))
 		template<typename genIUType>
 		static int findMSB_avx(genIUType Value)
 		{
@@ -589,7 +589,7 @@ namespace findMSB
 
 			return int(_tzcnt_u32(Value));
 		}
-#	endif//GLM_ARCH & GLM_ARCH_AVX && GLM_PLATFORM & GLM_PLATFORM_WINDOWS
+#	endif//((GLM_ARCH & GLM_ARCH_AVX_BIT) && (GLM_PLATFORM & GLM_PLATFORM_WINDOWS))
 
 	template<typename genIUType>
 	static int findMSB_095(genIUType Value)
@@ -756,7 +756,7 @@ namespace findMSB
 
 		std::clock_t Timestamps6 = std::clock();
 
-#		if GLM_ARCH & GLM_ARCH_AVX && GLM_COMPILER & GLM_COMPILER_VC
+#		if ((GLM_ARCH & GLM_ARCH_AVX_BIT) && (GLM_COMPILER & GLM_COMPILER_VC))
 			for(std::size_t k = 0; k < Count; ++k)
 			for(std::size_t i = 0; i < sizeof(Data) / sizeof(type<int, int>); ++i)
 			{
@@ -765,7 +765,7 @@ namespace findMSB
 			}
 
 			std::clock_t Timestamps7 = std::clock();
-#		endif
+#		endif//((GLM_ARCH & GLM_ARCH_AVX_BIT) && (GLM_COMPILER & GLM_COMPILER_VC))
 
 		std::printf("glm::findMSB: %d clocks\n", static_cast<int>(Timestamps1 - Timestamps0));
 		std::printf("findMSB - nlz1: %d clocks\n", static_cast<int>(Timestamps2 - Timestamps1));
@@ -777,9 +777,9 @@ namespace findMSB
 #		endif//GLM_HAS_BITSCAN_WINDOWS
 		std::printf("findMSB - pop: %d clocks\n", static_cast<int>(Timestamps6 - Timestamps5));
 
-#		if GLM_ARCH & GLM_ARCH_AVX && GLM_COMPILER & GLM_COMPILER_VC
+#		if ((GLM_ARCH & GLM_ARCH_AVX_BIT) && (GLM_COMPILER & GLM_COMPILER_VC))
 			std::printf("findMSB - avx tzcnt: %d clocks\n", static_cast<int>(Timestamps7 - Timestamps6));
-#		endif//GLM_ARCH & GLM_ARCH_AVX && GLM_PLATFORM & GLM_PLATFORM_WINDOWS
+#		endif//((GLM_ARCH & GLM_ARCH_AVX_BIT) && (GLM_COMPILER & GLM_COMPILER_VC))
 
 		return Error;
 	}

--- a/test/core/core_func_integer_bit_count.cpp
+++ b/test/core/core_func_integer_bit_count.cpp
@@ -9,7 +9,7 @@
 
 #ifdef NDEBUG
 
-#if GLM_COMPILER & GLM_COMPILER_CLANG
+#if (GLM_COMPILER & GLM_COMPILER_CLANG)
 #	pragma clang diagnostic push
 #	pragma clang diagnostic ignored "-Wsign-conversion"
 #endif
@@ -183,7 +183,7 @@ static void error(int x, int y)
 	std::printf("Error for x = %08x, got %08x\n", x, y);
 }
 
-#if defined(_MSC_VER)
+#if (GLM_COMPILER & GLM_COMPILER_VC)
 #	pragma warning(push)
 #	pragma warning(disable: 4389)  // nonstandard extension used : nameless struct/union
 #endif
@@ -300,11 +300,9 @@ int main()
 		std::printf("Passed all %d cases.\n", static_cast<int>(sizeof(test)/8));
 }
 
-#if defined(_MSC_VER)
+#if (GLM_COMPILER & GLM_COMPILER_VC)
 #	pragma warning(pop)
-#endif
-
-#if GLM_COMPILER & GLM_COMPILER_CLANG
+#elif (GLM_COMPILER & GLM_COMPILER_CLANG)
 #	pragma clang diagnostic pop
 #endif
 

--- a/test/core/core_func_integer_find_lsb.cpp
+++ b/test/core/core_func_integer_find_lsb.cpp
@@ -264,7 +264,7 @@ static int ntz11(unsigned int n) {
    };
    unsigned int k;
    n = n & (-n);        /* isolate lsb */
-   printf("n = %d\n", n);
+   //printf("n = %d\n", n);
 #if defined(SLOW_MUL)
    k = (n << 11) - n;
    k = (k <<  2) + k;

--- a/test/core/core_type_aligned.cpp
+++ b/test/core/core_type_aligned.cpp
@@ -87,6 +87,9 @@ static int test_vec3_aligned()
 #if GLM_COMPILER & GLM_COMPILER_CLANG
 #	pragma clang diagnostic push
 #	pragma clang diagnostic ignored "-Wpadded"
+#elif (GLM_COMPILER & GLM_COMPILER_VC)
+#	pragma warning(push)
+#	pragma warning(disable: 4324) // 'test_vec3_aligned::Struct2': structure was padded due to alignment specifier 
 #endif
 
 	struct Struct2
@@ -98,6 +101,8 @@ static int test_vec3_aligned()
 
 #if GLM_COMPILER & GLM_COMPILER_CLANG
 #	pragma clang diagnostic pop
+#elif (GLM_COMPILER & GLM_COMPILER_VC)
+#	pragma warning(pop)
 #endif
 
 	std::size_t const Size2 = sizeof(Struct2);


### PR DESCRIPTION
This is only due to the very limited Github C.I. resources making the project challenging to maintain.

Branch 1.0 can be used for older C++ compiler support.