### PR TITLE
clear documentation for quaternions rotate

### DIFF
--- a/glm/ext/quaternion_transform.hpp
+++ b/glm/ext/quaternion_transform.hpp
@@ -31,11 +31,11 @@ namespace glm
 	/// @addtogroup ext_quaternion_transform
 	/// @{
 
-	/// Rotates a quaternion from a vector of 3 components axis and an angle.
+	/// Builds a quaternion created from an axis and angle and rotates it by input quaternion.
 	///
-	/// @param q Source orientation
-	/// @param angle Angle expressed in radians.
-	/// @param axis Axis of the rotation
+	/// @param q Input quaternion
+	/// @param angle Rotation angle expressed in radians.
+	/// @param axis Rotation axis
 	///
 	/// @tparam T Floating-point scalar types
 	/// @tparam Q Value from qualifier enum


### PR DESCRIPTION
The current documentation does not clearly communicate what the function does. This has very likely lead to #960 and caused the reverted #1297.

This change also brings it in line with other documentation like that of `glm::rotate(mat4, angle, axis)`.