### PR TITLE
Update CMake minimum version and policy range

### DIFF
--- a/test/cmake/CMakeLists.txt
+++ b/test/cmake/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 3.6 FATAL_ERROR)
-cmake_policy(VERSION 3.6)
+cmake_minimum_required(VERSION 3.6...3.14 FATAL_ERROR)
+cmake_policy(VERSION 3.6...3.14)
 project(test_find_glm)
 
 find_package(glm REQUIRED)


### PR DESCRIPTION
Compatibility with CMake < 3.10 will be removed in a future release