### PR TITLE
SIMD dot product and normalization changes

### DIFF
--- a/glm/detail/func_geometric_simd.inl
+++ b/glm/detail/func_geometric_simd.inl
@@ -66,6 +66,28 @@ namespace detail
 		}
 	};
 
+	template<>
+	struct compute_normalize<4, float, aligned_lowp, true>
+	{
+		GLM_FUNC_QUALIFIER static vec<4, float, aligned_lowp> call(vec<4, float, aligned_lowp> const& v)
+		{
+			vec<4, float, aligned_lowp> Result;
+			Result.data = glm_vec4_normalize(v.data);
+			return Result;
+		}
+	};
+
+	template<>
+	struct compute_normalize<3, float, aligned_lowp, true>
+	{
+		GLM_FUNC_QUALIFIER static vec<3, float, aligned_lowp> call(vec<3, float, aligned_lowp> const& v)
+		{
+			vec<3, float, aligned_lowp> Result;
+			Result.data = glm_vec3_normalize_lowp(v.data);
+			return Result;
+		}
+	};
+
 	template<qualifier Q>
 	struct compute_normalize<4, float, Q, true>
 	{
@@ -73,6 +95,17 @@ namespace detail
 		{
 			vec<4, float, Q> Result;
 			Result.data = glm_vec4_normalize(v.data);
+			return Result;
+		}
+	};
+
+	template<qualifier Q>
+	struct compute_normalize<3, float, Q, true>
+	{
+		GLM_FUNC_QUALIFIER static vec<3, float, Q> call(vec<3, float, Q> const& v)
+		{
+			vec<3, float, Q> Result;
+			Result.data = glm_vec3_normalize(v.data);
 			return Result;
 		}
 	};

--- a/glm/simd/geometric.h
+++ b/glm/simd/geometric.h
@@ -98,13 +98,54 @@ GLM_FUNC_QUALIFIER glm_vec4 glm_vec4_cross(glm_vec4 v1, glm_vec4 v2)
 	return sub0;
 }
 
-GLM_FUNC_QUALIFIER glm_vec4 glm_vec4_normalize(glm_vec4 v)
+GLM_FUNC_QUALIFIER glm_vec4 glm_vec4_normalize_lowp(glm_vec4 v)
 {
 	glm_vec4 const dot0 = glm_vec4_dot(v, v);
 	glm_vec4 const isr0 = _mm_rsqrt_ps(dot0);
 	glm_vec4 const mul0 = _mm_mul_ps(v, isr0);
 	return mul0;
 }
+
+GLM_FUNC_QUALIFIER glm_vec4 glm_vec3_normalize_lowp(glm_vec4 v)
+{
+	glm_vec4 const dot0 = glm_vec3_dot(v, v);
+	glm_vec4 const isr0 = _mm_rsqrt_ps(dot0);
+	glm_vec4 const mul0 = _mm_mul_ps(v, isr0);
+	return mul0;
+}
+
+GLM_FUNC_QUALIFIER glm_vec4 glm_vec4_normalize(glm_vec4 v)
+{
+	glm_vec4 const dot0 = glm_vec4_dot(v, v);
+	glm_vec4 const isr0 = _mm_rsqrt_ps(dot0);
+
+	// One iteration of Newton-Raphson method to improve precision
+	glm_vec4 const mul0 = glm_vec4_mul(dot0, isr0);
+	glm_vec4 const fma0 = glm_vec4_fma(mul0, isr0, _mm_set1_ps(-3.0f));
+	glm_vec4 const mul1 = glm_vec4_mul(isr0, _mm_set1_ps(-0.5f));
+
+	glm_vec4 const mul2 = glm_vec4_mul(mul1, v);
+	glm_vec4 const mul3 = glm_vec4_mul(mul2, fma0);
+
+	return mul3;
+}
+
+GLM_FUNC_QUALIFIER glm_vec4 glm_vec3_normalize(glm_vec4 v)
+{
+	glm_vec4 const dot0 = glm_vec3_dot(v, v);
+	glm_vec4 const isr0 = _mm_rsqrt_ps(dot0);
+
+	// One iteration of Newton-Raphson method to improve precision
+	glm_vec4 const mul0 = glm_vec4_mul(dot0, isr0);
+	glm_vec4 const fma0 = glm_vec4_fma(mul0, isr0, _mm_set1_ps(-3.0f));
+	glm_vec4 const mul1 = glm_vec4_mul(isr0, _mm_set1_ps(-0.5f));
+
+	glm_vec4 const mul2 = glm_vec4_mul(mul1, v);
+	glm_vec4 const mul3 = glm_vec4_mul(mul2, fma0);
+
+	return mul3;
+}
+
 
 GLM_FUNC_QUALIFIER glm_vec4 glm_vec4_faceforward(glm_vec4 N, glm_vec4 I, glm_vec4 Nref)
 {


### PR DESCRIPTION
I have change the #if to use SSE4.1 instead of AVX as the instruction "dpps" is available since SSE4.1 not AVX and I have added a dedicated pathway for Vec3.
added normalization changes as well