### PR TITLE
gtx_polar_coordinates fixes

### DIFF
--- a/glm/gtx/polar_coordinates.hpp
+++ b/glm/gtx/polar_coordinates.hpp
@@ -33,12 +33,19 @@ namespace glm
 	GLM_FUNC_DECL vec<3, T, Q> polar(
 		vec<3, T, Q> const& euclidean);
 
-	/// Convert Polar to Euclidean coordinates.
+	/// Convert Polar coordinates (x is the latitude, y the longitude, and radial distance is 1) to Euclidean.
 	///
 	/// @see gtx_polar_coordinates
 	template<typename T, qualifier Q>
 	GLM_FUNC_DECL vec<3, T, Q> euclidean(
 		vec<2, T, Q> const& polar);
+
+	/// Convert Polar coordinates (x is the latitude, y the longitude, and z the radial distance) to Euclidean.
+	///
+	/// @see gtx_polar_coordinates
+	template<typename T, qualifier Q>
+	GLM_FUNC_DECL vec<3, T, Q> euclidean(
+		vec<3, T, Q> const& polar);
 
 	/// @}
 }//namespace glm

--- a/glm/gtx/polar_coordinates.hpp
+++ b/glm/gtx/polar_coordinates.hpp
@@ -26,7 +26,7 @@ namespace glm
 	/// @addtogroup gtx_polar_coordinates
 	/// @{
 
-	/// Convert Euclidean to Polar coordinates, x is the latitude, y the longitude and z the xz distance.
+	/// Convert Euclidean to Polar coordinates (x is the latitude, y the longitude, and z the radial distance). For the origin, radial distance is 0, and latitude and longitude are undefined.
 	///
 	/// @see gtx_polar_coordinates
 	template<typename T, qualifier Q>

--- a/glm/gtx/polar_coordinates.inl
+++ b/glm/gtx/polar_coordinates.inl
@@ -32,4 +32,18 @@ namespace glm
 			cos(latitude) * cos(longitude));
 	}
 
+	template<typename T, qualifier Q>
+	GLM_FUNC_QUALIFIER vec<3, T, Q> euclidean
+	(
+		vec<3, T, Q> const& polar
+	)
+	{
+		T const RadialDistance(polar.z);
+
+		if(isinf(static_cast<T>(1) / RadialDistance))
+			return vec<3, T, Q>(static_cast<T>(0));
+
+		return RadialDistance * euclidean(vec<2, T, Q>(polar.x, polar.y));
+	}
+
 }//namespace glm

--- a/glm/gtx/polar_coordinates.inl
+++ b/glm/gtx/polar_coordinates.inl
@@ -10,12 +10,11 @@ namespace glm
 	{
 		T const Length(length(euclidean));
 		vec<3, T, Q> const tmp(euclidean / Length);
-		T const xz_dist(sqrt(tmp.x * tmp.x + tmp.z * tmp.z));
 
 		return vec<3, T, Q>(
 			asin(tmp.y),	// latitude
 			atan(tmp.x, tmp.z),		// longitude
-			xz_dist);				// xz distance
+			Length); // radial distance
 	}
 
 	template<typename T, qualifier Q>

--- a/test/gtx/gtx_polar_coordinates.cpp
+++ b/test/gtx/gtx_polar_coordinates.cpp
@@ -1,9 +1,45 @@
 #define GLM_ENABLE_EXPERIMENTAL
 #include <glm/gtx/polar_coordinates.hpp>
 
+#include <glm/gtc/constants.hpp>
+#include <glm/gtc/epsilon.hpp>
+#include <glm/ext/vector_relational.hpp>
+
+static int test_revertConversion()
+{
+	int Error = 0;
+
+	glm::vec3 const Polar = {glm::quarter_pi<float>(), glm::quarter_pi<float>(), 10.0f};
+	glm::vec3 const Euclidean = glm::euclidean(Polar);
+	glm::vec3 const PolarAgain = glm::polar(Euclidean);
+	glm::vec3 const EuclideanAgain = glm::euclidean(PolarAgain);
+
+	Error += glm::all(glm::equal(Polar, PolarAgain, 0.001f)) ? 0 : 1;
+	Error += glm::all(glm::equal(Euclidean, EuclideanAgain, 0.001f)) ? 0 : 1;
+
+	return Error;
+}
+
+static int test_originConversion()
+{
+	int Error = 0;
+
+	glm::vec3 const EuclideanOrigin = {0.0f, 0.0f, 0.0f};
+	glm::vec3 const PolarOrigin = glm::polar(EuclideanOrigin);
+	glm::vec3 const EuclideanOriginAgain = glm::euclidean(PolarOrigin);
+
+	Error += glm::epsilonEqual(PolarOrigin.z, 0.0f, 0.001f) ? 0 : 1;
+	Error += glm::all(glm::equal(EuclideanOrigin, EuclideanOriginAgain, 0.001f)) ? 0 : 1;
+
+	return Error;
+}
+
 int main()
 {
-	int Error(0);
+	int Error = 0;
+
+	Error += test_revertConversion();
+	Error += test_originConversion();
 
 	return Error;
 }


### PR DESCRIPTION
The current polar() function only returns the direction from the origin to the given euclidean position, discarding the distance. It computes the projection of the point on a unit radius sphere, not its polar coordinates #1442. The changes here make it return the radial distance as the z component, instead of the current length squared of the normalized vector projected on the xz plane.

There's also an added euclidean(vec3) overload, to allow converting back and forth from polar to euclidean, and some tests.

This only breaks backwards compatibility with code that currently uses the z component returned by polar().