### PR TITLE
fix(gtx): extractRealComponent returns the canonical (non-negative) real part

### DIFF
--- a/glm/gtx/quaternion.inl
+++ b/glm/gtx/quaternion.inl
@@ -66,7 +66,7 @@ namespace glm
 		if(w < T(0))
 			return T(0);
 		else
-			return -sqrt(w);
+			return sqrt(w);
 	}
 
 	template<typename T, qualifier Q>

--- a/test/gtx/gtx_quaternion.cpp
+++ b/test/gtx/gtx_quaternion.cpp
@@ -102,13 +102,14 @@ static int test_extractRealComponent()
 {
 	int Error = 0;
 
-	// A canonical unit quaternion (60 degrees about X): w = cos(30 deg) >= 0.
-	glm::quat const q(0.8660254f, 0.5f, 0.0f, 0.0f);
+	// A canonical unit quaternion (rotation about X): w = cos(angle / 2) >= 0.
+	float const Angle = glm::radians(60.0f);
+	glm::quat const q = glm::angleAxis(Angle, glm::vec3(1.0f, 0.0f, 0.0f));
 	float const w = glm::extractRealComponent(q);
 
 	// Reconstructing the real component from x/y/z must recover the canonical
 	// (non-negative) w, not its negation.
-	Error += glm::epsilonEqual(w, q.w, 0.0001f) ? 0 : 1;
+	Error += glm::epsilonEqual(w, glm::cos(Angle * 0.5f), 0.0001f) ? 0 : 1;
 	Error += (w >= 0.0f) ? 0 : 1;
 
 	return Error;

--- a/test/gtx/gtx_quaternion.cpp
+++ b/test/gtx/gtx_quaternion.cpp
@@ -98,6 +98,22 @@ static int test_log()
 	return Error;
 }
 
+static int test_extractRealComponent()
+{
+	int Error = 0;
+
+	// A canonical unit quaternion (60 degrees about X): w = cos(30 deg) >= 0.
+	glm::quat const q(0.8660254f, 0.5f, 0.0f, 0.0f);
+	float const w = glm::extractRealComponent(q);
+
+	// Reconstructing the real component from x/y/z must recover the canonical
+	// (non-negative) w, not its negation.
+	Error += glm::epsilonEqual(w, q.w, 0.0001f) ? 0 : 1;
+	Error += (w >= 0.0f) ? 0 : 1;
+
+	return Error;
+}
+
 int main()
 {
 	int Error = 0;
@@ -107,6 +123,7 @@ int main()
 	Error += test_orientation();
 	Error += test_quat_fastMix();
 	Error += test_quat_shortMix();
+	Error += test_extractRealComponent();
 
 	return Error;
 }


### PR DESCRIPTION
## Problem

`glm::extractRealComponent` reconstructs a quaternion's real component from its imaginary parts as `sqrt(1 - x² - y² - z²)`, but it returns the **negative** root:

```cpp
template<typename T, qualifier Q>
GLM_FUNC_QUALIFIER T extractRealComponent(qua<T, Q> const& q)
{
    T w = static_cast<T>(1) - q.x * q.x - q.y * q.y - q.z * q.z;
    if(w < T(0))
        return T(0);   // clamp: keep the result non-negative...
    else
        return -sqrt(w);   // ...then negate it (?)
}
```

The function is internally contradictory: it clamps the radicand with `if (w < 0) return 0` — signalling a non-negative magnitude — and then returns `-sqrt(w)`, which is always ≤ 0. So for any canonical unit quaternion (`w ≥ 0`) it returns the wrong sign:

| quaternion (w, x, y, z) | true real part | `extractRealComponent` |
|---|---|---|
| 60° about X → `(0.8660254, 0.5, 0, 0)` | **+0.8660254** | −0.8660254 |
| identity → `(1, 0, 0, 0)` | **+1** | −1 |

This contradicts the documented purpose (*"Extract the real component of a quaternion"*) and the standard reconstruction convention (the canonical real part of a unit quaternion is the non-negative root — the same `w = sqrt(1 - x² - y² - z²)` used when reconstructing a quaternion stored as x/y/z only).

## Fix

Return the positive root (`sqrt(w)`).

## Tests

The function had **no test coverage** (which is why the sign error went unnoticed). Added `test_extractRealComponent` to `test/gtx/gtx_quaternion.cpp`: it builds a canonical unit quaternion, extracts the real component, and asserts it recovers the true `w` and is non-negative. (Fails on the old `-sqrt`, passes on the fix.)
