### PR TITLE
Fix inverseTranspose for mat2 returning the inverse without transposing

### DIFF
--- a/glm/gtc/matrix_inverse.inl
+++ b/glm/gtc/matrix_inverse.inl
@@ -32,8 +32,8 @@ namespace glm
 
 		mat<2, 2, T, Q> Inverse(
 			+ m[1][1] / Determinant,
-			- m[0][1] / Determinant,
 			- m[1][0] / Determinant,
+			- m[0][1] / Determinant,
 			+ m[0][0] / Determinant);
 
 		return Inverse;

--- a/test/gtc/gtc_matrix_inverse.cpp
+++ b/test/gtc/gtc_matrix_inverse.cpp
@@ -41,11 +41,55 @@ static int test_affine()
 	return Error;
 }
 
+static int test_inverse_transpose()
+{
+	int Error = 0;
+
+	{
+		glm::mat2 const M(
+			1.f, 3.f,
+			2.f, 4.f);
+		glm::mat2 const A = glm::inverseTranspose(M);
+		glm::mat2 const R = glm::transpose(glm::inverse(M));
+
+		for(glm::length_t i = 0; i < A.length(); ++i)
+			Error += glm::all(glm::epsilonEqual(A[i], R[i], 0.01f)) ? 0 : 1;
+	}
+
+	{
+		glm::mat3 const M(
+			1.f, 3.f, 0.f,
+			2.f, 4.f, 0.f,
+			0.f, 0.f, 1.f);
+		glm::mat3 const A = glm::inverseTranspose(M);
+		glm::mat3 const R = glm::transpose(glm::inverse(M));
+
+		for(glm::length_t i = 0; i < A.length(); ++i)
+			Error += glm::all(glm::epsilonEqual(A[i], R[i], 0.01f)) ? 0 : 1;
+	}
+
+	{
+		glm::mat4 const M(
+			1.f, 3.f, 0.f, 0.f,
+			2.f, 4.f, 0.f, 0.f,
+			0.f, 0.f, 1.f, 0.f,
+			0.f, 0.f, 0.f, 1.f);
+		glm::mat4 const A = glm::inverseTranspose(M);
+		glm::mat4 const R = glm::transpose(glm::inverse(M));
+
+		for(glm::length_t i = 0; i < A.length(); ++i)
+			Error += glm::all(glm::epsilonEqual(A[i], R[i], 0.01f)) ? 0 : 1;
+	}
+
+	return Error;
+}
+
 int main()
 {
 	int Error = 0;
 
 	Error += test_affine();
+	Error += test_inverse_transpose();
 
 	return Error;
 }


### PR DESCRIPTION
Fixes #1448

The `mat<2, 2, T, Q>` overload of `inverseTranspose` constructed the same matrix as `inverse(mat2)`, the two middle cofactors were never swapped, so the result was the inverse without the transpose. This swaps them, matching `transpose(inverse(m))` and the (correct) `mat3`/`mat4` overloads.

Adds a regression test `test_inverse_transpose` to `test/gtc/gtc_matrix_inverse.cpp` verifying `inverseTranspose(M) == transpose(inverse(M))` for `mat2`, `mat3` and `mat4` with a non-symmetric matrix. The test fails against the previous implementation (both `mat2` columns wrong) and passes with the fix; `gtc_matrix_transform`, `gtc_quaternion` and `core_func_matrix` still pass.
