### PR TITLE
Fix refract for scalars returning NaN on total internal reflection #1451

### DIFF
--- a/glm/detail/func_geometric.inl
+++ b/glm/detail/func_geometric.inl
@@ -243,7 +243,7 @@ namespace detail
 		static_assert(std::numeric_limits<genType>::is_iec559, "'refract' accepts only floating-point inputs");
 		genType const dotValue(dot(N, I));
 		genType const k(static_cast<genType>(1) - eta * eta * (static_cast<genType>(1) - dotValue * dotValue));
-		return (eta * I - (eta * dotValue + sqrt(k)) * N) * static_cast<genType>(k >= static_cast<genType>(0));
+		return (k >= static_cast<genType>(0)) ? (eta * I - (eta * dotValue + sqrt(k)) * N) : static_cast<genType>(0);
 	}
 
 	template<length_t L, typename T, qualifier Q>

--- a/test/core/core_func_geometric.cpp
+++ b/test/core/core_func_geometric.cpp
@@ -188,6 +188,43 @@ namespace refract
 			Error += glm::all(glm::equal(C, glm::vec4(0.0, -1.0, 0.0f, 0.0f), 0.0001f)) ? 0 : 1;
 		}
 
+		// Total internal reflection (k < 0) must yield zero, like the vector
+		// overloads, not NaN
+		{
+			float A(-0.5f);
+			float B(1.0f);
+			float C = glm::refract(A, B, 2.0f);
+			Error += glm::equal(C, 0.0f, 0.0001f) ? 0 : 1;
+		}
+
+		{
+			double A(-0.5);
+			double B(1.0);
+			double C = glm::refract(A, B, 2.0);
+			Error += glm::equal(C, 0.0, 0.0001) ? 0 : 1;
+		}
+
+		{
+			glm::vec2 A(glm::normalize(glm::vec2(1.0f, -1.0f)));
+			glm::vec2 B(0.0f, 1.0f);
+			glm::vec2 C = glm::refract(A, B, 2.0f);
+			Error += glm::all(glm::equal(C, glm::vec2(0.0f), 0.0001f)) ? 0 : 1;
+		}
+
+		{
+			glm::dvec2 A(glm::normalize(glm::dvec2(1.0, -1.0)));
+			glm::dvec2 B(0.0, 1.0);
+			glm::dvec2 C = glm::refract(A, B, 2.0);
+			Error += glm::all(glm::equal(C, glm::dvec2(0.0), 0.0001)) ? 0 : 1;
+		}
+
+		{
+			glm::vec4 A(glm::normalize(glm::vec4(1.0f, -1.0f, 0.0f, 0.0f)));
+			glm::vec4 B(0.0f, 1.0f, 0.0f, 0.0f);
+			glm::vec4 C = glm::refract(A, B, 2.0f);
+			Error += glm::all(glm::equal(C, glm::vec4(0.0f), 0.0001f)) ? 0 : 1;
+		}
+
 		return Error;
 	}
 }//namespace refract


### PR DESCRIPTION
Fixes #1451.

The scalar overload of `refract` computed `sqrt(k)` unconditionally and multiplied by `(k >= 0)`, so total internal reflection (k < 0) returned NaN * 0 = NaN instead of the zero value required by the GLSL specification. Regression from 20bdab33 ("Branch free refract and reflect"); the vector path was later restored to a real conditional (`detail::compute_refract`), the scalar path was not.

The fix mirrors the vector overload: evaluate the refraction expression only when k >= 0, otherwise return `genType(0)`.

Regression tests cover the scalar float and double total internal reflection cases (NaN before this change), plus vec2, dvec2, and vec4 cases pinning the already-correct vector behavior.
