### PR TITLE
Fix `glm::identity` when XYZW quaternion format is set.

### DIFF
--- a/glm/detail/qualifier.hpp
+++ b/glm/detail/qualifier.hpp
@@ -273,7 +273,11 @@ namespace detail
 	{
 		GLM_FUNC_QUALIFIER GLM_CONSTEXPR static genType identity()
 		{
-			return genType(1, 0, 0, 0);
+#			ifdef GLM_FORCE_QUAT_DATA_XYZW
+				return genType(0, 0, 0, 1);
+#			else
+				return genType(1, 0, 0, 0);
+#			endif
 		}
 	};
 

--- a/test/gtc/gtc_quaternion.cpp
+++ b/test/gtc/gtc_quaternion.cpp
@@ -318,8 +318,13 @@ static int test_identity()
 
 	glm::quat const Q = glm::identity<glm::quat>();
 
+#ifdef GLM_FORCE_QUAT_DATA_XYZW
+	Error += glm::all(glm::equal(Q, glm::quat(0, 0, 0, 1), 0.0001f)) ? 0 : 1;
+	Error += glm::any(glm::notEqual(Q, glm::quat(0, 0, 0, 1), 0.0001f)) ? 1 : 0;
+#else
 	Error += glm::all(glm::equal(Q, glm::quat(1, 0, 0, 0), 0.0001f)) ? 0 : 1;
 	Error += glm::any(glm::notEqual(Q, glm::quat(1, 0, 0, 0), 0.0001f)) ? 1 : 0;
+#endif
 
 	glm::mat4 const M = glm::identity<glm::mat4x4>();
 	glm::mat4 const N(1.0f);


### PR DESCRIPTION
- `glm::identity` assumed a constant argument order for `glm::qua`'s constructor.
- Fixed `test_identity` to reflect the argument order swap.

Hello. This small PR offers a fix for #1450. I'm not fully sure about the proper usage. In one hand using the constructors seems like the most adapted solution for quaternion creation but on the other hand, `glm::quat::wxyz` provide a code path that handles itself the argument swapping. I opted for the first solution in that case but I'll look for your feedback.

Note that `test_slerp` and `test_slerp_spins` still fail due to wrong argument order. I didn't want to add changes irrelevant to the issue in the patch but I consider making another PR for them once we settled on a course.

Have a nice day.