### PR TITLE
Fix hsvColor returning a NaN hue for achromatic (grey) colors

### DIFF
--- a/glm/gtx/color_space.inl
+++ b/glm/gtx/color_space.inl
@@ -75,22 +75,32 @@ namespace glm
 		if(!equal(Max, static_cast<T>(0), epsilon<T>()))
 		{
 			hsv.y = Delta / hsv.z;
-			T h = static_cast<T>(0);
 
-			if(equal(rgbColor.r, Max, epsilon<T>()))
-				// between yellow & magenta
-				h = static_cast<T>(0) + T(60) * (rgbColor.g - rgbColor.b) / Delta;
-			else if(equal(rgbColor.g, Max, epsilon<T>()))
-				// between cyan & yellow
-				h = static_cast<T>(120) + T(60) * (rgbColor.b - rgbColor.r) / Delta;
+			if(equal(Delta, static_cast<T>(0), epsilon<T>()))
+			{
+				// Achromatic (grey): saturation is 0 and the hue is undefined.
+				// Guarding here avoids a division by zero that would make the hue NaN.
+				hsv.x = static_cast<T>(0);
+			}
 			else
-				// between magenta & cyan
-				h = static_cast<T>(240) + T(60) * (rgbColor.r - rgbColor.g) / Delta;
+			{
+				T h = static_cast<T>(0);
 
-			if(h < T(0))
-				hsv.x = h + T(360);
-			else
-				hsv.x = h;
+				if(equal(rgbColor.r, Max, epsilon<T>()))
+					// between yellow & magenta
+					h = static_cast<T>(0) + T(60) * (rgbColor.g - rgbColor.b) / Delta;
+				else if(equal(rgbColor.g, Max, epsilon<T>()))
+					// between cyan & yellow
+					h = static_cast<T>(120) + T(60) * (rgbColor.b - rgbColor.r) / Delta;
+				else
+					// between magenta & cyan
+					h = static_cast<T>(240) + T(60) * (rgbColor.r - rgbColor.g) / Delta;
+
+				if(h < T(0))
+					hsv.x = h + T(360);
+				else
+					hsv.x = h;
+			}
 		}
 		else
 		{

--- a/test/gtx/gtx_color_space.cpp
+++ b/test/gtx/gtx_color_space.cpp
@@ -15,6 +15,21 @@ static int test_hsv()
 	return Error;
 }
 
+static int test_hsv_achromatic()
+{
+	int Error = 0;
+
+	// Achromatic (grey) colors have delta == 0. The hue must be 0, not NaN.
+	glm::vec3 colorHSV = glm::hsvColor(glm::vec3(0.5f, 0.5f, 0.5f));
+	Error += glm::all(glm::equal(colorHSV, glm::vec3(0.0f, 0.0f, 0.5f), glm::epsilon<float>())) ? 0 : 1;
+
+	// And it must round-trip back to the same grey.
+	glm::vec3 colorRGB = glm::rgbColor(colorHSV);
+	Error += glm::all(glm::equal(colorRGB, glm::vec3(0.5f), glm::epsilon<float>())) ? 0 : 1;
+
+	return Error;
+}
+
 static int test_saturation()
 {
 	int Error = 0;
@@ -30,6 +45,7 @@ int main()
 	int Error(0);
 
 	Error += test_hsv();
+	Error += test_hsv_achromatic();
 	Error += test_saturation();
 
 	return Error;


### PR DESCRIPTION
`hsvColor()` computes the hue by dividing by `Delta = max - min`, but it only guards against `max == 0`, not `Delta == 0`. For any achromatic color where `r == g == b > 0` (a grey), `Delta` is `0`, so the hue becomes `60 * 0 / 0 = NaN`:

```cpp
glm::vec3 hsv = glm::hsvColor(glm::vec3(0.5f)); // hsv.x is NaN, expected 0
```

The reverse function `rgbColor()` already special-cases achromatic colors (`if(hsv.y == 0)`), so this makes `hsvColor()` consistent: when `Delta == 0` the hue is undefined and set to `0` (saturation is already `0`). Colored inputs are unchanged.

Added a regression test in test/gtx/gtx_color_space.cpp covering a grey input (hue must be `0`, not `NaN`) and its round-trip.