### PR TITLE
Fix to_string with GLM_FORCE_INLINE on GCC

### DIFF
--- a/glm/detail/setup.hpp
+++ b/glm/detail/setup.hpp
@@ -236,6 +236,7 @@
 #define GLM_FUNC_DISCARD_DECL GLM_CUDA_FUNC_DECL
 #define GLM_FUNC_DECL [[nodiscard]] GLM_CUDA_FUNC_DECL
 #define GLM_FUNC_QUALIFIER GLM_CUDA_FUNC_DEF GLM_INLINE
+#define GLM_FUNC_QUALIFIER_VARARG GLM_CUDA_FUNC_DEF inline
 
 // Do not use CUDA function qualifiers on CUDA compiler when functions are made default
 

--- a/glm/gtx/string_cast.inl
+++ b/glm/gtx/string_cast.inl
@@ -18,7 +18,7 @@ namespace detail
 		typedef double value_type;
 	};
 
-	GLM_FUNC_QUALIFIER std::string format(const char* message, ...) {
+	GLM_FUNC_QUALIFIER_VARARG std::string format(const char* message, ...) {
 		std::size_t const STRING_BUFFER(4096);
 
 		assert(message != NULL);


### PR DESCRIPTION
Fixes #1455

`GLM_FORCE_INLINE` makes `GLM_FUNC_QUALIFIER` expand to an always_inline attribute, which GCC rejects on variadic functions.

Add `GLM_FUNC_QUALIFIER_VARARG`, which keeps the CUDA qualifier and adds an inline.